### PR TITLE
INC-735: Avoid 500s when Prison API responds 404

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/HmppsIncentivesApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/HmppsIncentivesApiExceptionHandler.kt
@@ -15,6 +15,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.bind.support.WebExchangeBindException
+import org.springframework.web.reactive.function.client.WebClientResponseException.NotFound
 import org.springframework.web.server.ServerWebInputException
 import uk.gov.justice.digital.hmpps.incentivesapi.service.NoPrisonersAtLocationException
 import javax.validation.ValidationException
@@ -75,6 +76,20 @@ class HmppsIncentivesApiExceptionHandler {
         ErrorResponse(
           status = BAD_REQUEST,
           userMessage = "Validation failure: $message",
+          developerMessage = e.message
+        )
+      )
+  }
+
+  @ExceptionHandler(NotFound::class)
+  fun handleNotFoundException(e: NotFound): ResponseEntity<ErrorResponse?>? {
+    log.debug("Not found exception caught: {}", e.message)
+    return ResponseEntity
+      .status(NOT_FOUND)
+      .body(
+        ErrorResponse(
+          status = NOT_FOUND,
+          userMessage = "Not Found: ${e.message}",
           developerMessage = e.message
         )
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonApiService.kt
@@ -1,12 +1,8 @@
 package uk.gov.justice.digital.hmpps.incentivesapi.service
 
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.emitAll
-import kotlinx.coroutines.flow.emptyFlow
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
-import org.springframework.web.reactive.function.client.WebClientResponseException.NotFound
 import org.springframework.web.reactive.function.client.awaitBodilessEntity
 import org.springframework.web.reactive.function.client.awaitBody
 import org.springframework.web.reactive.function.client.bodyToFlow
@@ -25,9 +21,6 @@ class PrisonApiService(
       .header("Page-Limit", "3000")
       .retrieve()
       .bodyToFlow<PrisonerAtLocation>()
-      .catch {
-        if (it is NotFound) { emitAll(emptyFlow()) } else { throw it }
-      }
 
   fun getIEPSummaryPerPrisoner(@NotEmpty bookingIds: List<Long>): Flow<IepSummary> =
     prisonWebClient.post()
@@ -35,9 +28,6 @@ class PrisonApiService(
       .bodyValue(bookingIds)
       .retrieve()
       .bodyToFlow<IepSummary>()
-      .catch {
-        if (it is NotFound) { emitAll(emptyFlow()) } else { throw it }
-      }
 
   suspend fun getIEPSummaryForPrisoner(bookingId: Long, withDetails: Boolean, useClientCredentials: Boolean = false): IepSummary {
     val webClient = if (useClientCredentials) prisonWebClientClientCredentials else prisonWebClient
@@ -54,9 +44,6 @@ class PrisonApiService(
       .bodyValue(CaseNoteUsageRequest(numMonths = 3, offenderNos = offenderNos, type = type, subType = null))
       .retrieve()
       .bodyToFlow<CaseNoteUsage>()
-      .catch {
-        if (it is NotFound) { emitAll(emptyFlow()) } else { throw it }
-      }
 
   suspend fun retrieveProvenAdjudications(@NotEmpty bookingIds: List<Long>): Flow<ProvenAdjudication> =
     prisonWebClient.post()
@@ -64,9 +51,6 @@ class PrisonApiService(
       .bodyValue(bookingIds)
       .retrieve()
       .bodyToFlow<ProvenAdjudication>()
-      .catch {
-        if (it is NotFound) { emitAll(emptyFlow()) } else { throw it }
-      }
 
   suspend fun getLocation(locationId: String): PrisonLocation =
     prisonWebClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/wiremock/PrisonApiMockServer.kt
@@ -5,6 +5,7 @@ import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.post
+import uk.gov.justice.digital.hmpps.incentivesapi.config.ErrorResponse
 
 class PrisonApiMockServer : WireMockServer(WIREMOCK_PORT) {
   companion object {
@@ -313,6 +314,25 @@ class PrisonApiMockServer : WireMockServer(WIREMOCK_PORT) {
               }
             """.trimIndent()
           )
+      )
+    )
+  }
+
+  fun stubApi404for(url: String = "/api/bookings/1234134/iepSummary?withDetails=true") {
+    stubFor(
+      get(url).willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(404)
+          .withBody("""
+            {
+              "status": 404,
+              "userMessage": "Entity Not Found",
+              "errorCode": 42,
+              "developerMessage": "This is a test 404 Not Found response",
+              "moreInfo": "This is a test 404 Not Found response"
+            }
+          """.trimIndent())
       )
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/wiremock/PrisonApiMockServer.kt
@@ -5,7 +5,6 @@ import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.post
-import uk.gov.justice.digital.hmpps.incentivesapi.config.ErrorResponse
 
 class PrisonApiMockServer : WireMockServer(WIREMOCK_PORT) {
   companion object {
@@ -324,7 +323,8 @@ class PrisonApiMockServer : WireMockServer(WIREMOCK_PORT) {
         aResponse()
           .withHeader("Content-Type", "application/json")
           .withStatus(404)
-          .withBody("""
+          .withBody(
+            """
             {
               "status": 404,
               "userMessage": "Entity Not Found",
@@ -332,7 +332,8 @@ class PrisonApiMockServer : WireMockServer(WIREMOCK_PORT) {
               "developerMessage": "This is a test 404 Not Found response",
               "moreInfo": "This is a test 404 Not Found response"
             }
-          """.trimIndent())
+            """.trimIndent()
+          )
       )
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
@@ -43,6 +43,18 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
   }
 
   @Test
+  fun `Prison API '404 Not Found' responses are handled instead of responding 500 Internal Server Error`() {
+    val bookingId: Long = 1234134
+
+    prisonApiMockServer.stubApi404for("/api/bookings/$bookingId/iepSummary?withDetails=true")
+
+    webTestClient.get().uri("/iep/reviews/booking/$bookingId")
+      .headers(setAuthorisation())
+      .exchange()
+      .expectStatus().isNotFound
+  }
+
+  @Test
   fun `get IEP Levels for a prison`() {
 
     webTestClient.get().uri("/iep/levels/MDI")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
@@ -48,7 +48,7 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
 
     prisonApiMockServer.stubApi404for("/api/bookings/$bookingId/iepSummary?withDetails=true")
 
-    webTestClient.get().uri("/iep/reviews/booking/$bookingId")
+    webTestClient.get().uri("/iep/reviews/booking/$bookingId?use-nomis-data=true")
       .headers(setAuthorisation())
       .exchange()
       .expectStatus().isNotFound


### PR DESCRIPTION
### Background
We saw some odd `NoSuchElementException` exceptions when Prison API responded with a `404 Not Found`, this meant these requests to the Incentive API responded with a `500 Internal Server Error`.

### Reason
A `NoSuchElementException` was caused by [calling `first()` on an empty flow](https://github.com/ministryofjustice/hmpps-incentives-api/blob/88481925a2360cfc8bbdc67bbb423e3338d9364e/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt#L56).

The `PrisonApiService` methods were swallowing the `NotFound` exceptions and returning an empty flow in those cases causing the `NoSuchElementException` above when calling `.first()` on it.

### Solution
`PrisonApiService` doesn't swallow exceptions anymore and `NotFound` exceptions are now handled and clients gets a `404 Not Found` instead of a `500` error.

### Ticket
https://dsdmoj.atlassian.net/browse/INC-735