### PR TITLE
INC-760: Feature flag to either publish domain event or call Prison API on new IEP review

### DIFF
--- a/helm_deploy/hmpps-incentives-api/values.yaml
+++ b/helm_deploy/hmpps-incentives-api/values.yaml
@@ -33,6 +33,7 @@ generic-service:
     SPRING_PROFILES_ACTIVE: "logstash"
     APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY)"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
+    FEATURE_REVIEWADDEDSYNCMECHANISM: "PRISON_API"
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -12,6 +12,7 @@ generic-service:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     API_BASE_URL_OAUTH: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
     API_BASE_URL_PRISON: https://api-dev.prison.service.justice.gov.uk
+    FEATURE_REVIEWADDEDSYNCMECHANISM: "DOMAIN_EVENT"
 
 # CloudPlatform AlertManager receiver to route Prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -10,6 +10,7 @@ generic-service:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     API_BASE_URL_OAUTH: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
     API_BASE_URL_PRISON: https://api-preprod.prison.service.justice.gov.uk
+    FEATURE_REVIEWADDEDSYNCMECHANISM: "PRISON_API"
 
 # CloudPlatform AlertManager receiver to route Prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -9,6 +9,7 @@ generic-service:
   env:
     API_BASE_URL_OAUTH: https://sign-in.hmpps.service.justice.gov.uk/auth
     API_BASE_URL_PRISON: https://api.prison.service.justice.gov.uk
+    FEATURE_REVIEWADDEDSYNCMECHANISM: "PRISON_API"
 
 # CloudPlatform AlertManager receiver to route Prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/FeatureFlagsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/FeatureFlagsService.kt
@@ -10,7 +10,7 @@ enum class ReviewAddedSyncMechanism {
 
 @Service
 class FeatureFlagsService(
-  @Value("\${feature.reviewAddedSyncMechanism}")
+  @Value("\${feature.review-added-sync-mechanism}")
   val reviewAddedSyncMechanism: String,
 ) {
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/FeatureFlagsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/FeatureFlagsService.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.incentivesapi.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+
+enum class ReviewAddedSyncMechanism {
+  DOMAIN_EVENT,
+  PRISON_API,
+}
+
+@Service
+class FeatureFlagsService(
+  @Value("\${feature.reviewAddedSyncMechanism}")
+  val reviewAddedSyncMechanism: String,
+) {
+
+  fun reviewAddedSyncMechanism(): ReviewAddedSyncMechanism {
+    return ReviewAddedSyncMechanism.valueOf(reviewAddedSyncMechanism)
+  }
+
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/FeatureFlagsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/FeatureFlagsService.kt
@@ -17,5 +17,4 @@ class FeatureFlagsService(
   fun reviewAddedSyncMechanism(): ReviewAddedSyncMechanism {
     return ReviewAddedSyncMechanism.valueOf(reviewAddedSyncMechanism)
   }
-
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResource.kt
@@ -405,5 +405,4 @@ class IepLevelResource(
     )
     @RequestBody @Valid syncPatchRequest: SyncPatchRequest,
   ): IepDetail = prisonerIepLevelReviewService.handleSyncPatchIepReviewRequest(bookingId, id, syncPatchRequest)
-
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResource.kt
@@ -26,10 +26,8 @@ import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepSummary
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.SyncPatchRequest
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.SyncPostRequest
 import uk.gov.justice.digital.hmpps.incentivesapi.service.AuditService
-import uk.gov.justice.digital.hmpps.incentivesapi.service.AuditType
 import uk.gov.justice.digital.hmpps.incentivesapi.service.IepLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.service.IepLevelService
-import uk.gov.justice.digital.hmpps.incentivesapi.service.IncentivesDomainEventType
 import uk.gov.justice.digital.hmpps.incentivesapi.service.PrisonerIepLevelReviewService
 import uk.gov.justice.digital.hmpps.incentivesapi.service.SnsService
 import javax.validation.Valid
@@ -247,11 +245,7 @@ class IepLevelResource(
       implementation = IepReview::class,
     )
     @RequestBody @Valid iepReview: IepReview,
-  ): IepDetail {
-    val iepDetail = prisonerIepLevelReviewService.addIepReview(bookingId, iepReview)
-    sendEventAndAudit(iepDetail, IncentivesDomainEventType.IEP_REVIEW_INSERTED, AuditType.IEP_REVIEW_ADDED)
-    return iepDetail
-  }
+  ): IepDetail = prisonerIepLevelReviewService.addIepReview(bookingId, iepReview)
 
   @PostMapping("/reviews/prisoner/{prisonerNumber}")
   @PreAuthorize("hasRole('MAINTAIN_IEP') and hasAuthority('SCOPE_write')")
@@ -290,11 +284,7 @@ class IepLevelResource(
       implementation = IepReview::class,
     )
     @RequestBody @Valid iepReview: IepReview,
-  ): IepDetail {
-    val iepDetail = prisonerIepLevelReviewService.addIepReview(prisonerNumber, iepReview)
-    sendEventAndAudit(iepDetail, IncentivesDomainEventType.IEP_REVIEW_INSERTED, AuditType.IEP_REVIEW_ADDED)
-    return iepDetail
-  }
+  ): IepDetail = prisonerIepLevelReviewService.addIepReview(prisonerNumber, iepReview)
 
   @PostMapping("/migration/booking/{bookingId}")
   @PreAuthorize("hasRole('MAINTAIN_IEP') and hasAuthority('SCOPE_write')")
