### PR TITLE
INC-738: POST /iep/sync/booking/{bookingId} endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IepSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IepSummary.kt
@@ -113,17 +113,17 @@ data class IepReview(
 )
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@Schema(description = "Request to migrate an IEP Review from NOMIS")
-data class IepMigration(
+@Schema(description = "Request to synchronise an IEP Review from NOMIS")
+data class SyncPostRequest(
   @Schema(description = "Date and time when the review took place", required = true)
   val iepTime: LocalDateTime,
 
   @Schema(description = "Prison ID", example = "MDI", required = true)
-  @field:NotBlank(message = "Prison ID on IEP Level migration is required")
+  @field:NotBlank(message = "Prison ID is required")
   val prisonId: String,
 
   @Schema(description = "Location of prisoner when review took place within prison (i.e. their cell)", example = "1-2-003", required = true)
-  @field:NotBlank(message = "Location ID on IEP Level migration is required")
+  @field:NotBlank(message = "Location ID is required")
   val locationId: String,
 
   @Schema(description = "IEP Level", example = "STD", required = true, allowableValues = ["STD", "BAS", "ENH", "EN2", "EN3", "ENT"])
@@ -134,7 +134,7 @@ data class IepMigration(
   ) @field:NotBlank(message = "IEP Level is required") val iepLevel: String,
 
   @Schema(description = "Comment about review", example = "This is a comment", required = true)
-  @field:NotBlank(message = "Comment on IEP Level migration is required")
+  @field:NotBlank(message = "Comment is required")
   val comment: String,
 
   @Schema(description = "NOMIS User Id who performed the review", example = "XYZ_GEN", required = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResource.kt
@@ -19,9 +19,9 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.incentivesapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.CurrentIepLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepDetail
-import uk.gov.justice.digital.hmpps.incentivesapi.dto.SyncPostRequest
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepReview
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepSummary
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.SyncPostRequest
 import uk.gov.justice.digital.hmpps.incentivesapi.service.AuditService
 import uk.gov.justice.digital.hmpps.incentivesapi.service.AuditType
 import uk.gov.justice.digital.hmpps.incentivesapi.service.IepLevel

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResource.kt
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.incentivesapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.CurrentIepLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepDetail
-import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepMigration
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.SyncPostRequest
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepReview
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepSummary
 import uk.gov.justice.digital.hmpps.incentivesapi.service.AuditService
@@ -318,9 +318,9 @@ class IepLevelResource(
     @Schema(description = "Booking Id", example = "2342342", required = true)
     @PathVariable bookingId: Long,
     @Schema(description = "IEP Review", required = true)
-    @RequestBody @Valid iepMigration: IepMigration,
+    @RequestBody @Valid syncPostRequest: SyncPostRequest,
   ): IepDetail =
-    prisonerIepLevelReviewService.addIepMigration(bookingId, iepMigration)
+    prisonerIepLevelReviewService.persistPrisonerIepLevel(bookingId, syncPostRequest)
 
   @PostMapping("/sync/booking/{bookingId}")
   @PreAuthorize("hasRole('MAINTAIN_IEP') and hasAuthority('SCOPE_write')")
@@ -354,8 +354,8 @@ class IepLevelResource(
     @Schema(description = "Booking Id", example = "2342342", required = true)
     @PathVariable bookingId: Long,
     @Schema(description = "IEP Review", required = true)
-    @RequestBody @Valid iepMigration: IepMigration,
-  ): IepDetail = prisonerIepLevelReviewService.handleSyncPostIepReviewRequest(bookingId, iepMigration)
+    @RequestBody @Valid syncPostRequest: SyncPostRequest,
+  ): IepDetail = prisonerIepLevelReviewService.handleSyncPostIepReviewRequest(bookingId, syncPostRequest)
 
   private suspend fun sendEventAndAudit(iepDetail: IepDetail) {
     snsService.sendIepReviewEvent(iepDetail.id!!, iepDetail.iepTime)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResource.kt
@@ -355,11 +355,7 @@ class IepLevelResource(
     @PathVariable bookingId: Long,
     @Schema(description = "IEP Review", required = true)
     @RequestBody @Valid iepMigration: IepMigration,
-  ): IepDetail {
-    val iepDetail = prisonerIepLevelReviewService.syncPostIepReview(bookingId, iepMigration)
-    sendEventAndAudit(iepDetail)
-    return iepDetail
-  }
+  ): IepDetail = prisonerIepLevelReviewService.handleSyncPostIepReviewRequest(bookingId, iepMigration)
 
   private suspend fun sendEventAndAudit(iepDetail: IepDetail) {
     snsService.sendIepReviewEvent(iepDetail.id!!, iepDetail.iepTime)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -93,6 +93,27 @@ class PrisonerIepLevelReviewService(
     ).translate()
   }
 
+  @Transactional
+  suspend fun syncPostIepReview(bookingId: Long, iepMigration: IepMigration): IepDetail {
+    val prisonerInfo = prisonApiService.getPrisonerInfo(bookingId)
+
+    return prisonerIepLevelRepository.save(
+      PrisonerIepLevel(
+        iepCode = iepMigration.iepLevel,
+        commentText = iepMigration.comment,
+        bookingId = prisonerInfo.bookingId,
+        prisonId = iepMigration.prisonId,
+        locationId = iepMigration.locationId,
+        sequence = 0,
+        current = iepMigration.current,
+        reviewedBy = iepMigration.userId,
+        reviewTime = iepMigration.iepTime,
+        reviewType = iepMigration.reviewType,
+        prisonerNumber = prisonerInfo.offenderNo
+      )
+    ).translate()
+  }
+
   fun getCurrentIEPLevelForPrisoners(bookingIds: List<Long>, useNomisData: Boolean): Flow<CurrentIepLevel> {
     return if (useNomisData) {
       prisonApiService.getIEPSummaryPerPrisoner(bookingIds)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -93,24 +93,10 @@ class PrisonerIepLevelReviewService(
     ).translate()
   }
 
-  @Transactional
-  suspend fun syncPostIepReview(bookingId: Long, iepMigration: IepMigration): IepDetail {
-    val prisonerInfo = prisonApiService.getPrisonerInfo(bookingId)
-
-    return prisonerIepLevelRepository.save(
-      PrisonerIepLevel(
-        iepCode = iepMigration.iepLevel,
-        commentText = iepMigration.comment,
-        bookingId = prisonerInfo.bookingId,
-        prisonId = iepMigration.prisonId,
-        locationId = iepMigration.locationId,
-        current = iepMigration.current,
-        reviewedBy = iepMigration.userId,
-        reviewTime = iepMigration.iepTime,
-        reviewType = iepMigration.reviewType,
-        prisonerNumber = prisonerInfo.offenderNo
-      )
-    ).translate()
+  suspend fun handleSyncPostIepReviewRequest(bookingId: Long, iepMigration: IepMigration): IepDetail {
+    val iepDetail = addIepMigration(bookingId, iepMigration)
+    sendEventAndAudit(iepDetail)
+    return iepDetail
   }
 
   fun getCurrentIEPLevelForPrisoners(bookingIds: List<Long>, useNomisData: Boolean): Flow<CurrentIepLevel> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -12,9 +12,9 @@ import uk.gov.justice.digital.hmpps.incentivesapi.config.AuthenticationFacade
 import uk.gov.justice.digital.hmpps.incentivesapi.config.NoDataFoundException
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.CurrentIepLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepDetail
-import uk.gov.justice.digital.hmpps.incentivesapi.dto.SyncPostRequest
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepReview
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepSummary
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.SyncPostRequest
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.daysSinceReview
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.ReviewType

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.incentivesapi.config.AuthenticationFacade
 import uk.gov.justice.digital.hmpps.incentivesapi.config.NoDataFoundException
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.CurrentIepLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepDetail
-import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepMigration
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.SyncPostRequest
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepReview
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepSummary
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.daysSinceReview
@@ -75,26 +75,26 @@ class PrisonerIepLevelReviewService(
   }
 
   @Transactional
-  suspend fun addIepMigration(bookingId: Long, iepMigration: IepMigration): IepDetail {
+  suspend fun persistPrisonerIepLevel(bookingId: Long, syncPostRequest: SyncPostRequest): IepDetail {
     val prisonerInfo = prisonApiService.getPrisonerInfo(bookingId)
     return prisonerIepLevelRepository.save(
       PrisonerIepLevel(
-        iepCode = iepMigration.iepLevel,
-        commentText = iepMigration.comment,
+        iepCode = syncPostRequest.iepLevel,
+        commentText = syncPostRequest.comment,
         bookingId = prisonerInfo.bookingId,
-        prisonId = iepMigration.prisonId,
-        locationId = iepMigration.locationId,
-        current = iepMigration.current,
-        reviewedBy = iepMigration.userId,
-        reviewTime = iepMigration.iepTime,
-        reviewType = iepMigration.reviewType,
+        prisonId = syncPostRequest.prisonId,
+        locationId = syncPostRequest.locationId,
+        current = syncPostRequest.current,
+        reviewedBy = syncPostRequest.userId,
+        reviewTime = syncPostRequest.iepTime,
+        reviewType = syncPostRequest.reviewType,
         prisonerNumber = prisonerInfo.offenderNo
       )
     ).translate()
   }
 
-  suspend fun handleSyncPostIepReviewRequest(bookingId: Long, iepMigration: IepMigration): IepDetail {
-    val iepDetail = addIepMigration(bookingId, iepMigration)
+  suspend fun handleSyncPostIepReviewRequest(bookingId: Long, syncPostRequest: SyncPostRequest): IepDetail {
+    val iepDetail = persistPrisonerIepLevel(bookingId, syncPostRequest)
     sendEventAndAudit(iepDetail)
     return iepDetail
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -104,7 +104,6 @@ class PrisonerIepLevelReviewService(
         bookingId = prisonerInfo.bookingId,
         prisonId = iepMigration.prisonId,
         locationId = iepMigration.locationId,
-        sequence = 0,
         current = iepMigration.current,
         reviewedBy = iepMigration.userId,
         reviewTime = iepMigration.iepTime,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import uk.gov.justice.digital.hmpps.incentivesapi.dto.SyncPostRequest
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepReview
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.SyncPostRequest
 import uk.gov.justice.digital.hmpps.incentivesapi.integration.SqsIntegrationTestBase
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.ReviewType
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonerIepLevelRepository

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
@@ -17,8 +17,8 @@ import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.incentivesapi.config.AuthenticationFacade
 import uk.gov.justice.digital.hmpps.incentivesapi.config.NoDataFoundException
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepDetail
-import uk.gov.justice.digital.hmpps.incentivesapi.dto.SyncPostRequest
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepSummary
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.SyncPostRequest
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.IepLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.ReviewType
@@ -388,7 +388,7 @@ class PrisonerIepLevelReviewServiceTest {
     )
 
     private val iepDetail = IepDetail(
-      id=iepReviewId,
+      id = iepReviewId,
       iepLevel = iepLevelDescription,
       comments = syncPostRequest.comment,
       prisonerNumber = offenderNo,
@@ -411,12 +411,12 @@ class PrisonerIepLevelReviewServiceTest {
 
       // Mock IEP level query
       whenever(iepLevelRepository.findById("ENH")).thenReturn(
-        IepLevel(iepCode = iepLevelCode, iepDescription = iepLevelDescription, sequence=3, active=true),
+        IepLevel(iepCode = iepLevelCode, iepDescription = iepLevelDescription, sequence = 3, active = true),
       )
 
       // Mock save() of PrisonerIepLevel record
       whenever(prisonerIepLevelRepository.save(iepReview))
-        .thenReturn(iepReview.copy(id=iepReviewId))
+        .thenReturn(iepReview.copy(id = iepReviewId))
     }
 
     @Test


### PR DESCRIPTION
Endpoint invoked to synchronise IEP reviews from NOMIS.

As per ticket this endpoint has same request format as per migration endpoint (but it publishes the domain events).
As part of this I've renamed the `IepMigration` data class into `SyncPostRequest`.