### PR TITLE
INC-815: Basic next review date calculation

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -14,3 +14,9 @@ CVE-2022-38751
 # Suppression for snakeyaml 1.31 vulnerability as not fixed yet
 #   Can be suppressed as we we don't parse untrusted yaml
 CVE-2022-38752
+# Suppression for jackson databind 2.13.4 as no release for it yet
+#   Can be suppressed as UNWRAP_SINGLE_VALUE_ARRAYS is not enabled
+CVE-2022-42003
+# Suppression for jackson databind 2.13.3 as bundled with application insights
+#   Can be suppressed as don't parse untrusted json in application insights
+CVE-2022-42004

--- a/README.md
+++ b/README.md
@@ -41,25 +41,25 @@ This assumes you have the [AWS CLI](https://aws.amazon.com/cli/) installed
 
 1. Follow [Running Locally](#running-locally) to bring up the service and docker containers
 2. Find the ARN of the Domain Events topic created in your localstack instance and update the `topic-arn` parameter in the command below
-```
-aws --endpoint-url=http://localhost:4566 sns publish \
-    --topic-arn arn:aws:sns:eu-west-2:000000000000:[find this in the Incentives API log for HmppsTopicFactory] \
-    --message-attributes '{
-      "eventType": { "DataType": "String", "StringValue": "prison-offender-events.prisoner.received" }
-    }' \
-    --message '{
-      "version":"1.0",
-      "occurredAt":"2020-02-12T15:14:24.125533+00:00",
-      "publishedAt":"2020-02-12T15:15:09.902048716+00:00",
-      "description":"A prisoner has been received into prison",
-      "additionalInformation": {
-        "nomsNumber":"A0289IR",
-        "prisonId":"MDI",
-        "reason":"ADMISSION",
-        "details":"ecall referral date 2021-05-12"
-      }
-    }'
-```
+    ```shell
+    aws --endpoint-url=http://localhost:4566 sns publish \
+        --topic-arn arn:aws:sns:eu-west-2:000000000000:[find this in the Incentives API log for HmppsTopicFactory] \
+        --message-attributes '{
+          "eventType": { "DataType": "String", "StringValue": "prison-offender-events.prisoner.received" }
+        }' \
+        --message '{
+          "version":"1.0",
+          "occurredAt":"2020-02-12T15:14:24.125533+00:00",
+          "publishedAt":"2020-02-12T15:15:09.902048716+00:00",
+          "description":"A prisoner has been received into prison",
+          "additionalInformation": {
+            "nomsNumber":"A0289IR",
+            "prisonId":"MDI",
+            "reason":"ADMISSION",
+            "details":"ecall referral date 2021-05-12"
+          }
+        }'
+    ```
 3. Paste the command into your terminal
 
 **NOTE**: If you get a `Topic does not exist` error, it may mean your default AWS profile points to a different region,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IepSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IepSummary.kt
@@ -39,6 +39,10 @@ data class IepSummary(
       return Duration.between(iepDate.atStartOfDay(), currentIepDate).toDays().toInt()
     }
 
+  @get:Schema(description = "Date of next review", example = "2022-12-31", required = true)
+  @get:JsonProperty
+  val nextReviewDate: LocalDate = iepDate.plusYears(1)
+
   fun daysOnLevel(): Int {
     val currentIepDate = LocalDate.now().atStartOfDay()
     var daysOnLevel = 0

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IepSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IepSummary.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.incentivesapi.dto
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.ReviewType
 import java.time.Duration
@@ -24,17 +25,19 @@ data class IepSummary(
   val iepDate: LocalDate,
   @Schema(description = "Date and time when last review took place", required = true, example = "2021-12-31T12:34:56.789012")
   val iepTime: LocalDateTime,
-  @Schema(description = "Days Since last Review", example = "23", required = true)
-  val daysSinceReview: Int,
   @Schema(description = "Location  of prisoner when review took place within prison (i.e. their cell)", example = "1-2-003", required = false)
   val locationId: String? = null,
   @Schema(description = "IEP Review History (descending in time)", required = true)
   val iepDetails: List<IepDetail>,
 ) {
 
-  fun daysSinceReview(): Int {
-    return daysSinceReview(iepDetails)
-  }
+  @get:Schema(description = "Days since last review", example = "23", required = true)
+  @get:JsonProperty
+  val daysSinceReview: Int
+    get() {
+      val currentIepDate = LocalDate.now().atStartOfDay()
+      return Duration.between(iepDate.atStartOfDay(), currentIepDate).toDays().toInt()
+    }
 
   fun daysOnLevel(): Int {
     val currentIepDate = LocalDate.now().atStartOfDay()
@@ -51,11 +54,6 @@ data class IepSummary(
 
     return daysOnLevel
   }
-}
-
-fun daysSinceReview(iepHistory: List<IepDetail>): Int {
-  val currentIepDate = LocalDate.now().atStartOfDay()
-  return Duration.between(iepHistory.first().iepDate.atStartOfDay(), currentIepDate).toDays().toInt()
 }
 
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IepSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IepSummary.kt
@@ -35,8 +35,8 @@ data class IepSummary(
   @get:JsonProperty
   val daysSinceReview: Int
     get() {
-      val currentIepDate = LocalDate.now().atStartOfDay()
-      return Duration.between(iepDate.atStartOfDay(), currentIepDate).toDays().toInt()
+      val today = LocalDate.now().atStartOfDay()
+      return Duration.between(iepDate.atStartOfDay(), today).toDays().toInt()
     }
 
   @get:Schema(description = "Date of next review", example = "2022-12-31", required = true)
@@ -44,7 +44,7 @@ data class IepSummary(
   val nextReviewDate: LocalDate = iepDate.plusYears(1)
 
   fun daysOnLevel(): Int {
-    val currentIepDate = LocalDate.now().atStartOfDay()
+    val today = LocalDate.now().atStartOfDay()
     var daysOnLevel = 0
 
     run iepCheck@{
@@ -52,7 +52,7 @@ data class IepSummary(
         if (it.iepLevel != iepLevel) {
           return@iepCheck
         }
-        daysOnLevel = Duration.between(it.iepDate.atStartOfDay(), currentIepDate).toDays().toInt()
+        daysOnLevel = Duration.between(it.iepDate.atStartOfDay(), today).toDays().toInt()
       }
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveSummaryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveSummaryService.kt
@@ -122,7 +122,7 @@ class IncentiveSummaryService(
         IepResult(
           bookingId = it.bookingId,
           iepLevel = it.iepLevel,
-          daysSinceReview = it.daysSinceReview(),
+          daysSinceReview = it.daysSinceReview,
           daysOnLevel = it.daysOnLevel()
         )
       }.toList().associateBy(IepResult::bookingId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -16,7 +16,6 @@ import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepReview
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepSummary
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.SyncPatchRequest
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.SyncPostRequest
-import uk.gov.justice.digital.hmpps.incentivesapi.dto.daysSinceReview
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.ReviewType
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.IepLevelRepository
@@ -225,7 +224,6 @@ class PrisonerIepLevelReviewService(
       prisonerNumber = currentIep.prisonerNumber,
       locationId = currentIep.locationId,
       iepDetails = if (withDetails) iepLevels else emptyList(),
-      daysSinceReview = daysSinceReview(iepLevels)
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/wiremock/PrisonApiMockServer.kt
@@ -281,7 +281,7 @@ class PrisonApiMockServer : WireMockServer(WIREMOCK_PORT) {
           .withBody(
             """
               {
-                "bookingId": 1234134,
+                "bookingId": $bookingId,
                 "iepLevel": "Basic",
                 "daysSinceReview": 35,
                 "iepDate": "2021-12-02T00:00:00",
@@ -289,7 +289,7 @@ class PrisonApiMockServer : WireMockServer(WIREMOCK_PORT) {
                 "iepDetails": [
                   {
                     "agencyId": "MDI",
-                    "bookingId": 1234134,
+                    "bookingId": $bookingId,
                     "sequence": 2,
                     "iepDate": "2021-12-02",
                     "iepLevel": "Basic",
@@ -300,7 +300,7 @@ class PrisonApiMockServer : WireMockServer(WIREMOCK_PORT) {
                   },
                    {
                     "agencyId": "BXI",
-                    "bookingId": 1234134,
+                    "bookingId": $bookingId,
                     "sequence": 1,
                     "iepDate": "2020-11-02",
                     "iepLevel": "Entry",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/wiremock/PrisonApiMockServer.kt
@@ -139,7 +139,7 @@ class PrisonApiMockServer : WireMockServer(WIREMOCK_PORT) {
                   "bookingId": 1234134,
                   "iepLevel": "Basic",
                   "daysSinceReview": 35,
-                  "iepDate": "2021-12-02T00:00:00",
+                  "iepDate": "2021-12-02",
                   "iepTime": "2021-12-02T09:24:42.894Z",
                   "iepDetails": [
                     {
@@ -170,7 +170,7 @@ class PrisonApiMockServer : WireMockServer(WIREMOCK_PORT) {
                   "bookingId": 1234135,
                   "iepLevel": "Standard",
                   "daysSinceReview": 50,
-                  "iepDate": "2022-01-02T00:00:00",
+                  "iepDate": "2022-01-02",
                   "iepTime": "2022-01-02T09:24:42.894Z",
                   "iepDetails": [
                     {
@@ -190,7 +190,7 @@ class PrisonApiMockServer : WireMockServer(WIREMOCK_PORT) {
                   "bookingId": 1234136,
                   "iepLevel": "Enhanced",
                   "daysSinceReview": 12,
-                  "iepDate": "2021-10-02T00:00:00",
+                  "iepDate": "2021-10-02",
                   "iepTime": "2021-10-02T09:24:42.894Z",
                   "iepDetails": [
                     {
@@ -210,7 +210,7 @@ class PrisonApiMockServer : WireMockServer(WIREMOCK_PORT) {
                   "bookingId": 1234137,
                   "iepLevel": "Basic",
                   "daysSinceReview": 2,
-                  "iepDate": "2021-12-02T00:00:00",
+                  "iepDate": "2021-12-02",
                   "iepTime": "2021-12-02T09:24:42.894Z",
                   "iepDetails": [
                     {
@@ -230,7 +230,7 @@ class PrisonApiMockServer : WireMockServer(WIREMOCK_PORT) {
                   "bookingId": 1234138,
                   "iepLevel": "Standard",
                   "daysSinceReview": 6,
-                  "iepDate": "2021-12-02T00:00:00",
+                  "iepDate": "2021-12-02",
                   "iepTime": "2021-12-02T09:24:42.894Z",
                   "iepDetails": [
                     {
@@ -250,7 +250,7 @@ class PrisonApiMockServer : WireMockServer(WIREMOCK_PORT) {
                   "bookingId": 2734134,
                   "iepLevel": "Entry",
                   "daysSinceReview": 1,
-                  "iepDate": "2022-01-02T00:00:00",
+                  "iepDate": "2022-01-02",
                   "iepTime": "2022-01-02T09:24:42.894Z",
                   "iepDetails": [
                     {
@@ -284,7 +284,7 @@ class PrisonApiMockServer : WireMockServer(WIREMOCK_PORT) {
                 "bookingId": $bookingId,
                 "iepLevel": "Basic",
                 "daysSinceReview": 35,
-                "iepDate": "2021-12-02T00:00:00",
+                "iepDate": "2021-12-02",
                 "iepTime": "2021-12-02T09:24:42.894Z",
                 "iepDetails": [
                   {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
@@ -92,6 +92,7 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
              "iepDate":"2021-12-02",
              "iepLevel":"Basic",
              "iepTime":"2021-12-02T09:24:42.894",
+             "nextReviewDate": "2022-12-02",
              "iepDetails":[
                 {
                    "bookingId":1234134,
@@ -204,6 +205,7 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
       .expectStatus().isCreated
 
     val today = now().format(DateTimeFormatter.ISO_DATE)
+    val nextReviewDate = now().plusYears(1).format(DateTimeFormatter.ISO_DATE)
     webTestClient.get().uri("/iep/reviews/booking/$bookingId?use-nomis-data=false")
       .headers(setAuthorisation())
       .exchange()
@@ -215,6 +217,7 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
              "daysSinceReview":0,
              "iepDate":"$today",
              "iepLevel":"Standard",
+             "nextReviewDate": "$nextReviewDate",
              "iepDetails":[
                 {
                    "bookingId":$bookingId,
@@ -254,6 +257,7 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
       .expectStatus().isCreated
 
     val today = now().format(DateTimeFormatter.ISO_DATE)
+    val nextReviewDate = now().plusYears(1).format(DateTimeFormatter.ISO_DATE)
     webTestClient.get().uri("/iep/reviews/prisoner/$prisonerNumber?use-nomis-data=false")
       .headers(setAuthorisation())
       .exchange()
@@ -266,6 +270,7 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
              "daysSinceReview":0,
              "iepDate":"$today",
              "iepLevel":"Enhanced",
+             "nextReviewDate":"$nextReviewDate",
              "iepDetails":[
                 {
                    "prisonerNumber": $prisonerNumber,
@@ -687,6 +692,7 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
              "daysSinceReview":0,
              "iepDate":"${migrationRequest.iepTime.toLocalDate()}",
              "iepLevel":"Standard",
+             "nextReviewDate":"${migrationRequest.iepTime.toLocalDate().plusYears(1)}",
              "iepDetails":[
                 {
                    "bookingId":$bookingId,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
@@ -13,6 +13,8 @@ import uk.gov.justice.digital.hmpps.incentivesapi.integration.SqsIntegrationTest
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.ReviewType
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonerIepLevelRepository
+import java.time.Duration
+import java.time.LocalDate
 import java.time.LocalDate.now
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -75,6 +77,9 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
   fun `get IEP Levels for a prisoner`() {
     prisonApiMockServer.stubIEPSummaryForBooking()
 
+    val lastReviewDate = LocalDate.of(2021, 12, 2)
+    val daysSinceReview = Duration.between(lastReviewDate.atStartOfDay(), now().atStartOfDay()).toDays().toInt()
+
     webTestClient.get().uri("/iep/reviews/booking/1234134")
       .headers(setAuthorisation())
       .exchange()
@@ -83,7 +88,7 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
         """
             {
              "bookingId":1234134,
-             "daysSinceReview":35,
+             "daysSinceReview": $daysSinceReview,
              "iepDate":"2021-12-02",
              "iepLevel":"Basic",
              "iepTime":"2021-12-02T09:24:42.894",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/DaysOnLevelTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/DaysOnLevelTest.kt
@@ -79,9 +79,9 @@ class DaysOnLevelTest {
       val iepTime = LocalDateTime.now().minusDays(3)
       val iepSummary = IepSummary(
         bookingId = 1L,
-        iepDate = iepTime.toLocalDate(),
+        iepDate = iepTime.toLocalDate().plusDays(3),
         iepLevel = "Standard",
-        iepTime = iepTime,
+        iepTime = iepTime.plusDays(3),
         iepDetails = listOf(
           IepDetail(
             bookingId = 1L,
@@ -117,9 +117,9 @@ class DaysOnLevelTest {
       val iepTime = LocalDateTime.now().minusDays(10)
       val iepSummary = IepSummary(
         bookingId = 1L,
-        iepDate = iepTime.toLocalDate(),
+        iepDate = iepTime.toLocalDate().plusDays(9),
         iepLevel = "Basic",
-        iepTime = iepTime,
+        iepTime = iepTime.plusDays(9),
         iepDetails = listOf(
           IepDetail(
             bookingId = 1L,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/DaysOnLevelTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/DaysOnLevelTest.kt
@@ -16,7 +16,6 @@ class DaysOnLevelTest {
       val iepTime = LocalDateTime.now().minusDays(60)
       val iepSummary = IepSummary(
         bookingId = 1L,
-        daysSinceReview = 60,
         iepDate = iepTime.toLocalDate(),
         iepLevel = "Enhanced",
         iepTime = iepTime,
@@ -44,7 +43,7 @@ class DaysOnLevelTest {
         )
       )
 
-      assertThat(iepSummary.daysSinceReview()).isEqualTo(60)
+      assertThat(iepSummary.daysSinceReview).isEqualTo(60)
       assertThat(iepSummary.daysOnLevel()).isEqualTo(60)
     }
 
@@ -53,7 +52,6 @@ class DaysOnLevelTest {
       val iepTime = LocalDateTime.now().minusDays(3)
       val iepSummary = IepSummary(
         bookingId = 1L,
-        daysSinceReview = -1,
         iepDate = iepTime.toLocalDate(),
         iepLevel = "Basic",
         iepTime = iepTime,
@@ -72,7 +70,7 @@ class DaysOnLevelTest {
         )
       )
 
-      assertThat(iepSummary.daysSinceReview()).isEqualTo(3)
+      assertThat(iepSummary.daysSinceReview).isEqualTo(3)
       assertThat(iepSummary.daysOnLevel()).isEqualTo(3)
     }
 
@@ -81,7 +79,6 @@ class DaysOnLevelTest {
       val iepTime = LocalDateTime.now().minusDays(3)
       val iepSummary = IepSummary(
         bookingId = 1L,
-        daysSinceReview = -1,
         iepDate = iepTime.toLocalDate(),
         iepLevel = "Standard",
         iepTime = iepTime,
@@ -111,7 +108,7 @@ class DaysOnLevelTest {
         )
       )
 
-      assertThat(iepSummary.daysSinceReview()).isEqualTo(0)
+      assertThat(iepSummary.daysSinceReview).isEqualTo(0)
       assertThat(iepSummary.daysOnLevel()).isEqualTo(0)
     }
 
@@ -120,7 +117,6 @@ class DaysOnLevelTest {
       val iepTime = LocalDateTime.now().minusDays(10)
       val iepSummary = IepSummary(
         bookingId = 1L,
-        daysSinceReview = -1,
         iepDate = iepTime.toLocalDate(),
         iepLevel = "Basic",
         iepTime = iepTime,
@@ -161,7 +157,7 @@ class DaysOnLevelTest {
         )
       )
 
-      assertThat(iepSummary.daysSinceReview()).isEqualTo(1)
+      assertThat(iepSummary.daysSinceReview).isEqualTo(1)
       assertThat(iepSummary.daysOnLevel()).isEqualTo(10)
     }
 
@@ -171,7 +167,6 @@ class DaysOnLevelTest {
       val previousIep = iepTime.minusDays(60)
       val iepSummary = IepSummary(
         bookingId = 1L,
-        daysSinceReview = 0,
         iepDate = iepTime.toLocalDate(),
         iepLevel = "Enhanced",
         iepTime = iepTime,
@@ -199,7 +194,7 @@ class DaysOnLevelTest {
         )
       )
 
-      assertThat(iepSummary.daysSinceReview()).isEqualTo(0)
+      assertThat(iepSummary.daysSinceReview).isEqualTo(0)
       assertThat(iepSummary.daysOnLevel()).isEqualTo(0)
     }
 
@@ -211,7 +206,6 @@ class DaysOnLevelTest {
 
       val iepSummary = IepSummary(
         bookingId = 1L,
-        daysSinceReview = 30,
         iepDate = latestIepTime.toLocalDate(),
         iepLevel = "Enhanced",
         iepTime = latestIepTime,
@@ -249,7 +243,7 @@ class DaysOnLevelTest {
         )
       )
 
-      assertThat(iepSummary.daysSinceReview()).isEqualTo(30)
+      assertThat(iepSummary.daysSinceReview).isEqualTo(30)
       assertThat(iepSummary.daysOnLevel()).isEqualTo(90)
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IepSummaryDateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IepSummaryDateTest.kt
@@ -7,7 +7,7 @@ import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepDetail
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepSummary
 import java.time.LocalDateTime
 
-class DaysOnLevelTest {
+class IepSummaryDateTest {
 
   @Nested
   inner class GetDaysOnLevel {
@@ -245,6 +245,44 @@ class DaysOnLevelTest {
 
       assertThat(iepSummary.daysSinceReview).isEqualTo(30)
       assertThat(iepSummary.daysOnLevel()).isEqualTo(90)
+    }
+  }
+
+  @Nested
+  inner class `Calc next review date for someone` {
+    @Test
+    fun `not on basic, nor newly in prison who has not been transferred since the last review`() {
+      val iepTime = LocalDateTime.now().minusDays(60)
+      val iepSummary = IepSummary(
+        bookingId = 1L,
+        iepDate = iepTime.toLocalDate(),
+        iepLevel = "Standard",
+        iepTime = iepTime,
+        iepDetails = listOf(
+          IepDetail(
+            bookingId = 1L,
+            agencyId = "MDI",
+            iepLevel = "Standard",
+            iepCode = "STD",
+            iepDate = iepTime.toLocalDate(),
+            iepTime = iepTime,
+            userId = "TEST_USER",
+            auditModuleName = "PRISON_API",
+          ),
+          IepDetail(
+            bookingId = 1L,
+            agencyId = "MDI",
+            iepLevel = "Standard",
+            iepCode = "STD",
+            iepDate = iepTime.minusDays(100).toLocalDate(),
+            iepTime = iepTime.minusDays(100),
+            userId = "TEST_USER",
+            auditModuleName = "PRISON_API",
+          ),
+        )
+      )
+
+      assertThat(iepSummary.nextReviewDate).isEqualTo(iepTime.toLocalDate().plusYears(1))
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
@@ -549,7 +549,6 @@ class PrisonerIepLevelReviewServiceTest {
   private val iepTime: LocalDateTime = LocalDateTime.now().minusDays(10)
   private fun iepSummary(iepLevel: String = "Enhanced", iepDetails: List<IepDetail> = emptyList()) = IepSummary(
     bookingId = 1L,
-    daysSinceReview = 60,
     iepDate = iepTime.toLocalDate(),
     iepLevel = iepLevel,
     iepTime = iepTime,


### PR DESCRIPTION
• Adds new derived field to `IepSummary` with a very simple calculation for next review date. `lastReviewDate + 1 year` applies to people not on basic, not newly in prison, not recalled and not transferred since last review.
• Fixes some minor test issues
• Changes how `daysSinceReview` is calculated to prevent errors and confusion, see explanation in 273f44ae3c934a62e8a5b69c5758bd75cf608c11