### PR TITLE
INC-883: Improve request parameter validation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
   implementation("org.springframework.boot:spring-boot-starter-security")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+  implementation("org.springframework.boot:spring-boot-starter-validation")
 
   implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:1.1.12")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,6 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
   implementation("org.springframework.boot:spring-boot-starter-security")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
-  implementation("org.springframework.boot:spring-boot-starter-validation")
 
   implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:1.1.12")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/HmppsIncentivesApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/HmppsIncentivesApiExceptionHandler.kt
@@ -19,6 +19,7 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import org.springframework.web.server.ServerWebInputException
 import uk.gov.justice.digital.hmpps.incentivesapi.service.IncentiveReviewNotFoundException
 import uk.gov.justice.digital.hmpps.incentivesapi.service.NoPrisonersAtLocationException
+import uk.gov.justice.digital.hmpps.incentivesapi.util.ParameterValidationException
 import javax.validation.ValidationException
 
 @RestControllerAdvice
@@ -62,6 +63,20 @@ class HmppsIncentivesApiExceptionHandler {
         ErrorResponse(
           status = BAD_REQUEST,
           userMessage = "Validation failure: ${e.message}",
+          developerMessage = e.message
+        )
+      )
+  }
+
+  @ExceptionHandler(ParameterValidationException::class)
+  fun handleValidationException(e: ParameterValidationException): ResponseEntity<ErrorResponse> {
+    log.info("Invalid parameters: {}", e.errors)
+    return ResponseEntity
+      .status(BAD_REQUEST)
+      .body(
+        ErrorResponse(
+          status = BAD_REQUEST,
+          userMessage = e.message,
           developerMessage = e.message
         )
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IepSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IepSummary.kt
@@ -88,17 +88,19 @@ data class IepReview(
   @Schema(
     description = "IEP Level",
     required = true,
-    allowableValues = ["STD", "BAS", "ENH", "EN2", "ENT"],
+    allowableValues = ["BAS", "STD", "ENH", "EN2", "EN3"],
     example = "STD",
+    minLength = 2, maxLength = 6,
+    nullable = false,
   )
-  @field:Size(
-    max = 6,
-    min = 2,
-    message = "IEP Level must be between 2 and 6"
-  ) @field:NotBlank(message = "IEP Level is required") val iepLevel: String,
-  @Schema(description = "Comment about review", required = true, example = "A review took place")
+  @field:Size(max = 6, min = 2, message = "IEP Level must be between 2 and 6")
+  @field:NotBlank(message = "IEP Level is required")
+  val iepLevel: String,
+
+  @Schema(description = "Comment about review", required = true, example = "A review took place", minLength = 1)
   @field:NotBlank(message = "Comment on IEP Level review is required")
   val comment: String,
+
   @Schema(description = "Review Type", example = "REVIEW", required = false, defaultValue = "REVIEW")
   val reviewType: ReviewType? = ReviewType.REVIEW,
 )
@@ -109,16 +111,20 @@ data class SyncPostRequest(
   @Schema(description = "Date and time when the review took place", required = true, example = "2021-12-31T12:34:56.789012")
   val iepTime: LocalDateTime,
 
-  @Schema(description = "Prison ID", required = true, example = "MDI")
+  @Schema(description = "Prison ID", required = true, example = "MDI", minLength = 2, maxLength = 5)
   @field:NotBlank(message = "Prison ID is required")
   val prisonId: String,
 
-  @Schema(description = "IEP Level", example = "STD", required = true, allowableValues = ["STD", "BAS", "ENH", "EN2", "EN3", "ENT"])
-  @field:Size(
-    max = 6,
-    min = 2,
-    message = "IEP Level must be between 2 and 6"
-  ) @field:NotBlank(message = "IEP Level is required") val iepLevel: String,
+  @Schema(
+    description = "IEP Level",
+    required = true,
+    allowableValues = ["BAS", "STD", "ENH", "EN2", "EN3"],
+    example = "STD",
+    minLength = 2, maxLength = 6,
+    nullable = false,
+  )
+  @field:Size(max = 6, min = 2, message = "IEP Level must be between 2 and 6")
+  @field:NotBlank(message = "IEP Level is required") val iepLevel: String,
 
   @Schema(description = "Comment about review", required = false, example = "A review took place")
   val comment: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IepSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IepSummary.kt
@@ -4,11 +4,10 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.ReviewType
+import uk.gov.justice.digital.hmpps.incentivesapi.util.ensure
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalDateTime
-import javax.validation.constraints.NotBlank
-import javax.validation.constraints.Size
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "IEP Review Summary for Prisoner")
@@ -93,17 +92,21 @@ data class IepReview(
     minLength = 2, maxLength = 6,
     nullable = false,
   )
-  @field:Size(max = 6, min = 2, message = "IEP Level must be between 2 and 6")
-  @field:NotBlank(message = "IEP Level is required")
   val iepLevel: String,
 
   @Schema(description = "Comment about review", required = true, example = "A review took place", minLength = 1)
-  @field:NotBlank(message = "Comment on IEP Level review is required")
   val comment: String,
 
   @Schema(description = "Review Type", example = "REVIEW", required = false, defaultValue = "REVIEW")
   val reviewType: ReviewType? = ReviewType.REVIEW,
-)
+) {
+  init {
+    ensure {
+      ("iepLevel" to iepLevel).hasLengthAtLeast(2).hasLengthAtMost(6)
+      ("comment" to comment).hasLengthAtLeast(1)
+    }
+  }
+}
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Request to synchronise an IEP Review from NOMIS")
@@ -112,7 +115,6 @@ data class SyncPostRequest(
   val iepTime: LocalDateTime,
 
   @Schema(description = "Prison ID", required = true, example = "MDI", minLength = 2, maxLength = 5)
-  @field:NotBlank(message = "Prison ID is required")
   val prisonId: String,
 
   @Schema(
@@ -123,8 +125,7 @@ data class SyncPostRequest(
     minLength = 2, maxLength = 6,
     nullable = false,
   )
-  @field:Size(max = 6, min = 2, message = "IEP Level must be between 2 and 6")
-  @field:NotBlank(message = "IEP Level is required") val iepLevel: String,
+  val iepLevel: String,
 
   @Schema(description = "Comment about review", required = false, example = "A review took place")
   val comment: String?,
@@ -137,7 +138,14 @@ data class SyncPostRequest(
 
   @Schema(description = "Flag to indicate this is the current review for the prisoner", example = "true", required = true)
   val current: Boolean,
-)
+) {
+  init {
+    ensure {
+      ("prisonId" to prisonId).hasLengthAtLeast(3).hasLengthAtMost(5)
+      ("iepLevel" to iepLevel).hasLengthAtLeast(2).hasLengthAtMost(6)
+    }
+  }
+}
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Patch request to synchronise an IEP Review from NOMIS")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResource.kt
@@ -66,7 +66,7 @@ class IepLevelResource(
     ]
   )
   suspend fun getPrisonIepLevels(
-    @Schema(description = "Prison Id", example = "MDI", required = true, type = "string", pattern = "^[A-Z]{3}\$")
+    @Schema(description = "Prison Id", example = "MDI", required = true, minLength = 3, maxLength = 5)
     @PathVariable @Size(max = 3, min = 3, message = "Prison ID must be 3 characters") prisonId: String
   ): List<IepLevel> =
     iepLevelService.getIepLevelsForPrison(prisonId)