@@ -416,13 +406,4 @@ class IepLevelResource(
     @RequestBody @Valid syncPatchRequest: SyncPatchRequest,
   ): IepDetail = prisonerIepLevelReviewService.handleSyncPatchIepReviewRequest(bookingId, id, syncPatchRequest)
 
-  private suspend fun sendEventAndAudit(iepDetail: IepDetail, eventType: IncentivesDomainEventType, auditType: AuditType) {
-    snsService.sendIepReviewEvent(iepDetail.id!!, iepDetail.prisonerNumber ?: "N/A", iepDetail.iepTime, eventType)
-
-    auditService.sendMessage(
-      auditType,
-      iepDetail.id.toString(),
-      iepDetail
-    )
-  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -12,10 +12,10 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import uk.gov.justice.digital.hmpps.incentivesapi.config.ReviewAddedSyncMechanism
 import uk.gov.justice.digital.hmpps.incentivesapi.config.AuthenticationFacade
 import uk.gov.justice.digital.hmpps.incentivesapi.config.FeatureFlagsService
 import uk.gov.justice.digital.hmpps.incentivesapi.config.NoDataFoundException
+import uk.gov.justice.digital.hmpps.incentivesapi.config.ReviewAddedSyncMechanism
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.CurrentIepLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepDetail
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepReview

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -70,13 +70,13 @@ class PrisonerIepLevelReviewService(
   @Transactional
   suspend fun addIepReview(prisonerNumber: String, iepReview: IepReview): IepDetail {
     val prisonerInfo = prisonApiService.getPrisonerInfo(prisonerNumber)
-    return addIepLevel(prisonerInfo, iepReview)
+    return addIepReviewForPrisonerAtLocation(prisonerInfo, iepReview)
   }
 
   @Transactional
   suspend fun addIepReview(bookingId: Long, iepReview: IepReview): IepDetail {
     val prisonerInfo = prisonApiService.getPrisonerInfo(bookingId)
-    return addIepLevel(prisonerInfo, iepReview)
+    return addIepReviewForPrisonerAtLocation(prisonerInfo, iepReview)
   }
 
   @Transactional
@@ -238,7 +238,7 @@ class PrisonerIepLevelReviewService(
     )
   }
 
-  private suspend fun addIepLevel(
+  private suspend fun addIepReviewForPrisonerAtLocation(
     prisonerInfo: PrisonerAtLocation,
     iepReview: IepReview
   ): IepDetail {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -107,7 +107,7 @@ class PrisonerIepLevelReviewService(
   }
 
   suspend fun handleSyncPostIepReviewRequest(bookingId: Long, syncPostRequest: SyncPostRequest): IepDetail {
-    val iepDetail = persistPrisonerIepLevel(bookingId, syncPostRequest, true)
+    val iepDetail = persistSyncPostRequest(bookingId, syncPostRequest, true)
 
     publishDomainEvent(iepDetail, IncentivesDomainEventType.IEP_REVIEW_INSERTED)
     publishAuditEvent(iepDetail, AuditType.IEP_REVIEW_ADDED)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -264,6 +264,8 @@ class PrisonerIepLevelReviewService(
       )
     )
 
+    sendEventAndAudit(newIepReview, IncentivesDomainEventType.IEP_REVIEW_INSERTED, AuditType.IEP_REVIEW_ADDED)
+
     return newIepReview
   }
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,3 +1,6 @@
+feature:
+  reviewAddedSyncMechanism: DOMAIN_EVENT
+
 server:
   shutdown: immediate
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,5 +1,5 @@
 feature:
-  reviewAddedSyncMechanism: DOMAIN_EVENT
+  review-added-sync-mechanism: DOMAIN_EVENT
 
 server:
   shutdown: immediate

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ feature:
   # - 'DOMAIN_EVENT', a domain event is published (long term, this will be the preferred/only method)
   #
   # NOTE: Environment variable is `FEATURE_REVIEWADDEDSYNCMECHANISM`
-  reviewAddedSyncMechanism: PRISON_API
+  review-added-sync-mechanism: PRISON_API
 
 spring:
   application:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,15 @@ info.app:
   name: Hmpps Incentives API
   version: 1.0
 
+feature:
+  # Determine how the creation of an IEP review is propagated to other systems.
+  # Can be:
+  # - 'PRISON_API', an HTTP request to Prison API's `POST /api/bookings/{bookingId}/iepLevels` is made
+  # - 'DOMAIN_EVENT', a domain event is published (long term, this will be the preferred/only method)
+  #
+  # NOTE: Environment variable is `FEATURE_REVIEWADDEDSYNCMECHANISM`
+  reviewAddedSyncMechanism: PRISON_API
+
 spring:
   application:
     name: hmpps-incentives-api

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
@@ -16,10 +16,10 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
-import uk.gov.justice.digital.hmpps.incentivesapi.config.ReviewAddedSyncMechanism
 import uk.gov.justice.digital.hmpps.incentivesapi.config.AuthenticationFacade
 import uk.gov.justice.digital.hmpps.incentivesapi.config.FeatureFlagsService
 import uk.gov.justice.digital.hmpps.incentivesapi.config.NoDataFoundException
+import uk.gov.justice.digital.hmpps.incentivesapi.config.ReviewAddedSyncMechanism
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepDetail
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepReview
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepSummary

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
@@ -125,7 +125,7 @@ class PrisonerIepLevelReviewServiceTest {
           checkRequestToPrisonApiWasMade()
 
           // Domain event not published
-          verify(snsService, times(0)).sendIepReviewEvent(any(), any(), any())
+          verify(snsService, times(0)).sendIepReviewEvent(any(), any(), any(), any())
         }
 
         // An audit event is published
@@ -159,7 +159,7 @@ class PrisonerIepLevelReviewServiceTest {
           checkRequestToPrisonApiWasMade()
 
           // Domain event not published
-          verify(snsService, times(0)).sendIepReviewEvent(any(), any(), any())
+          verify(snsService, times(0)).sendIepReviewEvent(any(), any(), any(), any())
         }
 
         // An audit event is published
@@ -174,6 +174,7 @@ class PrisonerIepLevelReviewServiceTest {
     private fun checkDomainEventWasPublished() {
       verify(snsService, times(1)).sendIepReviewEvent(
         42,
+        prisonerNumber,
         reviewTime,
         IncentivesDomainEventType.IEP_REVIEW_INSERTED,
       )


### PR DESCRIPTION
### Current state
When a new IEP review is created two things happen to update NOMIS/notify other services that may be interested in this:
1. a domain event is published
2. an HTTP request to Prison API's `POST /api/bookings/{bookingId}/iepLevels` is made

A sync service is being developed/built and it's currently in `dev` environment.
This service is updating NOMIS when the domain event above is published.

This means that in `dev` at the moment a duplicated review is recorded in NOMIS (a record is created by our POST request to Prison API and another is created by the sync service).

### Main change
A new feature flag (`feature.review-added-sync-mechanism`, env variable `FEATURE_REVIEWADDEDSYNCMECHANISM`) can be set to determine how a new IEP review is propagated to NOMIS/other services:
- when set to `DOMAIN_EVENT` a domain event will be published
- when set to `PRISON_API` the HTTP request to Prison API will be made

In `dev` environment a domain event will be published for the sync service (and any other services interested in it) while in `preprod`/`prod` environment where the sync service is not deployed to yet an HTTP request to Prison API will be made.


**NOTE**: Either one or the other will be made, as per requirements.

### Other refactorings/changes
- simplified resource class by moving most of the logic into the service class
- separate publishing of domain events from publishing of audit events (the former will be only published depending on the new feature flag but the latter will always be published)
- renamed service methods to make them more explicit and less similar
- added missing tests for `addIepReview()` functionality