### PR TITLE
INC-827: Improve `daysOnLevel` calculation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IepSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IepSummary.kt
@@ -42,22 +42,6 @@ data class IepSummary(
   @get:Schema(description = "Date of next review", example = "2022-12-31", required = true)
   @get:JsonProperty
   val nextReviewDate: LocalDate = iepDate.plusYears(1)
-
-  fun daysOnLevel(): Int {
-    val today = LocalDate.now().atStartOfDay()
-    var daysOnLevel = 0
-
-    run iepCheck@{
-      iepDetails.forEach {
-        if (it.iepLevel != iepLevel) {
-          return@iepCheck
-        }
-        daysOnLevel = Duration.between(it.iepDate.atStartOfDay(), today).toDays().toInt()
-      }
-    }
-
-    return daysOnLevel
-  }
 }
 
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveSummaryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveSummaryService.kt
@@ -89,7 +89,7 @@ class IncentiveSummaryService(
       levels[prisonerMap.key] ?: invalidLevel()
     }
 
-  fun getPrisonersByLevel(
+  private fun getPrisonersByLevel(
     prisoners: List<PrisonerAtLocation>,
     prisonerLevels: Map<Long, IepResult>
   ): Map<String, List<PrisonerAtLocation>> =
@@ -97,7 +97,7 @@ class IncentiveSummaryService(
       prisonerLevels[it.bookingId]?.iepLevel ?: missingLevel().iepLevel
     }
 
-  fun addMissingLevels(
+  private fun addMissingLevels(
     data: List<IncentiveLevelSummary>,
     levelMap: Map<String, IepLevel>
   ): List<IncentiveLevelSummary> {
@@ -114,11 +114,11 @@ class IncentiveSummaryService(
     return incentiveLevelSummaries.sortedWith(compareBy { v -> additionalLevels[v.level]?.sequence })
   }
 
-  suspend fun getProvenAdjudications(bookingIds: List<Long>): Map<Long, ProvenAdjudication> =
+  private suspend fun getProvenAdjudications(bookingIds: List<Long>): Map<Long, ProvenAdjudication> =
     prisonApiService.retrieveProvenAdjudications(bookingIds)
       .toList().associateBy(ProvenAdjudication::bookingId)
 
-  suspend fun getIEPDetails(bookingIds: List<Long>): Map<Long, IepResult> =
+  private suspend fun getIEPDetails(bookingIds: List<Long>): Map<Long, IepResult> =
     prisonApiService.getIEPSummaryPerPrisoner(bookingIds)
       .map {
 
@@ -130,7 +130,7 @@ class IncentiveSummaryService(
         )
       }.toList().associateBy(IepResult::bookingId)
 
-  suspend fun getCaseNoteUsage(type: String, subType: String, offenderNos: List<String>): Map<String, CaseNoteSummary> =
+  private suspend fun getCaseNoteUsage(type: String, subType: String, offenderNos: List<String>): Map<String, CaseNoteSummary> =
     prisonApiService.retrieveCaseNoteCounts(type, offenderNos)
       .toList()
       .groupBy(CaseNoteUsage::offenderNo)
@@ -145,7 +145,7 @@ class IncentiveSummaryService(
   private fun calcTypeCount(caseNoteUsage: List<CaseNoteUsage>): Int =
     caseNoteUsage.map { it.numCaseNotes }.fold(0) { acc, next -> acc + next }
 
-  suspend fun getLocation(locationId: String): String =
+  private suspend fun getLocation(locationId: String): String =
     prisonApiService.getLocation(locationId).description
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IepSummaryDateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IepSummaryDateTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.incentivesapi.service
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepDetail
@@ -44,7 +45,7 @@ class IepSummaryDateTest {
       )
 
       assertThat(iepSummary.daysSinceReview).isEqualTo(60)
-      assertThat(iepSummary.daysOnLevel()).isEqualTo(60)
+      assertThat(daysOnLevel(iepSummary.iepDetails)).isEqualTo(60)
     }
 
     @Test
@@ -71,7 +72,7 @@ class IepSummaryDateTest {
       )
 
       assertThat(iepSummary.daysSinceReview).isEqualTo(3)
-      assertThat(iepSummary.daysOnLevel()).isEqualTo(3)
+      assertThat(daysOnLevel(iepSummary.iepDetails)).isEqualTo(3)
     }
 
     @Test
@@ -109,7 +110,7 @@ class IepSummaryDateTest {
       )
 
       assertThat(iepSummary.daysSinceReview).isEqualTo(0)
-      assertThat(iepSummary.daysOnLevel()).isEqualTo(0)
+      assertThat(daysOnLevel(iepSummary.iepDetails)).isEqualTo(0)
     }
 
     @Test
@@ -158,7 +159,7 @@ class IepSummaryDateTest {
       )
 
       assertThat(iepSummary.daysSinceReview).isEqualTo(1)
-      assertThat(iepSummary.daysOnLevel()).isEqualTo(10)
+      assertThat(daysOnLevel(iepSummary.iepDetails)).isEqualTo(10)
     }
 
     @Test
@@ -195,7 +196,7 @@ class IepSummaryDateTest {
       )
 
       assertThat(iepSummary.daysSinceReview).isEqualTo(0)
-      assertThat(iepSummary.daysOnLevel()).isEqualTo(0)
+      assertThat(daysOnLevel(iepSummary.iepDetails)).isEqualTo(0)
     }
 
     @Test
@@ -244,7 +245,24 @@ class IepSummaryDateTest {
       )
 
       assertThat(iepSummary.daysSinceReview).isEqualTo(30)
-      assertThat(iepSummary.daysOnLevel()).isEqualTo(90)
+      assertThat(daysOnLevel(iepSummary.iepDetails)).isEqualTo(90)
+    }
+
+    @Test
+    fun `days on level cannot be calculated when iepDetail history is missing`() {
+      val iepTime = LocalDateTime.now().minusDays(3)
+      val iepSummary = IepSummary(
+        bookingId = 1L,
+        iepDate = iepTime.toLocalDate(),
+        iepLevel = "Basic",
+        iepTime = iepTime,
+        iepDetails = emptyList(),
+      )
+
+      assertThat(iepSummary.daysSinceReview).isEqualTo(3)
+      assertThatThrownBy { daysOnLevel(iepSummary.iepDetails) }
+        .isInstanceOf(UnsupportedOperationException::class.java)
+        .hasMessageContaining("Empty collection")
     }
   }
 


### PR DESCRIPTION
Previously, it silently returned 0 when history was unavailable (i.e. `IepSummary` was loaded "without details") instead of indicating that there was a problem. It was only used in one place (on an intermediate object) and was not serialised as part of the `IepSummary` schema.

Throwing an exception seems prudent to indicate that there is an _implementation_ problem (wrong details passed in). The calculation has also been moved closer to where it's used. It's less error prone than being a method that looked reusable.