@@ -194,7 +194,7 @@ class IepLevelResource(
     ]
   )
   suspend fun getPrisonerIepLevelHistory(
-    @Schema(description = "Prisoner Number", example = "A1234AB", required = true, type = "string", pattern = "^[A-Z0-9]{7}$")
+    @Schema(description = "Prisoner Number", example = "A1234AB", required = true, pattern = "^[A-Z0-9]{7}$")
     @PathVariable prisonerNumber: String
   ): IepSummary =
     prisonerIepLevelReviewService.getPrisonerIepLevelHistory(prisonerNumber)
@@ -267,7 +267,7 @@ class IepLevelResource(
     ]
   )
   suspend fun addIepReview(
-    @Schema(description = "Prisoner Number", example = "A1234AB", required = true, type = "string", pattern = "^[A-Z0-9]{1,20}$")
+    @Schema(description = "Prisoner Number", example = "A1234AB", required = true, pattern = "^[A-Z0-9]{1,20}$")
     @PathVariable prisonerNumber: String,
     @Schema(
       description = "IEP Review",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResource.kt
@@ -29,9 +29,8 @@ import uk.gov.justice.digital.hmpps.incentivesapi.dto.SyncPostRequest
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.IepLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.service.IepLevelService
 import uk.gov.justice.digital.hmpps.incentivesapi.service.PrisonerIepLevelReviewService
+import uk.gov.justice.digital.hmpps.incentivesapi.util.ensure
 import javax.validation.Valid
-import javax.validation.constraints.NotEmpty
-import javax.validation.constraints.Size
 
 @RestController
 @RequestMapping("/iep", produces = [MediaType.APPLICATION_JSON_VALUE])
@@ -67,9 +66,13 @@ class IepLevelResource(
   )
   suspend fun getPrisonIepLevels(
     @Schema(description = "Prison Id", example = "MDI", required = true, minLength = 3, maxLength = 5)
-    @PathVariable @Size(max = 3, min = 3, message = "Prison ID must be 3 characters") prisonId: String
-  ): List<IepLevel> =
-    iepLevelService.getIepLevelsForPrison(prisonId)
+    @PathVariable prisonId: String
+  ): List<IepLevel> {
+    ensure {
+      ("prisonId" to prisonId).hasLengthAtLeast(3).hasLengthAtMost(5)
+    }
+    return iepLevelService.getIepLevelsForPrison(prisonId)
+  }
 
   @GetMapping("/reviews/booking/{bookingId}")
   @Operation(
@@ -163,9 +166,13 @@ class IepLevelResource(
   )
   suspend fun getCurrentIEPLevelForPrisoner(
     @ArraySchema(schema = Schema(description = "List of booking Ids", required = true, type = "array"), arraySchema = Schema(type = "integer", format = "int64", pattern = "^[0-9]{1,20}$", additionalProperties = Schema.AdditionalPropertiesValue.FALSE))
-    @RequestBody @Valid @NotEmpty bookingIds: List<Long>
-  ): Flow<CurrentIepLevel> =
-    prisonerIepLevelReviewService.getCurrentIEPLevelForPrisoners(bookingIds)
+    @RequestBody bookingIds: List<Long>
+  ): Flow<CurrentIepLevel> {
+    ensure {
+      ("bookingIds" to bookingIds).isNotEmpty()
+    }
+    return prisonerIepLevelReviewService.getCurrentIEPLevelForPrisoners(bookingIds)
+  }
 
   @GetMapping("/reviews/prisoner/{prisonerNumber}")
   @Operation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResource.kt
@@ -30,7 +30,6 @@ import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.IepLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.service.IepLevelService
 import uk.gov.justice.digital.hmpps.incentivesapi.service.PrisonerIepLevelReviewService
 import uk.gov.justice.digital.hmpps.incentivesapi.util.ensure
-import javax.validation.Valid
 
 @RestController
 @RequestMapping("/iep", produces = [MediaType.APPLICATION_JSON_VALUE])
@@ -242,7 +241,7 @@ class IepLevelResource(
       required = true,
       implementation = IepReview::class,
     )
-    @RequestBody @Valid iepReview: IepReview,
+    @RequestBody iepReview: IepReview,
   ): IepDetail = prisonerIepLevelReviewService.addIepReview(bookingId, iepReview)
 
   @PostMapping("/reviews/prisoner/{prisonerNumber}")
