### PR TITLE
INC-733: Set IEP level review time to when the domain event occurred

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ aws --endpoint-url=http://localhost:4566 sns publish \
     }' \
     --message '{
       "version":"1.0",
-      "occurredAt":"2020-02-12T15:14:24.125533Z",
-      "publishedAt":"2020-02-12T15:15:09.902048716Z",
+      "occurredAt":"2020-02-12T15:14:24.125533+00:00",
+      "publishedAt":"2020-02-12T15:15:09.902048716+00:00",
       "description":"A prisoner has been received into prison",
       "additionalInformation": {
         "nomsNumber":"A0289IR",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IepLevelService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IepLevelService.kt
@@ -24,7 +24,7 @@ class IepLevelService(
 
       withContext(Dispatchers.Default) {
         iepPrisonRepository.findAllByPrisonIdAndActiveIsTrue(prisonId)
-          .filter { iepLevelMap[it.iepCode] != null && iepLevelMap[it.iepCode]!!.active }
+          .filter { iepLevelMap[it.iepCode]?.active == true }
           .map {
             val iepLevel = iepLevelMap[it.iepCode]!!
             IepLevel(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.IepLevelReposit
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonerIepLevelRepository
 import java.time.Clock
 import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 @Service
 class PrisonerIepLevelReviewService(
@@ -118,7 +119,7 @@ class PrisonerIepLevelReviewService(
         prisonerInfo,
         iepReview,
         locationInfo,
-        LocalDateTime.now(clock),
+        LocalDateTime.parse(prisonOffenderEvent.occurredAt, DateTimeFormatter.ISO_DATE_TIME),
         "incentives-api"
       )
     } ?: run {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
@@ -24,6 +24,7 @@ import java.time.Clock
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 class PrisonerIepLevelReviewServiceTest {
 
@@ -137,7 +138,7 @@ class PrisonerIepLevelReviewServiceTest {
           sequence = 1,
           current = true,
           reviewedBy = "incentives-api",
-          reviewTime = LocalDateTime.now(clock),
+          reviewTime = LocalDateTime.parse(prisonOffenderEvent.occurredAt, DateTimeFormatter.ISO_DATE_TIME),
           reviewType = ReviewType.INITIAL,
           prisonerNumber = prisonerAtLocation().offenderNo
         )
@@ -174,7 +175,7 @@ class PrisonerIepLevelReviewServiceTest {
           sequence = 1,
           current = true,
           reviewedBy = "incentives-api",
-          reviewTime = LocalDateTime.now(clock),
+          reviewTime = LocalDateTime.parse(prisonOffenderEvent.occurredAt, DateTimeFormatter.ISO_DATE_TIME),
           reviewType = ReviewType.TRANSFER,
           prisonerNumber = prisonerAtLocation.offenderNo
         )
@@ -211,7 +212,7 @@ class PrisonerIepLevelReviewServiceTest {
           sequence = 1,
           current = true,
           reviewedBy = "incentives-api",
-          reviewTime = LocalDateTime.now(clock),
+          reviewTime = LocalDateTime.parse(prisonOffenderEvent.occurredAt, DateTimeFormatter.ISO_DATE_TIME),
           reviewType = ReviewType.TRANSFER,
           prisonerNumber = prisonerAtLocation.offenderNo
         )

--- a/src/test/resources/messages/prisonerReceivedReasonAdmission.json
+++ b/src/test/resources/messages/prisonerReceivedReasonAdmission.json
@@ -2,7 +2,7 @@
   "Type": "Notification",
   "MessageId": "ee46cb90-a2de-57bf-86ba-9d2eba64645a",
   "TopicArn": "arn:aws:sns:eu-west-2:754256621582:cloud-platform-Digital-Prison-Services-f221e27fcfcf78f6ab4f4c3cc165eee7",
-  "Message":"{\"version\":\"1.0\", \"occurredAt\":\"2020-02-12T15:14:24.125533Z\", \"publishedAt\":\"2020-02-12T15:15:09.902048716Z\", \"description\":\"A prisoner has been received into prison\", \"additionalInformation\":{\"nomsNumber\":\"A1244AB\", \"prisonId\":\"MDI\", \"reason\":\"ADMISSION\", \"probableCause\":\"RECALL\", \"source\":\"PROBATION\", \"details\":\"Recall referral date 2021-05-12\"}}",
+  "Message":"{\"version\":\"1.0\", \"occurredAt\":\"2020-02-12T15:14:24.125533+00:00\", \"publishedAt\":\"2020-02-12T15:15:09.902048716+00:00\", \"description\":\"A prisoner has been received into prison\", \"additionalInformation\":{\"nomsNumber\":\"A1244AB\", \"prisonId\":\"MDI\", \"reason\":\"ADMISSION\", \"probableCause\":\"RECALL\", \"source\":\"PROBATION\", \"details\":\"Recall referral date 2021-05-12\"}}",
   "Timestamp": "2020-02-12T15:15:06.239Z",
   "SignatureVersion": "1",
   "Signature": "E0oesISQOBGaDjgOg3wEFfCFcIMNN4GyOdCtLRuhXB8QOzFt5XhzhfhcypPyXvIN+G5+Ky79BK0SlXDWxv9vSw2tOSojNwH1vvbXApInAiqyAgIBNYgUk3l1MzKmkqoH5lWmgmo5U4szk5jKbL0LVVc4BYRY6pIq2ZWt4pPoX47Z5oibjfXZZhKsR6k5VCTnUD7lqa2hkWWqaqZIsoeCG5g83Xb5d7s+LlN5iV74gwP/lgZT0E/uSnRCk8Nx0UUPEvpk/04V5yaW6W9YP/hwKMNep873tYzTcFGilyKoU5ucy4vVMulwT+EL3iOmumQEoFcCd/BQotjU2+wQ4wL3/Q==",

--- a/src/test/resources/messages/prisonerReceivedReasonTransferred.json
+++ b/src/test/resources/messages/prisonerReceivedReasonTransferred.json
@@ -2,7 +2,7 @@
   "Type": "Notification",
   "MessageId": "ee46cb90-a2de-57bf-86ba-9d2eba64645a",
   "TopicArn": "arn:aws:sns:eu-west-2:754256621582:cloud-platform-Digital-Prison-Services-f221e27fcfcf78f6ab4f4c3cc165eee7",
-  "Message":"{\"version\":\"1.0\", \"occurredAt\":\"2020-02-12T15:14:24.125533Z\", \"publishedAt\":\"2020-02-12T15:15:09.902048716Z\", \"description\":\"A prisoner has been transferred into prison\", \"additionalInformation\":{\"nomsNumber\":\"A1244AB\", \"prisonId\":\"MDI\", \"reason\":\"TRANSFERRED\", \"probableCause\":\"RECALL\", \"source\":\"PROBATION\", \"details\":\"Recall referral date 2021-05-12\"}}",
+  "Message":"{\"version\":\"1.0\", \"occurredAt\":\"2020-02-12T15:14:24.125533+00:00\", \"publishedAt\":\"2020-02-12T15:15:09.902048716+00:00\", \"description\":\"A prisoner has been transferred into prison\", \"additionalInformation\":{\"nomsNumber\":\"A1244AB\", \"prisonId\":\"MDI\", \"reason\":\"TRANSFERRED\", \"probableCause\":\"RECALL\", \"source\":\"PROBATION\", \"details\":\"Recall referral date 2021-05-12\"}}",
   "Timestamp": "2020-02-12T15:15:06.239Z",
   "SignatureVersion": "1",
   "Signature": "E0oesISQOBGaDjgOg3wEFfCFcIMNN4GyOdCtLRuhXB8QOzFt5XhzhfhcypPyXvIN+G5+Ky79BK0SlXDWxv9vSw2tOSojNwH1vvbXApInAiqyAgIBNYgUk3l1MzKmkqoH5lWmgmo5U4szk5jKbL0LVVc4BYRY6pIq2ZWt4pPoX47Z5oibjfXZZhKsR6k5VCTnUD7lqa2hkWWqaqZIsoeCG5g83Xb5d7s+LlN5iV74gwP/lgZT0E/uSnRCk8Nx0UUPEvpk/04V5yaW6W9YP/hwKMNep873tYzTcFGilyKoU5ucy4vVMulwT+EL3iOmumQEoFcCd/BQotjU2+wQ4wL3/Q==",

--- a/src/test/resources/messages/prisonerReleased.json
+++ b/src/test/resources/messages/prisonerReleased.json
@@ -2,7 +2,7 @@
   "Type": "Notification",
   "MessageId": "ee46cb90-a2de-57bf-86ba-9d2eba64645a",
   "TopicArn": "arn:aws:sns:eu-west-2:754256621582:cloud-platform-Digital-Prison-Services-f221e27fcfcf78f6ab4f4c3cc165eee7",
-  "Message":"{\"version\":\"1.0\", \"occurredAt\":\"2020-02-12T15:14:24.125533Z\", \"publishedAt\":\"2020-02-12T15:15:09.902048716Z\", \"description\":\"A prisoner has been received into prison\", \"additionalInformation\":{\"nomsNumber\":\"A5194DY\", \"prisonId\":\"MDI\", \"reason\":\"RELEASED_TO_HOSPITAL\", \"source\":\"PROBATION\", \"details\":\"Release date 2021-05-12\"}}",
+  "Message":"{\"version\":\"1.0\", \"occurredAt\":\"2020-02-12T15:14:24.125533+00:00\", \"publishedAt\":\"2020-02-12T15:15:09.902048716+00:00\", \"description\":\"A prisoner has been received into prison\", \"additionalInformation\":{\"nomsNumber\":\"A5194DY\", \"prisonId\":\"MDI\", \"reason\":\"RELEASED_TO_HOSPITAL\", \"source\":\"PROBATION\", \"details\":\"Release date 2021-05-12\"}}",
   "Timestamp": "2020-02-12T15:15:06.239Z",
   "SignatureVersion": "1",
   "Signature": "E0oesISQOBGaDjgOg3wEFfCFcIMNN4GyOdCtLRuhXB8QOzFt5XhzhfhcypPyXvIN+G5+Ky79BK0SlXDWxv9vSw2tOSojNwH1vvbXApInAiqyAgIBNYgUk3l1MzKmkqoH5lWmgmo5U4szk5jKbL0LVVc4BYRY6pIq2ZWt4pPoX47Z5oibjfXZZhKsR6k5VCTnUD7lqa2hkWWqaqZIsoeCG5g83Xb5d7s+LlN5iV74gwP/lgZT0E/uSnRCk8Nx0UUPEvpk/04V5yaW6W9YP/hwKMNep873tYzTcFGilyKoU5ucy4vVMulwT+EL3iOmumQEoFcCd/BQotjU2+wQ4wL3/Q==",


### PR DESCRIPTION
The domain event contains the date/time of when the even occurred so
we can use this time in the created `PrisonerIepLevel` record instead
of "now" (when the domain event is processed).

Also:
- updated SNS message payload so that datetimes have same format as per production messages (with local time offset)
- simplified `filter {}` expression to get list of active prison levels