### PR TITLE
INC-633: upgrade to Java 18 and Kotlin 1.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
   validate:
     executor:
       name: hmpps/java_localstack_postgres
-      jdk_tag: "17.0"
+      jdk_tag: "18.0"
       localstack_tag: "0.14.0"
       services: "sns,sqs"
       postgres_tag: "14"
@@ -41,8 +41,9 @@ jobs:
           path: build/test-results
       - store_artifacts:
           path: build/reports/tests
-      - store_artifacts:
-          path: build/reports/jacoco/test/html
+# enable when gradle 7.5 is released which includes JaCoCo 0.8.8 that supports Java 18
+#      - store_artifacts:
+#          path: build/reports/jacoco/test/html
 
 workflows:
   version: 2
@@ -122,11 +123,12 @@ workflows:
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:
             - hmpps-common-vars
-      - hmpps/veracode_pipeline_scan:
-          slack_channel: << pipeline.parameters.alerts-slack-channel >>
-          context:
-            - veracode-credentials
-            - hmpps-common-vars
+# currently disabled as veracode doesn't yet support jdk 18 or kotlin 1.7
+#      - hmpps/veracode_pipeline_scan:
+#          slack_channel: << pipeline.parameters.alerts-slack-channel >>
+#          context:
+#            - hmpps-common-vars
+#            - veracode-credentials
   security-weekly:
     triggers:
       - schedule:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-slim AS builder
+FROM openjdk:18-slim AS builder
 
 ARG BUILD_NUMBER
 ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
@@ -11,7 +11,7 @@ RUN ./gradlew assemble -Dorg.gradle.daemon=false
 RUN apt-get update && apt-get install -y curl
 RUN curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem  > root.crt
 
-FROM openjdk:17-slim
+FROM openjdk:18-slim
 LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
 
 ARG BUILD_NUMBER

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,10 @@
 plugins {
   id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.3.0"
-  id("jacoco")
+  // enable when gradle 7.5 is released which includes JaCoCo 0.8.8 that supports Java 18
+  // id("jacoco")
   id("org.sonarqube") version "3.4.0.2513"
-  kotlin("plugin.spring") version "1.6.21"
-  kotlin("plugin.jpa") version "1.6.21"
+  kotlin("plugin.spring") version "1.7.0"
+  kotlin("plugin.jpa") version "1.7.0"
 }
 
 dependencyCheck {
@@ -64,24 +65,25 @@ dependencies {
 }
 
 java {
-  toolchain.languageVersion.set(JavaLanguageVersion.of(17))
+  toolchain.languageVersion.set(JavaLanguageVersion.of(18))
 }
 
 tasks {
   withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     kotlinOptions {
-      jvmTarget = "17"
+      jvmTarget = "18"
     }
   }
 }
 
-tasks.test {
-  finalizedBy(tasks.jacocoTestReport)
-}
-
-tasks.jacocoTestReport {
-  dependsOn(tasks.test)
-  reports {
-    xml.required.set(true)
-  }
-}
+// enable when gradle 7.5 is released which includes JaCoCo 0.8.8 that supports Java 18
+// tasks.test {
+//   finalizedBy(tasks.jacocoTestReport)
+// }
+//
+// tasks.jacocoTestReport {
+//   dependsOn(tasks.test)
+//   reports {
+//     xml.required.set(true)
+//   }
+// }

--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
   "packageRules": [
     {
       "matchDatasources": ["docker"],
-      "allowedVersions": "17-slim"
+      "allowedVersions": "18-slim"
     }
   ]
 }


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/INC-633

I raised https://dsdmoj.atlassian.net/browse/INC-634 and https://dsdmoj.atlassian.net/browse/INC-635 to re-enable Veracode and JaCoCo