@@ -281,7 +280,7 @@ class IepLevelResource(
       required = true,
       implementation = IepReview::class,
     )
-    @RequestBody @Valid iepReview: IepReview,
+    @RequestBody iepReview: IepReview,
   ): IepDetail = prisonerIepLevelReviewService.addIepReview(prisonerNumber, iepReview)
 
   @PostMapping("/migration/booking/{bookingId}")
@@ -320,7 +319,7 @@ class IepLevelResource(
       required = true,
       implementation = SyncPostRequest::class,
     )
-    @RequestBody @Valid syncPostRequest: SyncPostRequest,
+    @RequestBody syncPostRequest: SyncPostRequest,
   ): IepDetail =
     prisonerIepLevelReviewService.persistSyncPostRequest(bookingId, syncPostRequest, false)
 
@@ -360,7 +359,7 @@ class IepLevelResource(
       required = true,
       implementation = SyncPostRequest::class,
     )
-    @RequestBody @Valid syncPostRequest: SyncPostRequest,
+    @RequestBody syncPostRequest: SyncPostRequest,
   ): IepDetail = prisonerIepLevelReviewService.handleSyncPostIepReviewRequest(bookingId, syncPostRequest)
 
   @PatchMapping("/sync/booking/{bookingId}/id/{id}")
@@ -401,7 +400,7 @@ class IepLevelResource(
       required = true,
       implementation = SyncPatchRequest::class,
     )
