### PR TITLE
INC-872: sync DELETE endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResource.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.Flow
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -401,4 +402,39 @@ class IepLevelResource(
     )
     @RequestBody @Valid syncPatchRequest: SyncPatchRequest,
   ): IepDetail = prisonerIepLevelReviewService.handleSyncPatchIepReviewRequest(bookingId, id, syncPatchRequest)
+
+  @DeleteMapping("/sync/booking/{bookingId}/id/{id}")
+  @PreAuthorize("hasRole('MAINTAIN_IEP') and hasAuthority('SCOPE_write')")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @Operation(
+    summary = "Deletes an existing IEP review for this specific prisoner by booking Id",
+    description = "Booking ID is an internal ID for a prisoner in NOMIS, ID is the ID of the IEP review. Requires MAINTAIN_IEP role and write scope",
+    responses = [
+      ApiResponse(
+        responseCode = "204",
+        description = "IEP Review deleted"
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Incorrect data specified to delete the IEP review",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))]
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))]
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Incorrect permissions to use this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))]
+      )
+    ]
+  )
+  suspend fun syncDeleteIepReview(
+    @Schema(description = "Booking Id", required = true, example = "1234567", type = "integer", format = "int64", pattern = "^[0-9]{1,20}$")
+    @PathVariable bookingId: Long,
+    @Schema(description = "ID", required = true, example = "12345", type = "integer", format = "int64", pattern = "^[0-9]{1,20}$")
+    @PathVariable id: Long,
+  ): Unit = prisonerIepLevelReviewService.handleSyncDeleteIepReviewRequest(bookingId, id)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/AuditService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/AuditService.kt
@@ -67,5 +67,6 @@ data class AuditEvent(
 enum class AuditType {
   IEP_REVIEW_ADDED,
   IEP_REVIEW_UPDATED,
+  IEP_REVIEW_DELETED,
   PRISONER_NUMBER_MERGE,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -170,6 +170,14 @@ class PrisonerIepLevelReviewService(
 
     prisonerIepLevelRepository.delete(prisonerIepLevel)
 
+    // If the deleted record had `current=true`, latest IEP review becomes current
+    prisonerIepLevel.current ?.let {
+      // The deleted record was current, set new current to the latest IEP review
+      prisonerIepLevelRepository.findFirstByBookingIdOrderByReviewTimeDesc(bookingId)?.run {
+        prisonerIepLevelRepository.save(this.copy(current = true))
+      }
+    }
+
     val iepDetail = prisonerIepLevel.translate()
     publishDomainEvent(iepDetail, IncentivesDomainEventType.IEP_REVIEW_DELETED)
     publishAuditEvent(iepDetail, AuditType.IEP_REVIEW_DELETED)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/SnsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/SnsService.kt
@@ -77,6 +77,7 @@ data class HMPPSDomainEvent(
 enum class IncentivesDomainEventType(val value: String) {
   IEP_REVIEW_INSERTED("incentives.iep-review.inserted"),
   IEP_REVIEW_UPDATED("incentives.iep-review.updated"),
+  IEP_REVIEW_DELETED("incentives.iep-review.deleted"),
 }
 
 fun Instant.toOffsetDateFormat(): String =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
@@ -401,6 +401,7 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
 
     private val syncCreateEndpoint = "/iep/sync/booking/$bookingId"
     private var syncPatchEndpoint: String? = null
+    private var syncDeleteEndpoint: String? = null
 
     @BeforeEach
     fun setUp(): Unit = runBlocking {
@@ -409,6 +410,7 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
       )
 
       syncPatchEndpoint = "/iep/sync/booking/$bookingId/id/${existingPrisonerIepLevel!!.id}"
+      syncDeleteEndpoint = syncPatchEndpoint
     }
 
     @Test
@@ -432,6 +434,15 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
     }
 
     @Test
+    fun `DELETE to sync endpoint without write scope responds 403 Unauthorized`() {
+      // When the client doesn't have the `write` scope the API responds 403 Forbidden
+      webTestClient.delete().uri(syncPatchEndpoint)
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_IEP"), scopes = listOf("read")))
+        .exchange()
+        .expectStatus().isForbidden
+    }
+
+    @Test
     fun `POST to sync endpoint without 'ROLE_MAINTAIN_IEP' role responds 403 Unauthorized`() {
       // When the client doesn't have the `ROLE_MAINTAIN_IEP` role the API responds 403 Forbidden
       webTestClient.post().uri(syncCreateEndpoint)
@@ -447,6 +458,15 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
       webTestClient.patch().uri(syncPatchEndpoint)
         .headers(setAuthorisation(roles = listOf("ROLE_DUMMY"), scopes = listOf("read", "write")))
         .bodyValue(requestBody)
+        .exchange()
+        .expectStatus().isForbidden
+    }
+
+    @Test
+    fun `DELETE to sync endpoint without 'ROLE_MAINTAIN_IEP' role responds 403 Unauthorized`() {
+      // When the client doesn't have the `ROLE_MAINTAIN_IEP` role the API responds 403 Forbidden
+      webTestClient.delete().uri(syncDeleteEndpoint)
+        .headers(setAuthorisation(roles = listOf("ROLE_DUMMY"), scopes = listOf("read", "write")))
         .exchange()
         .expectStatus().isForbidden
     }
@@ -477,6 +497,17 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
     }
 
     @Test
+    fun `DELETE to sync endpoint when record with given id doesn't exist responds 404 Not Found`() {
+      val syncDeleteEndpoint = "/iep/sync/booking/42000/id/42000"
+
+      // The API responds 404 Not Found
+      webTestClient.delete().uri(syncDeleteEndpoint)
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_IEP"), scopes = listOf("read", "write")))
+        .exchange()
+        .expectStatus().isNotFound
+    }
+
+    @Test
     fun `PATCH to sync endpoint when bookingId doesn't match the one in the IEP review record responds 404 Not Found`() {
       val wrongBookingId = existingPrisonerIepLevel!!.bookingId + 42
       val syncPatchEndpoint = "/iep/sync/booking/$wrongBookingId/id/${existingPrisonerIepLevel!!.id}"
@@ -485,6 +516,18 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
       webTestClient.patch().uri(syncPatchEndpoint)
         .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_IEP"), scopes = listOf("read", "write")))
         .bodyValue(requestBody)
+        .exchange()
+        .expectStatus().isNotFound
+    }
+
+    @Test
+    fun `DELETE to sync endpoint when bookingId doesn't match the one in the IEP review record responds 404 Not Found`() {
+      val wrongBookingId = existingPrisonerIepLevel!!.bookingId + 42
+      val syncDeleteEndpoint = "/iep/sync/booking/$wrongBookingId/id/${existingPrisonerIepLevel!!.id}"
+
+      // The API responds 404 Not Found
+      webTestClient.delete().uri(syncDeleteEndpoint)
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_IEP"), scopes = listOf("read", "write")))
         .exchange()
         .expectStatus().isNotFound
     }
@@ -657,6 +700,31 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
         .exchange()
         .expectStatus().isOk
         .expectBody().json(expectedResponseBody)
+    }
+
+    @Test
+    fun `DELETE to sync endpoint when request valid deletes the IEP review`() {
+      // Given the bookingId is valid
+      prisonApiMockServer.stubGetPrisonerInfoByBooking(
+        bookingId = bookingId,
+        prisonerNumber = prisonerNumber,
+        locationId = 77778L,
+      )
+      prisonApiMockServer.stubGetLocationById(locationId = 77778L, locationDesc = "1-2-003")
+
+      // API responds 201 Created with the created IEP review record
+      webTestClient.delete().uri(syncDeleteEndpoint)
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_IEP"), scopes = listOf("read", "write")))
+        .exchange()
+        .expectStatus().isNoContent
+
+      val prisonerIepLevelId = existingPrisonerIepLevel!!.id
+
+      // IEP review is no longer available (cannot be retrieved later on)
+      webTestClient.get().uri("/iep/reviews/id/$prisonerIepLevelId")
+        .headers(setAuthorisation())
+        .exchange()
+        .expectStatus().isNotFound
     }
 
     private fun syncPostRequest(iepLevel: String = "STD") = SyncPostRequest(


### PR DESCRIPTION
`DELETE /iep/sync/booking/{bookingId}/id/{id}`

- delete an IEP review by id
- publishes a `IEP_REVIEW_DELETED` domain/audit events
- when the deleted IEP review had `current=true`, sets another one (latest) as current so that there is one current IEP review for that `bookingId`