### PR TITLE
On admission, throw exception when prison doesn't have default IEP Pr…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -220,7 +220,7 @@ class PrisonerIepLevelReviewService(
   private suspend fun getIepLevelForReviewType(prisonerInfo: PrisonerAtLocation, reviewType: ReviewType): String {
     val iepLevelsForPrison = iepLevelService.getIepLevelsForPrison(prisonerInfo.agencyId, useClientCredentials = true)
     val iepLevel = when (reviewType) {
-      ReviewType.INITIAL -> iepLevelsForPrison.first(IepLevel::default)
+      ReviewType.INITIAL -> iepLevelsForPrison.find(IepLevel::default) ?: throw Exception("No default IEP level found for Prison '${prisonerInfo.agencyId}'")
 
       ReviewType.TRANSFER -> {
         val iepHistory = getPrisonerIepLevelHistory(prisonerInfo.bookingId, useNomisData = true, withDetails = true, useClientCredentials = true).iepDetails


### PR DESCRIPTION
…isonerIepLevelReviewService

On admission the IEP review level is set to the Prison's default. Assumption is that all prison will always have one default IEP level.

However some prisons (in `dev`) don't seem to have a default.

Replacing `first()` (returns T or throw exception) with `find()` which tries to find the first or return `null`, and throwing a better exception with useful details about why the admission domain event couldn't be processed.