### PR TITLE
Simplify suspend functions/codebase

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/BehaviourSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/BehaviourSummary.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.incentivesapi.data
+package uk.gov.justice.digital.hmpps.incentivesapi.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveSummaryResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveSummaryResource.kt
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.incentivesapi.config.ErrorResponse
-import uk.gov.justice.digital.hmpps.incentivesapi.data.BehaviourSummary
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.BehaviourSummary
 import uk.gov.justice.digital.hmpps.incentivesapi.service.IncentiveSummaryService
 import uk.gov.justice.digital.hmpps.incentivesapi.service.SortColumn
 import javax.validation.constraints.Size

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IepLevelService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IepLevelService.kt
@@ -1,11 +1,8 @@
 package uk.gov.justice.digital.hmpps.incentivesapi.service
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.withContext
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.IepLevelRepository
@@ -19,22 +16,20 @@ class IepLevelService(
 
   @Transactional(readOnly = true)
   suspend fun getIepLevelsForPrison(prisonId: String): List<IepLevel> {
-    return coroutineScope {
-      val iepLevelMap = iepLevelRepository.findAll().toList().associateBy { it.iepCode }
+    val iepLevelMap = iepLevelRepository.findAll().toList().associateBy { it.iepCode }
 
-      withContext(Dispatchers.Default) {
-        iepPrisonRepository.findAllByPrisonIdAndActiveIsTrue(prisonId)
-          .filter { iepLevelMap[it.iepCode]?.active == true }
-          .map {
-            val iepLevel = iepLevelMap[it.iepCode]!!
-            IepLevel(
-              iepLevel = it.iepCode,
-              iepDescription = iepLevel.iepDescription,
-              sequence = iepLevel.sequence,
-              default = it.defaultIep
-            )
-          }
-      }.toList().sortedWith(compareBy(IepLevel::sequence))
-    }
+    return iepPrisonRepository.findAllByPrisonIdAndActiveIsTrue(prisonId)
+      .filter { iepLevelMap[it.iepCode]?.active == true }
+      .map {
+        val iepLevel = iepLevelMap[it.iepCode]!!
+        IepLevel(
+          iepLevel = it.iepCode,
+          iepDescription = iepLevel.iepDescription,
+          sequence = iepLevel.sequence,
+          default = it.defaultIep
+        )
+      }
+      .toList()
+      .sortedWith(compareBy(IepLevel::sequence))
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveSummaryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveSummaryService.kt
@@ -7,9 +7,9 @@ import kotlinx.coroutines.flow.toList
 import org.apache.commons.text.WordUtils
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.incentivesapi.data.BehaviourSummary
-import uk.gov.justice.digital.hmpps.incentivesapi.data.IncentiveLevelSummary
-import uk.gov.justice.digital.hmpps.incentivesapi.data.PrisonerIncentiveSummary
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.BehaviourSummary
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.IncentiveLevelSummary
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.PrisonerIncentiveSummary
 
 @Service
 class IncentiveSummaryService(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveSummaryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveSummaryService.kt
@@ -146,11 +146,7 @@ class IncentiveSummaryService(
       }
 
   private fun calcTypeCount(caseNoteUsage: List<CaseNoteUsage>): Int =
-    if (caseNoteUsage.isNotEmpty()) {
-      caseNoteUsage.map { it.numCaseNotes }.reduce { acc, next -> acc + next }
-    } else {
-      0
-    }
+    caseNoteUsage.map { it.numCaseNotes }.fold(0) { acc, next -> acc + next }
 
   suspend fun getLocation(locationId: String): String =
     prisonApiService.getLocation(locationId).description

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -107,12 +107,7 @@ class PrisonerIepLevelReviewService(
   }
 
   suspend fun getReviewById(id: Long): IepDetail =
-    prisonerIepLevelRepository.findById(id)
-      ?.let {
-        with(it) {
-          translate()
-        }
-      } ?: throw NoDataFoundException(id)
+    prisonerIepLevelRepository.findById(id)?.translate() ?: throw NoDataFoundException(id)
 
   @Transactional
   suspend fun processReceivedPrisoner(prisonOffenderEvent: HMPPSDomainEvent) =
@@ -168,11 +163,7 @@ class PrisonerIepLevelReviewService(
   }
 
   private suspend fun buildIepSummary(levels: Flow<PrisonerIepLevel>, withDetails: Boolean = true): IepSummary {
-    val iepLevels = levels.map {
-      with(it) {
-        translate()
-      }
-    }.toList()
+    val iepLevels = levels.map { it.translate() }.toList()
 
     val currentIep = iepLevels.first()
     return IepSummary(


### PR DESCRIPTION
- removed unnecessary `coroutineScope`
- simplified `getIncentivesSummaryByLocation()` method
- use `fold()` when counting case notes
- use property references when it makes code a bit more concise
- moved BehaviourSummary classes in `dto` packages for consistency
- removed unnecessary `let {}`/`with()`