### PR TITLE
INC-824: Fix handling of 'TRANSFERRED' domain event when 2+ current=true

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonerIepLevelRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonerIepLevelRepository.kt
@@ -9,7 +9,7 @@ import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
 interface PrisonerIepLevelRepository : CoroutineCrudRepository<PrisonerIepLevel, Long> {
   fun findAllByPrisonerNumberOrderByReviewTimeDesc(prisonerNumber: String): Flow<PrisonerIepLevel>
   fun findAllByBookingIdOrderByReviewTimeDesc(bookingId: Long): Flow<PrisonerIepLevel>
-  fun findAllByBookingIdInAndCurrentIsTrue(bookingIds: List<Long>): Flow<PrisonerIepLevel>
-  suspend fun findOneByBookingIdAndCurrentIsTrue(bookingId: Long): PrisonerIepLevel?
+  fun findAllByBookingIdInAndCurrentIsTrueOrderByReviewTimeDesc(bookingIds: List<Long>): Flow<PrisonerIepLevel>
+  suspend fun findFirstByBookingIdAndCurrentIsTrueOrderByReviewTimeDesc(bookingId: Long): PrisonerIepLevel?
   suspend fun findFirstByBookingIdOrderByReviewTimeDesc(bookingId: Long): PrisonerIepLevel?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -143,7 +143,7 @@ class PrisonerIepLevelReviewService(
           CurrentIepLevel(iepLevel = it.iepLevel, bookingId = it.bookingId)
         }
     } else {
-      prisonerIepLevelRepository.findAllByBookingIdInAndCurrentIsTrue(bookingIds)
+      prisonerIepLevelRepository.findAllByBookingIdInAndCurrentIsTrueOrderByReviewTimeDesc(bookingIds)
         .map {
           CurrentIepLevel(iepLevel = iepLevelRepository.findById(it.iepCode)?.iepDescription ?: "Unmapped", bookingId = it.bookingId)
         }
@@ -266,7 +266,7 @@ class PrisonerIepLevelReviewService(
     reviewTime: LocalDateTime,
     reviewerUserName: String,
   ): PrisonerIepLevel {
-    prisonerIepLevelRepository.findOneByBookingIdAndCurrentIsTrue(prisonerInfo.bookingId)
+    prisonerIepLevelRepository.findFirstByBookingIdAndCurrentIsTrueOrderByReviewTimeDesc(prisonerInfo.bookingId)
       ?.let {
         prisonerIepLevelRepository.save(it.copy(current = false))
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonerIepLevelRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonerIepLevelRepositoryTest.kt
@@ -52,7 +52,7 @@ class PrisonerIepLevelRepositoryTest : TestBase() {
     )
 
     coroutineScope {
-      val prisonerLevelCurrent = async { repository.findOneByBookingIdAndCurrentIsTrue(bookingId) }
+      val prisonerLevelCurrent = async { repository.findFirstByBookingIdAndCurrentIsTrueOrderByReviewTimeDesc(bookingId) }
       val prisonerLevelFirst = async { repository.findFirstByBookingIdOrderByReviewTimeDesc(bookingId) }
       val prisonerAllLevels = async { repository.findAllByBookingIdOrderByReviewTimeDesc(bookingId) }
 


### PR DESCRIPTION
The `prisoner_iep_level` DB table has `current` boolean column (`current` is something of a legacy concept coming from NOMIS. In theory the record with latest `review_time` should be the "current")

More than one record can currently have that set to `true` which can cause a problem for the following method/generated query that expect only one result:

```
findOneByBookingIdAndCurrentIsTrue()
```

I've changed this method to `findFirstByBookingIdAndCurrentIsTrueOrderByReviewTimeDesc()`:
- so it sorts by `review_time` DESC (as that's the natural order)
- it returns the first record with `current=true`

This should avoid that exception to be raised on transfer.

I've also added ordering to the other repository method:
- renamed `findAllByBookingIdInAndCurrentIsTrue()`
- to `findAllByBookingIdInAndCurrentIsTrueOrderByReviewTimeDesc()`