-    @RequestBody @Valid syncPatchRequest: SyncPatchRequest,
+    @RequestBody syncPatchRequest: SyncPatchRequest,
   ): IepDetail = prisonerIepLevelReviewService.handleSyncPatchIepReviewRequest(bookingId, id, syncPatchRequest)
 
   @DeleteMapping("/sync/booking/{bookingId}/id/{id}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResource.kt
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -14,13 +13,8 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.incentivesapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.incentivesapi.service.IncentiveReviewsService
-import javax.validation.Valid
-import javax.validation.constraints.Max
-import javax.validation.constraints.Min
-import javax.validation.constraints.Size
 
 @RestController
-@Validated
 @RequestMapping("/incentives-reviews", produces = [MediaType.APPLICATION_JSON_VALUE])
 @PreAuthorize("hasRole('ROLE_INCENTIVES')")
 class IncentiveReviewsResource(private val incentiveReviewsService: IncentiveReviewsService) {
@@ -50,22 +44,18 @@ class IncentiveReviewsResource(private val incentiveReviewsService: IncentiveRev
   suspend fun getReviews(
     @Schema(description = "Prison ID", required = true, example = "MDI", minLength = 3, maxLength = 5)
     @PathVariable
-    @Valid @Size(min = 3, max = 5, message = "Prison ID must be 3-5 characters")
     prisonId: String,
 
-    @Schema(description = "Cell location ID prefix", required = true, example = "MDI-1", minLength = 3)
+    @Schema(description = "Cell location ID prefix", required = true, example = "MDI-1", minLength = 5)
     @PathVariable
-    @Valid @Size(min = 3, message = "Cell location ID prefix must be specified and start with prison id")
     cellLocationPrefix: String,
 
     @Schema(description = "Page (starts at 1)", defaultValue = "1", minimum = "1", example = "2", type = "integer", required = false, format = "int32")
     @RequestParam(required = false, defaultValue = "1")
-    @Valid @Min(1)
     page: Int,
 
     @Schema(description = "Page size", defaultValue = "20", minimum = "1", maximum = "100", example = "20", type = "integer", required = false, format = "int32")
     @RequestParam(required = false, defaultValue = "20")
-    @Valid @Min(1) @Max(100)
     pageSize: Int,
   ) = incentiveReviewsService.reviews(prisonId, cellLocationPrefix, page, pageSize)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResource.kt
@@ -43,7 +43,7 @@ class IncentiveReviewsResource(private val incentiveReviewsService: IncentiveRev
     ]
   )
   suspend fun getReviews(
-    @Schema(description = "Prison ID", required = true, example = "MDI")
+    @Schema(description = "Prison ID", required = true, example = "MDI", minLength = 3, maxLength = 5)
     @Size(max = 5, min = 3, message = "Prison ID must be 3-5 characters")
     @PathVariable
     prisonId: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResource.kt
@@ -12,7 +12,9 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.incentivesapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.IncentiveReviewResponse
 import uk.gov.justice.digital.hmpps.incentivesapi.service.IncentiveReviewsService
+import uk.gov.justice.digital.hmpps.incentivesapi.util.ensure
 
 @RestController
 @RequestMapping("/incentives-reviews", produces = [MediaType.APPLICATION_JSON_VALUE])
@@ -57,5 +59,14 @@ class IncentiveReviewsResource(private val incentiveReviewsService: IncentiveRev
     @Schema(description = "Page size", defaultValue = "20", minimum = "1", maximum = "100", example = "20", type = "integer", required = false, format = "int32")
     @RequestParam(required = false, defaultValue = "20")
     pageSize: Int,
-  ) = incentiveReviewsService.reviews(prisonId, cellLocationPrefix, page, pageSize)
+  ): IncentiveReviewResponse {
+    ensure {
+      ("prisonId" to prisonId).hasLengthAtLeast(3).hasLengthAtMost(5)
+      ("cellLocationPrefix" to cellLocationPrefix).hasLengthAtLeast(5)
+      ("page" to page).isAtLeast(1)
+      ("pageSize" to pageSize).isAtLeast(1).isAtMost(100)
+    }
+
+    return incentiveReviewsService.reviews(prisonId, cellLocationPrefix, page, pageSize)
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResource.kt
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -13,9 +14,13 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.incentivesapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.incentivesapi.service.IncentiveReviewsService
+import javax.validation.Valid
+import javax.validation.constraints.Max
+import javax.validation.constraints.Min
 import javax.validation.constraints.Size
 
 @RestController
+@Validated
 @RequestMapping("/incentives-reviews", produces = [MediaType.APPLICATION_JSON_VALUE])
 @PreAuthorize("hasRole('ROLE_INCENTIVES')")
 class IncentiveReviewsResource(private val incentiveReviewsService: IncentiveReviewsService) {
@@ -44,20 +49,23 @@ class IncentiveReviewsResource(private val incentiveReviewsService: IncentiveRev
   )
   suspend fun getReviews(
     @Schema(description = "Prison ID", required = true, example = "MDI", minLength = 3, maxLength = 5)
-    @Size(max = 5, min = 3, message = "Prison ID must be 3-5 characters")
     @PathVariable
+    @Valid @Size(min = 3, max = 5, message = "Prison ID must be 3-5 characters")
     prisonId: String,
 
-    @Schema(description = "Cell location ID prefix", required = true, example = "MDI-1")
+    @Schema(description = "Cell location ID prefix", required = true, example = "MDI-1", minLength = 3)
     @PathVariable
+    @Valid @Size(min = 3, message = "Cell location ID prefix must be specified and start with prison id")
     cellLocationPrefix: String,
 
-    @Schema(description = "Page (starts at 1)", defaultValue = "1", example = "2", type = "integer", required = false, format = "int32")
+    @Schema(description = "Page (starts at 1)", defaultValue = "1", minimum = "1", example = "2", type = "integer", required = false, format = "int32")
     @RequestParam(required = false, defaultValue = "1")
+    @Valid @Min(1)
     page: Int,
 
-    @Schema(description = "Page size", defaultValue = "20", example = "20", type = "integer", required = false, format = "int32")
+    @Schema(description = "Page size", defaultValue = "20", minimum = "1", maximum = "100", example = "20", type = "integer", required = false, format = "int32")
     @RequestParam(required = false, defaultValue = "20")
+    @Valid @Min(1) @Max(100)
     pageSize: Int,
   ) = incentiveReviewsService.reviews(prisonId, cellLocationPrefix, page, pageSize)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveSummaryResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveSummaryResource.kt
@@ -16,7 +16,7 @@ import uk.gov.justice.digital.hmpps.incentivesapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.BehaviourSummary
 import uk.gov.justice.digital.hmpps.incentivesapi.service.IncentiveSummaryService
 import uk.gov.justice.digital.hmpps.incentivesapi.service.SortColumn
-import javax.validation.constraints.Size
+import uk.gov.justice.digital.hmpps.incentivesapi.util.ensure
 
 @RestController
 @RequestMapping("/incentives-summary", produces = [MediaType.APPLICATION_JSON_VALUE])
@@ -50,13 +50,29 @@ class IncentiveSummaryResource(private val incentiveSummaryService: IncentiveSum
   )
   suspend fun getIncentiveSummary(
     @Schema(description = "Prison Id", required = true, example = "MDI", minLength = 3, maxLength = 5)
-    @PathVariable @Size(max = 5, min = 3, message = "Prison ID must be 3-5 characters") prisonId: String,
-    @Schema(description = "Location Id", required = true, example = "MDI-1")
-    @PathVariable locationId: String,
-    @Schema(description = "Sort By", required = false, defaultValue = "NAME", example = "NAME")
-    @RequestParam(required = false, defaultValue = "NAME") sortBy: SortColumn,
+    @PathVariable
+    prisonId: String,
+
+    @Schema(description = "Location Id", required = true, example = "MDI-1", minLength = 5)
+    @PathVariable
+    locationId: String,
+
+    @Schema(
+      description = "Sort By", required = false, defaultValue = "NAME", example = "NAME",
+      allowableValues = ["NUMBER", "NAME", "DAYS_ON_LEVEL", "POS_BEHAVIOURS", "NEG_BEHAVIOURS", "DAYS_SINCE_LAST_REVIEW", "INCENTIVE_WARNINGS", "INCENTIVE_ENCOURAGEMENTS", "PROVEN_ADJUDICATIONS"],
+    )
+    @RequestParam(required = false, defaultValue = "NAME")
+    sortBy: SortColumn,
+
     @Schema(description = "Sort Direction", required = false, defaultValue = "ASC", example = "ASC")
-    @RequestParam(required = false, defaultValue = "ASC") sortDirection: Sort.Direction
-  ): BehaviourSummary =
-    incentiveSummaryService.getIncentivesSummaryByLocation(prisonId, locationId, sortBy, sortDirection)
+    @RequestParam(required = false, defaultValue = "ASC")
+    sortDirection: Sort.Direction
+  ): BehaviourSummary {
+    ensure {
+      ("prisonId" to prisonId).hasLengthAtLeast(3).hasLengthAtMost(5)
+      ("locationId" to locationId).hasLengthAtLeast(5)
+    }
+
+    return incentiveSummaryService.getIncentivesSummaryByLocation(prisonId, locationId, sortBy, sortDirection)
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveSummaryResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveSummaryResource.kt
@@ -49,8 +49,8 @@ class IncentiveSummaryResource(private val incentiveSummaryService: IncentiveSum
     ]
   )
   suspend fun getIncentiveSummary(
-    @Schema(description = "Prison Id", required = true, example = "MDI")
-    @PathVariable @Size(max = 3, min = 3, message = "Prison ID must be 3 characters") prisonId: String,
+    @Schema(description = "Prison Id", required = true, example = "MDI", minLength = 3, maxLength = 5)
+    @PathVariable @Size(max = 5, min = 3, message = "Prison ID must be 3-5 characters") prisonId: String,
     @Schema(description = "Location Id", required = true, example = "MDI-1")
     @PathVariable locationId: String,
     @Schema(description = "Sort By", required = false, defaultValue = "NAME", example = "NAME")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonApiService.kt
@@ -19,7 +19,6 @@ import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.Location
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.PrisonLocation
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.PrisonerAtLocation
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.ProvenAdjudication
-import javax.validation.constraints.NotEmpty
 
 @Service
 class PrisonApiService(
@@ -64,7 +63,7 @@ class PrisonApiService(
       .retrieve()
       .bodyToFlow()
 
-  fun getIEPSummaryPerPrisoner(@NotEmpty bookingIds: List<Long>): Flow<IepSummary> =
+  fun getIEPSummaryPerPrisoner(bookingIds: List<Long>): Flow<IepSummary> =
     prisonWebClient.post()
       .uri("/api/bookings/iepSummary")
       .bodyValue(bookingIds)
@@ -83,14 +82,14 @@ class PrisonApiService(
       .awaitBody()
   }
 
-  suspend fun retrieveCaseNoteCounts(type: String, @NotEmpty offenderNos: List<String>): Flow<CaseNoteUsage> =
+  suspend fun retrieveCaseNoteCounts(type: String, offenderNos: List<String>): Flow<CaseNoteUsage> =
     prisonWebClient.post()
       .uri("/api/case-notes/usage")
       .bodyValue(CaseNoteUsageRequest(numMonths = 3, offenderNos = offenderNos, type = type, subType = null))
       .retrieve()
       .bodyToFlow()
 
-  suspend fun retrieveProvenAdjudications(@NotEmpty bookingIds: List<Long>): Flow<ProvenAdjudication> =
+  suspend fun retrieveProvenAdjudications(bookingIds: List<Long>): Flow<ProvenAdjudication> =
     prisonWebClient.post()
       .uri("/api/bookings/proven-adjudications")
       .bodyValue(bookingIds)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/util/parameterValidators.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/util/parameterValidators.kt
@@ -43,6 +43,13 @@ class Ensure {
     }
     return this
   }
+
+  fun <T> Pair<String, List<T>>.isNotEmpty(): Pair<String, List<T>> {
+    if (second.isEmpty()) {
+      errors.add("`$first` list must not be empty")
+    }
+    return this
+  }
 }
 
 class ParameterValidationException(val errors: List<String>) :

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/util/parameterValidators.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/util/parameterValidators.kt
@@ -1,0 +1,49 @@
+/**
+ * Because Spring's javax validation annotation processing do not currently work with suspend function arguments,
+ * this can be used instead to validate request parameters within resources.
+ */
+package uk.gov.justice.digital.hmpps.incentivesapi.util
+
+import javax.validation.ValidationException
+
+fun ensure(block: Ensure.() -> Unit) = Ensure().apply {
+  block()
+  if (errors.isNotEmpty()) {
+    throw ParameterValidationException(errors)
+  }
+}
+
+class Ensure {
+  val errors: MutableList<String> = mutableListOf()
+
+  fun <T : Comparable<T>> Pair<String, T>.isAtLeast(min: T): Pair<String, T> {
+    if (second < min) {
+      errors.add("`$first` must be at least $min")
+    }
+    return this
+  }
+
+  fun <T : Comparable<T>> Pair<String, T>.isAtMost(max: T): Pair<String, T> {
+    if (second > max) {
+      errors.add("`$first` must be at most $max")
+    }
+    return this
+  }
+
+  fun <T : CharSequence> Pair<String, T>.hasLengthAtLeast(min: Int): Pair<String, T> {
+    if (second.length < min) {
+      errors.add("`$first` must have length of at least $min")
+    }
+    return this
+  }
+
+  fun <T : CharSequence> Pair<String, T>.hasLengthAtMost(max: Int): Pair<String, T> {
+    if (second.length > max) {
+      errors.add("`$first` must have length of at most $max")
+    }
+    return this
+  }
+}
+
+class ParameterValidationException(val errors: List<String>) :
+  ValidationException("Invalid parameters: ${errors.joinToString(", ")}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/util/parameterValidators.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/util/parameterValidators.kt
@@ -44,7 +44,7 @@ class Ensure {
     return this
   }
 
-  fun <T> Pair<String, List<T>>.isNotEmpty(): Pair<String, List<T>> {
+  fun <T, C : Collection<T>> Pair<String, C>.isNotEmpty(): Pair<String, C> {
     if (second.isEmpty()) {
       errors.add("`$first` list must not be empty")
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceForNomisDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceForNomisDataTest.kt
@@ -114,4 +114,18 @@ class IepLevelResourceForNomisDataTest : SqsIntegrationTestBase() {
           """
       )
   }
+
+  @Test
+  fun `get IEP Levels returns an error if no booking IDs provided`() {
+    prisonApiMockServer.stubIEPSummary()
+
+    webTestClient.post().uri("/iep/reviews/bookings")
+      .headers(setAuthorisation())
+      .bodyValue(emptyList<Long>())
+      .exchange()
+      .expectStatus().isBadRequest
+      .expectBody()
+      .jsonPath("userMessage")
+      .isEqualTo("Invalid parameters: `bookingIds` list must not be empty")
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResourceTest.kt
@@ -31,6 +31,18 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
   }
 
   @Test
+  fun `validates path parameters`() {
+    offenderSearchMockServer.stubFindOffenders("Moorland")
+
+    webTestClient.get()
+      .uri("/incentives-reviews/prison/Moorland/location/MDI-1?page=0")
+      .headers(setAuthorisation(roles = listOf("ROLE_INCENTIVES")))
+      .exchange()
+      .expectStatus()
+      .isBadRequest
+  }
+
+  @Test
   fun `loads prisoner details from offender search`() {
     offenderSearchMockServer.stubFindOffenders("MDI")
     prisonApiMockServer.stubLocation("MDI-1")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResourceTest.kt
@@ -31,18 +31,6 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
   }
 
   @Test
-  fun `validates path parameters`() {
-    offenderSearchMockServer.stubFindOffenders("Moorland")
-
-    webTestClient.get()
-      .uri("/incentives-reviews/prison/Moorland/location/MDI-1?page=0")
-      .headers(setAuthorisation(roles = listOf("ROLE_INCENTIVES")))
-      .exchange()
-      .expectStatus()
-      .isBadRequest
-  }
-
-  @Test
   fun `loads prisoner details from offender search`() {
     offenderSearchMockServer.stubFindOffenders("MDI")
     prisonApiMockServer.stubLocation("MDI-1")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResourceTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.incentivesapi.resource
 
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.incentivesapi.integration.SqsIntegrationTestBase
 
@@ -28,6 +29,75 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
       .exchange()
       .expectStatus()
       .isForbidden
+  }
+
+  @Nested
+  inner class `validates request parameters` {
+    @Test
+    fun `when prisonId is incorrect`() {
+      offenderSearchMockServer.stubFindOffenders("Moorland")
+      prisonApiMockServer.stubLocation("MDI-1")
+
+      webTestClient.get()
+        .uri("/incentives-reviews/prison/Moorland/location/MDI-1")
+        .headers(setAuthorisation(roles = listOf("ROLE_INCENTIVES")))
+        .exchange()
+        .expectStatus().isBadRequest
+        .expectBody().json(
+          // language=json
+          """
+          {
+            "status": 400,
+            "userMessage": "Invalid parameters: `prisonId` must have length of at most 5",
+            "developerMessage": "Invalid parameters: `prisonId` must have length of at most 5"
+          }
+          """
+        )
+    }
+
+    @Test
+    fun `when page is incorrect`() {
+      offenderSearchMockServer.stubFindOffenders("MDI")
+      prisonApiMockServer.stubLocation("MDI-1")
+
+      webTestClient.get()
+        .uri("/incentives-reviews/prison/MDI/location/MDI-1?page=0")
+        .headers(setAuthorisation(roles = listOf("ROLE_INCENTIVES")))
+        .exchange()
+        .expectStatus().isBadRequest
+        .expectBody().json(
+          // language=json
+          """
+          {
+            "status": 400,
+            "userMessage": "Invalid parameters: `page` must be at least 1",
+            "developerMessage": "Invalid parameters: `page` must be at least 1"
+          }
+          """
+        )
+    }
+
+    @Test
+    fun `when page & pageSize are incorrect`() {
+      offenderSearchMockServer.stubFindOffenders("MDI")
+      prisonApiMockServer.stubLocation("MDI-1")
+
+      webTestClient.get()
+        .uri("/incentives-reviews/prison/MDI/location/MDI-1?page=0&pageSize=0")
+        .headers(setAuthorisation(roles = listOf("ROLE_INCENTIVES")))
+        .exchange()
+        .expectStatus().isBadRequest
+        .expectBody().json(
+          // language=json
+          """
+          {
+            "status": 400,
+            "userMessage": "Invalid parameters: `page` must be at least 1, `pageSize` must be at least 1",
+            "developerMessage": "Invalid parameters: `page` must be at least 1, `pageSize` must be at least 1"
+          }
+          """
+        )
+    }
   }
 
   @Test
@@ -71,10 +141,10 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
   @Test
   fun `loads prisoner details even when location description not found`() {
     offenderSearchMockServer.stubFindOffenders("MDI")
-    prisonApiMockServer.stubApi404for("/api/locations/code/MDI")
+    prisonApiMockServer.stubApi404for("/api/locations/code/MDI-1")
 
     webTestClient.get()
-      .uri("/incentives-reviews/prison/MDI/location/MDI")
+      .uri("/incentives-reviews/prison/MDI/location/MDI-1")
       .headers(setAuthorisation(roles = listOf("ROLE_INCENTIVES")))
       .exchange()
       .expectStatus().isOk

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/OpenApiDocsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/OpenApiDocsTest.kt
@@ -36,7 +36,9 @@ class OpenApiDocsTest : SqsIntegrationTestBase() {
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().is3xxRedirection
-      .expectHeader().value("Location") { it.contains("/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config") }
+      .expectHeader().value("Location") {
+        assertThat(it).contains("/webjars/swagger-ui/index.html")
+      }
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/util/ParameterValidatorTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/util/ParameterValidatorTests.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.hmpps.incentivesapi.util
+
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class ParameterValidatorTests {
+  @Test
+  fun `does not throw errors when nothing is expected`() {
+    ensure {}
+  }
+
+  @Test
+  fun `does not throw errors when parameters have no assertions`() {
+    ensure {
+      ("param" to 123)
+    }
+  }
+
+  @Test
+  fun `does not throw errors when parameters meet assertions`() {
+    ensure {
+      ("param" to 123).isAtLeast(100).isAtMost(200)
+      ("param2" to "abc").hasLengthAtLeast(1).hasLengthAtMost(5)
+    }
+  }
+
+  @Test
+  fun `throws an error when a parameter does not meet assertions`() {
+    assertThatThrownBy {
+      ensure {
+        ("param1" to 123).isAtLeast(200)
+        ("param2" to 500).isAtLeast(200)
+      }
+    }.isInstanceOf(ParameterValidationException::class.java)
+      .hasMessage("Invalid parameters: `param1` must be at least 200")
+      .hasFieldOrPropertyWithValue("errors", listOf("`param1` must be at least 200"))
+  }
+
+  @Test
+  fun `throws an error when multiple parameters do not meet assertions`() {
+    assertThatThrownBy {
+      ensure {
+        ("param1" to 123).isAtLeast(200)
+        ("param2" to "abc").hasLengthAtLeast(5).hasLengthAtMost(5)
+      }
+    }.isInstanceOf(ParameterValidationException::class.java)
+      .hasMessage("Invalid parameters: `param1` must be at least 200, `param2` must have length of at least 5")
+      .hasFieldOrPropertyWithValue(
+        "errors",
+        listOf(
+          "`param1` must be at least 200",
+          "`param2` must have length of at least 5",
+        )
+      )
+  }
+}


### PR DESCRIPTION
Spring's validation of parameters using annotations does not work in suspend functions. C.f. https://github.com/spring-projects/spring-framework/issues/23499

We don't currently have the `Validated` annotation on the REST controllers (resources), meaning validation is disabled, but even with this annotation nothing gets checked.

Deserialisation of string parameters into objects like `Int` or `Sort.Direction` works correctly so there _is_ some validation happening.