### PR TITLE
INC-567: enable SonarCloud with code coverage metrics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,10 @@ jobs:
             - gradle-
       - hmpps/wait_till_ready_postgres
       - run:
-          command: ./gradlew check
+          name: Run check & send results to sonarcloud
+          command: |
+            export GRADLE_OPTS="--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED"
+            ./gradlew check sonarqube
       - save_cache:
           paths:
             - ~/.gradle
@@ -38,6 +41,8 @@ jobs:
           path: build/test-results
       - store_artifacts:
           path: build/reports/tests
+      - store_artifacts:
+          path: build/reports/jacoco/test/html
 
 workflows:
   version: 2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,7 @@
 plugins {
   id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.1.7"
+  id("jacoco")
+  id("org.sonarqube") version "3.3"
   kotlin("plugin.spring") version "1.6.21"
   kotlin("plugin.jpa") version "1.6.21"
 }
@@ -70,5 +72,16 @@ tasks {
     kotlinOptions {
       jvmTarget = "17"
     }
+  }
+}
+
+tasks.test {
+  finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+  dependsOn(tasks.test)
+  reports {
+    xml.required.set(true)
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+systemProp.sonar.host.url=https://sonarcloud.io
+systemProp.sonar.organization=ministryofjustice
+systemProp.sonar.projectKey=ministryofjustice_hmpps-incentives-api


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/INC-567

Copied from https://github.com/ministryofjustice/make-recall-decision-api/pull/86

Have already followed [SonarCloud configuration page](https://sonarcloud.io/project/configuration?id=ministryofjustice_hmpps-incentives-api&analysisMode=GitHubCircleCI) and created `SONAR_TOKEN` env variable in CircleCI 