### PR TITLE
INC-545: set executor versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,9 @@ parameters:
   releases-slack-channel:
     type: string
     default: dps-releases
+  node-version:
+    type: string
+    default: 16.15-browsers
 
 jobs:
   validate:
@@ -113,6 +116,9 @@ workflows:
           context:
             - hmpps-common-vars
           cache_key: "v2_0"
+          executor:
+            name: hmpps/java
+            tag: 11.0
       - hmpps/trivy_latest_scan:
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:
@@ -122,6 +128,9 @@ workflows:
           context:
             - veracode-credentials
             - hmpps-common-vars
+          executor:
+            name: hmpps/node
+            tag: << pipeline.parameters.node-version >>
   security-weekly:
     triggers:
       - schedule:
@@ -136,5 +145,6 @@ workflows:
           context:
             - veracode-credentials
             - hmpps-common-vars
-
-
+          executor:
+            name: hmpps/node
+            tag: << pipeline.parameters.node-version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,13 +10,16 @@ parameters:
   releases-slack-channel:
     type: string
     default: dps-releases
+  java-version:
+    type: string
+    default: "17.0"
 
 executors:
   hmpps/java:
     parameters:
       jdk_tag:
         type: string
-        default: "11.0"
+        default: << pipeline.parameters.java-version >>
   hmpps/node:
     parameters:
       node_tag:
@@ -27,7 +30,7 @@ jobs:
   validate:
     executor:
       name: hmpps/java_localstack_postgres
-      jdk_tag: "17.0"
+      jdk_tag: << pipeline.parameters.java-version >>
       localstack_tag: "0.14.0"
       services: "sns,sqs"
       postgres_tag: "14"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,18 @@ parameters:
   releases-slack-channel:
     type: string
     default: dps-releases
-  node-version:
-    type: string
-    default: 16.15-browsers
+
+executors:
+  hmpps/java:
+    parameters:
+      jdk_tag:
+        type: string
+        default: "11.0"
+  hmpps/node:
+    parameters:
+      node_tag:
+        type: string
+        default: "16.15-browsers"
 
 jobs:
   validate:
@@ -116,9 +125,6 @@ workflows:
           context:
             - hmpps-common-vars
           cache_key: "v2_0"
-          executor:
-            name: hmpps/java
-            tag: 11.0
       - hmpps/trivy_latest_scan:
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:
@@ -128,9 +134,6 @@ workflows:
           context:
             - veracode-credentials
             - hmpps-common-vars
-          executor:
-            name: hmpps/node
-            tag: << pipeline.parameters.node-version >>
   security-weekly:
     triggers:
       - schedule:
@@ -145,6 +148,3 @@ workflows:
           context:
             - veracode-credentials
             - hmpps-common-vars
-          executor:
-            name: hmpps/node
-            tag: << pipeline.parameters.node-version >>


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/INC-545

Required after [I bumped](https://github.com/ministryofjustice/hmpps-incentives-api/pull/66) the hmpps orb to v5.0 and the [security job wasn't able ](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-incentives-api/240/workflows/d56fae5c-7a70-485a-82fe-ae8847383a29)to run due to [this PR](https://github.com/ministryofjustice/hmpps-circleci-orb/pull/116) removing default versions