### PR TITLE
INC-818: next review date takes 'Basic' into consideration

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/FeatureFlagsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/FeatureFlagsService.kt
@@ -13,14 +13,14 @@ class FeatureFlagsService(
   @Value("\${feature.review-added-sync-mechanism}")
   val reviewAddedSyncMechanism: String,
   @Value("\${feature.incentives-data-source-of-truth:false}")
-  val incentiveReviewsMasteredOutsideNomisInIncentivesDatabase: Boolean
+  val incentivesDataSourceOfTruth: Boolean
 ) {
 
   fun reviewAddedSyncMechanism(): ReviewAddedSyncMechanism {
     return ReviewAddedSyncMechanism.valueOf(reviewAddedSyncMechanism)
   }
 
-  fun isIncentiveReviewsMasteredOutsideNomisInIncentivesDatabase(): Boolean {
-    return incentiveReviewsMasteredOutsideNomisInIncentivesDatabase
+  fun isIncentivesDataSourceOfTruth(): Boolean {
+    return incentivesDataSourceOfTruth
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IepSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IepSummary.kt
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.ReviewType
-import uk.gov.justice.digital.hmpps.incentivesapi.service.NextReviewDateInput
-import uk.gov.justice.digital.hmpps.incentivesapi.service.NextReviewDateService
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -30,7 +28,9 @@ data class IepSummary(
   @Schema(description = "Location  of prisoner when review took place within prison (i.e. their cell)", example = "1-2-003", required = false)
   val locationId: String? = null,
   @Schema(description = "IEP Review History (descending in time)", required = true)
-  val iepDetails: List<IepDetail>,
+  var iepDetails: List<IepDetail>,
+  @Schema(description = "Date of next review", example = "2022-12-31", required = false)
+  var nextReviewDate: LocalDate? = null,
 ) {
 
   @get:Schema(description = "Days since last review", example = "23", required = true)
@@ -39,19 +39,6 @@ data class IepSummary(
     get() {
       val today = LocalDate.now().atStartOfDay()
       return Duration.between(iepDate.atStartOfDay(), today).toDays().toInt()
-    }
-
-  @get:Schema(description = "Date of next review", example = "2022-12-31", required = true)
-  @get:JsonProperty
-  val nextReviewDate: LocalDate
-    get() {
-      return NextReviewDateService().calculate(
-        NextReviewDateInput(
-          lastReviewDate = iepDate,
-          lastReviewLevel = iepLevel,
-          iepDetails = iepDetails,
-        )
-      )
     }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IepSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IepSummary.kt
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.ReviewType
+import uk.gov.justice.digital.hmpps.incentivesapi.service.NextReviewDateInput
+import uk.gov.justice.digital.hmpps.incentivesapi.service.NextReviewDateService
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -41,7 +43,16 @@ data class IepSummary(
 
   @get:Schema(description = "Date of next review", example = "2022-12-31", required = true)
   @get:JsonProperty
-  val nextReviewDate: LocalDate = iepDate.plusYears(1)
+  val nextReviewDate: LocalDate
+    get() {
+      return NextReviewDateService().calculate(
+        NextReviewDateInput(
+          lastReviewDate = iepDate,
+          lastReviewLevel = iepLevel,
+          iepDetails = iepDetails,
+        )
+      )
+    }
 }
 
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveSummaryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveSummaryService.kt
@@ -130,7 +130,7 @@ class IncentiveSummaryService(
 
   private suspend fun getIEPDetails(bookingIds: List<Long>): Map<Long, IepResult> {
 
-    if (featureFlagsService.isIncentiveReviewsMasteredOutsideNomisInIncentivesDatabase()) {
+    if (featureFlagsService.isIncentivesDataSourceOfTruth()) {
 
       val incentiveLevels = prisonApiService.getIncentiveLevels()
       return prisonerIepLevelRepository.findAllByBookingIdInOrderByReviewTimeDesc(bookingIds = bookingIds)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateService.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.incentivesapi.service
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepDetail
 import java.time.LocalDate
 
+private const val BASIC = "Basic"
+
 data class NextReviewDateInput(
   val lastReviewDate: LocalDate,
   val lastReviewLevel: String,
@@ -18,7 +20,7 @@ class NextReviewDateService {
       throw Exception("Arguments passed to NextReviewDateService#calculate() for bookingId = '${iepDetails[0].bookingId}' were wrong, lastReviewDate ($lastReviewDate) should match iepDate on first element of iepDetails argument (${iepDetails[0].iepDate})")
     }
 
-    if (lastReviewLevel == "Basic") {
+    if (lastReviewLevel == BASIC) {
       return nextReviewDateForBasic(input)
     }
 
@@ -28,12 +30,12 @@ class NextReviewDateService {
   private fun nextReviewDateForBasic(input: NextReviewDateInput): LocalDate {
     val (lastReviewDate, lastReviewLevel, iepDetails) = input
 
-    if (lastReviewLevel != "Basic") {
+    if (lastReviewLevel != BASIC) {
       throw Exception("Programming error: private method nextReviewDateForBasic() called when lastReviewLevel was $lastReviewLevel")
     }
 
     // "if not suitable to return to Standard level further reviews must be undertaken at least every 28 days thereafter"
-    if (iepDetails.size >= 2 && iepDetails[1].iepLevel == "Basic") {
+    if (iepDetails.size >= 2 && iepDetails[1].iepLevel == BASIC) {
       // IEP level was 'Basic' for last 2 reviews
       return lastReviewDate.plusDays(28)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateService.kt
@@ -17,7 +17,7 @@ class NextReviewDateService {
     val (lastReviewDate, lastReviewLevel, iepDetails) = input
 
     if (iepDetails.isNotEmpty() && lastReviewDate != iepDetails[0].iepDate) {
-      throw Exception("Arguments passed to NextReviewDateService#calculate() for bookingId = '${iepDetails[0].bookingId}' were wrong, lastReviewDate ($lastReviewDate) should match iepDate on first element of iepDetails argument (${iepDetails[0].iepDate})")
+      throw IllegalArgumentException("Arguments passed to NextReviewDateService#calculate() for bookingId = '${iepDetails[0].bookingId}' were wrong, lastReviewDate ($lastReviewDate) should match iepDate on first element of iepDetails argument (${iepDetails[0].iepDate})")
     }
 
     if (lastReviewLevel == BASIC) {
@@ -31,7 +31,7 @@ class NextReviewDateService {
     val (lastReviewDate, lastReviewLevel, iepDetails) = input
 
     if (lastReviewLevel != BASIC) {
-      throw Exception("Programming error: private method nextReviewDateForBasic() called when lastReviewLevel was $lastReviewLevel")
+      throw IllegalArgumentException("Programming error: private method nextReviewDateForBasic() called when lastReviewLevel was $lastReviewLevel")
     }
 
     // "if not suitable to return to Standard level further reviews must be undertaken at least every 28 days thereafter"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateService.kt
@@ -6,21 +6,16 @@ import java.time.LocalDate
 private const val BASIC = "Basic"
 
 data class NextReviewDateInput(
-  val lastReviewDate: LocalDate,
-  val lastReviewLevel: String,
   val iepDetails: List<IepDetail>,
 )
 
 class NextReviewDateService {
 
   fun calculate(input: NextReviewDateInput): LocalDate {
-    val (lastReviewDate, lastReviewLevel, iepDetails) = input
+    val (iepDetails) = input
+    val lastReviewDate = iepDetails[0].iepDate
 
-    if (iepDetails.isNotEmpty() && lastReviewDate != iepDetails[0].iepDate) {
-      throw IllegalArgumentException("Arguments passed to NextReviewDateService#calculate() for bookingId = '${iepDetails[0].bookingId}' were wrong, lastReviewDate ($lastReviewDate) should match iepDate on first element of iepDetails argument (${iepDetails[0].iepDate})")
-    }
-
-    if (lastReviewLevel == BASIC) {
+    if (iepDetails[0].iepLevel == BASIC) {
       return nextReviewDateForBasic(input)
     }
 
@@ -28,8 +23,10 @@ class NextReviewDateService {
   }
 
   private fun nextReviewDateForBasic(input: NextReviewDateInput): LocalDate {
-    val (lastReviewDate, lastReviewLevel, iepDetails) = input
+    val (iepDetails) = input
+    val lastReviewDate = iepDetails[0].iepDate
 
+    val lastReviewLevel = iepDetails[0].iepLevel
     if (lastReviewLevel != BASIC) {
       throw IllegalArgumentException("Programming error: private method nextReviewDateForBasic() called when lastReviewLevel was $lastReviewLevel")
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateService.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.incentivesapi.service
+
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepDetail
+import java.time.LocalDate
+
+data class NextReviewDateInput(
+  val lastReviewDate: LocalDate,
+  val lastReviewLevel: String,
+  val iepDetails: List<IepDetail>,
+)
+
+class NextReviewDateService {
+
+  fun calculate(input: NextReviewDateInput): LocalDate {
+    val (lastReviewDate, lastReviewLevel, iepDetails) = input
+
+    if (iepDetails.isNotEmpty() && lastReviewDate != iepDetails[0].iepDate) {
+      throw Exception("Arguments passed to NextReviewDateService#calculate() for bookingId = '${iepDetails[0].bookingId}' were wrong, lastReviewDate ($lastReviewDate) should match iepDate on first element of iepDetails argument (${iepDetails[0].iepDate})")
+    }
+
+    if (lastReviewLevel == "Basic") {
+      return nextReviewDateForBasic(input)
+    }
+
+    return lastReviewDate.plusYears(1)
+  }
+
+  private fun nextReviewDateForBasic(input: NextReviewDateInput): LocalDate {
+    val (lastReviewDate, lastReviewLevel, iepDetails) = input
+
+    if (lastReviewLevel != "Basic") {
+      throw Exception("Programming error: private method nextReviewDateForBasic() called when lastReviewLevel was $lastReviewLevel")
+    }
+
+    // "if not suitable to return to Standard level further reviews must be undertaken at least every 28 days thereafter"
+    if (iepDetails.size >= 2 && iepDetails[1].iepLevel == "Basic") {
+      // IEP level was 'Basic' for last 2 reviews
+      return lastReviewDate.plusDays(28)
+    }
+
+    // "PF 5.16 Prisoners placed on Basic must be reviewed within 7 days"
+    return lastReviewDate.plusDays(7)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -56,7 +56,7 @@ class PrisonerIepLevelReviewService(
     withDetails: Boolean = true,
     useClientCredentials: Boolean = false,
   ): IepSummary {
-    return if (!featureFlagsService.isIncentiveReviewsMasteredOutsideNomisInIncentivesDatabase()) {
+    return if (!featureFlagsService.isIncentivesDataSourceOfTruth()) {
       prisonApiService.getIEPSummaryForPrisoner(bookingId, withDetails, useClientCredentials)
     } else {
       val reviews = prisonerIepLevelRepository.findAllByBookingIdOrderByReviewTimeDesc(bookingId)
@@ -67,7 +67,7 @@ class PrisonerIepLevelReviewService(
 
   suspend fun getPrisonerIepLevelHistory(prisonerNumber: String): IepSummary {
 
-    return if (!featureFlagsService.isIncentiveReviewsMasteredOutsideNomisInIncentivesDatabase()) {
+    return if (!featureFlagsService.isIncentivesDataSourceOfTruth()) {
       val prisonerInfo = prisonApiService.getPrisonerInfo(prisonerNumber)
       prisonApiService.getIEPSummaryPerPrisoner(listOf(prisonerInfo.bookingId)).first()
     } else {
@@ -196,7 +196,7 @@ class PrisonerIepLevelReviewService(
   }
 
   suspend fun getCurrentIEPLevelForPrisoners(bookingIds: List<Long>): Flow<CurrentIepLevel> {
-    return if (!featureFlagsService.isIncentiveReviewsMasteredOutsideNomisInIncentivesDatabase()) {
+    return if (!featureFlagsService.isIncentivesDataSourceOfTruth()) {
       prisonApiService.getIEPSummaryPerPrisoner(bookingIds)
         .map {
           CurrentIepLevel(iepLevel = it.iepLevel, bookingId = it.bookingId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceForNomisDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceForNomisDataTest.kt
@@ -48,7 +48,7 @@ class IepLevelResourceForNomisDataTest : SqsIntegrationTestBase() {
              "iepDate":"2021-12-02",
              "iepLevel":"Basic",
              "iepTime":"2021-12-02T09:24:42.894",
-             "nextReviewDate": "2022-12-02",
+             "nextReviewDate": "2021-12-09",
              "iepDetails":[
                 {
                    "bookingId":1234134,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IepSummaryDateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IepSummaryDateTest.kt
@@ -265,42 +265,4 @@ class IepSummaryDateTest {
         .hasMessageContaining("Empty collection")
     }
   }
-
-  @Nested
-  inner class `Calc next review date for someone` {
-    @Test
-    fun `not on basic, nor newly in prison who has not been transferred since the last review`() {
-      val iepTime = LocalDateTime.now().minusDays(60)
-      val iepSummary = IepSummary(
-        bookingId = 1L,
-        iepDate = iepTime.toLocalDate(),
-        iepLevel = "Standard",
-        iepTime = iepTime,
-        iepDetails = listOf(
-          IepDetail(
-            bookingId = 1L,
-            agencyId = "MDI",
-            iepLevel = "Standard",
-            iepCode = "STD",
-            iepDate = iepTime.toLocalDate(),
-            iepTime = iepTime,
-            userId = "TEST_USER",
-            auditModuleName = "PRISON_API",
-          ),
-          IepDetail(
-            bookingId = 1L,
-            agencyId = "MDI",
-            iepLevel = "Standard",
-            iepCode = "STD",
-            iepDate = iepTime.minusDays(100).toLocalDate(),
-            iepTime = iepTime.minusDays(100),
-            userId = "TEST_USER",
-            auditModuleName = "PRISON_API",
-          ),
-        )
-      )
-
-      assertThat(iepSummary.nextReviewDate).isEqualTo(iepTime.toLocalDate().plusYears(1))
-    }
-  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateServiceTest.kt
@@ -4,7 +4,6 @@ import org.assertj.core.api.AssertionsForClassTypes.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepDetail
-import java.time.LocalDate
 import java.time.LocalDateTime
 
 internal class NextReviewDateServiceTest {
@@ -12,11 +11,11 @@ internal class NextReviewDateServiceTest {
   @Test
   fun `when IEP level is not Basic, returns +1 year`() {
     val input = NextReviewDateInput(
-      lastReviewLevel = "Standard",
-      lastReviewDate = LocalDate.now(),
-      iepDetails = emptyList(),
+      iepDetails = listOf(
+        iepDetail(iepLevel = "Standard", iepTime = LocalDateTime.now()),
+      ),
     )
-    val expectedNextReviewDate = input.lastReviewDate.plusYears(1)
+    val expectedNextReviewDate = input.iepDetails[0].iepDate.plusYears(1)
 
     val nextReviewDate = NextReviewDateService().calculate(input)
 
@@ -25,30 +24,15 @@ internal class NextReviewDateServiceTest {
 
   @Nested
   inner class BasicTest {
-    @Test
-    fun `when IEP level is Basic and no iepDetails, returns +7 days`() {
-      val input = NextReviewDateInput(
-        lastReviewLevel = "Basic",
-        lastReviewDate = LocalDate.now(),
-        iepDetails = emptyList(),
-      )
-      val expectedNextReviewDate = input.lastReviewDate.plusDays(7)
-
-      val nextReviewDate = NextReviewDateService().calculate(input)
-
-      assertThat(nextReviewDate).isEqualTo(expectedNextReviewDate)
-    }
 
     @Test
     fun `when IEP level is Basic and there is no previous review, returns +7 days`() {
       val input = NextReviewDateInput(
-        lastReviewLevel = "Basic",
-        lastReviewDate = LocalDate.now(),
         iepDetails = listOf(
           iepDetail(iepLevel = "Basic", iepTime = LocalDateTime.now()),
         ),
       )
-      val expectedNextReviewDate = input.lastReviewDate.plusDays(7)
+      val expectedNextReviewDate = input.iepDetails[0].iepDate.plusDays(7)
 
       val nextReviewDate = NextReviewDateService().calculate(input)
 
@@ -58,14 +42,12 @@ internal class NextReviewDateServiceTest {
     @Test
     fun `when IEP level is Basic but previous review is at different level, returns +7 days`() {
       val input = NextReviewDateInput(
-        lastReviewLevel = "Basic",
-        lastReviewDate = LocalDate.now(),
         iepDetails = listOf(
           iepDetail(iepLevel = "Basic", iepTime = LocalDateTime.now()),
           iepDetail(iepLevel = "Standard", iepTime = LocalDateTime.now().minusDays(10)),
         ),
       )
-      val expectedNextReviewDate = input.lastReviewDate.plusDays(7)
+      val expectedNextReviewDate = input.iepDetails[0].iepDate.plusDays(7)
 
       val nextReviewDate = NextReviewDateService().calculate(input)
 
@@ -75,14 +57,12 @@ internal class NextReviewDateServiceTest {
     @Test
     fun `when IEP level is Basic and previous IEP level was also Basic, returns +28 days`() {
       val input = NextReviewDateInput(
-        lastReviewLevel = "Basic",
-        lastReviewDate = LocalDate.now(),
         iepDetails = listOf(
           iepDetail(iepLevel = "Basic", iepTime = LocalDateTime.now()),
           iepDetail(iepLevel = "Basic", iepTime = LocalDateTime.now().minusDays(10)),
         ),
       )
-      val expectedNextReviewDate = input.lastReviewDate.plusDays(28)
+      val expectedNextReviewDate = input.iepDetails[0].iepDate.plusDays(28)
 
       val nextReviewDate = NextReviewDateService().calculate(input)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateServiceTest.kt
@@ -10,7 +10,7 @@ import java.time.LocalDateTime
 internal class NextReviewDateServiceTest {
 
   @Test
-  fun `when IEP level is not Basic it, returns +1 year`() {
+  fun `when IEP level is not Basic, returns +1 year`() {
     val input = NextReviewDateInput(
       lastReviewLevel = "Standard",
       lastReviewDate = LocalDate.now(),
@@ -40,7 +40,7 @@ internal class NextReviewDateServiceTest {
     }
 
     @Test
-    fun `when IEP level is Basic and there is not previous review, returns +7 days`() {
+    fun `when IEP level is Basic and there is no previous review, returns +7 days`() {
       val input = NextReviewDateInput(
         lastReviewLevel = "Basic",
         lastReviewDate = LocalDate.now(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateServiceTest.kt
@@ -1,0 +1,103 @@
+package uk.gov.justice.digital.hmpps.incentivesapi.service
+
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepDetail
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+internal class NextReviewDateServiceTest {
+
+  @Test
+  fun `when IEP level is not Basic it, returns +1 year`() {
+    val input = NextReviewDateInput(
+      lastReviewLevel = "Standard",
+      lastReviewDate = LocalDate.now(),
+      iepDetails = emptyList(),
+    )
+    val expectedNextReviewDate = input.lastReviewDate.plusYears(1)
+
+    val nextReviewDate = NextReviewDateService().calculate(input)
+
+    assertThat(nextReviewDate).isEqualTo(expectedNextReviewDate)
+  }
+
+  @Nested
+  inner class BasicTest {
+    @Test
+    fun `when IEP level is Basic and no iepDetails, returns +7 days`() {
+      val input = NextReviewDateInput(
+        lastReviewLevel = "Basic",
+        lastReviewDate = LocalDate.now(),
+        iepDetails = emptyList(),
+      )
+      val expectedNextReviewDate = input.lastReviewDate.plusDays(7)
+
+      val nextReviewDate = NextReviewDateService().calculate(input)
+
+      assertThat(nextReviewDate).isEqualTo(expectedNextReviewDate)
+    }
+
+    @Test
+    fun `when IEP level is Basic and there is not previous review, returns +7 days`() {
+      val input = NextReviewDateInput(
+        lastReviewLevel = "Basic",
+        lastReviewDate = LocalDate.now(),
+        iepDetails = listOf(
+          iepDetail(iepLevel = "Basic", iepTime = LocalDateTime.now()),
+        ),
+      )
+      val expectedNextReviewDate = input.lastReviewDate.plusDays(7)
+
+      val nextReviewDate = NextReviewDateService().calculate(input)
+
+      assertThat(nextReviewDate).isEqualTo(expectedNextReviewDate)
+    }
+
+    @Test
+    fun `when IEP level is Basic but previous review is at different level, returns +7 days`() {
+      val input = NextReviewDateInput(
+        lastReviewLevel = "Basic",
+        lastReviewDate = LocalDate.now(),
+        iepDetails = listOf(
+          iepDetail(iepLevel = "Basic", iepTime = LocalDateTime.now()),
+          iepDetail(iepLevel = "Standard", iepTime = LocalDateTime.now().minusDays(10)),
+        ),
+      )
+      val expectedNextReviewDate = input.lastReviewDate.plusDays(7)
+
+      val nextReviewDate = NextReviewDateService().calculate(input)
+
+      assertThat(nextReviewDate).isEqualTo(expectedNextReviewDate)
+    }
+
+    @Test
+    fun `when IEP level is Basic and previous IEP level was also Basic, returns +28 days`() {
+      val input = NextReviewDateInput(
+        lastReviewLevel = "Basic",
+        lastReviewDate = LocalDate.now(),
+        iepDetails = listOf(
+          iepDetail(iepLevel = "Basic", iepTime = LocalDateTime.now()),
+          iepDetail(iepLevel = "Basic", iepTime = LocalDateTime.now().minusDays(10)),
+        ),
+      )
+      val expectedNextReviewDate = input.lastReviewDate.plusDays(28)
+
+      val nextReviewDate = NextReviewDateService().calculate(input)
+
+      assertThat(nextReviewDate).isEqualTo(expectedNextReviewDate)
+    }
+  }
+}
+
+fun iepDetail(iepLevel: String, iepTime: LocalDateTime): IepDetail {
+  return IepDetail(
+    iepLevel = iepLevel,
+    iepTime = iepTime,
+    iepDate = iepTime.toLocalDate(),
+    agencyId = "MDI",
+    bookingId = 1234567L,
+    userId = null,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
@@ -246,7 +246,7 @@ class PrisonerIepLevelReviewServiceTest {
     @Test
     fun `will query incentives db if useNomisData is false`(): Unit = runBlocking {
       coroutineScope {
-        whenever(featureFlagsService.isIncentiveReviewsMasteredOutsideNomisInIncentivesDatabase()).thenReturn(true)
+        whenever(featureFlagsService.isIncentivesDataSourceOfTruth()).thenReturn(true)
         whenever(prisonApiService.getIncentiveLevels()).thenReturn(incentiveLevels)
 
         // Given
@@ -267,7 +267,7 @@ class PrisonerIepLevelReviewServiceTest {
     fun `will query incentives db if useNomisData is false and will not return iep details if withDetails is false`(): Unit =
       runBlocking {
         coroutineScope {
-          whenever(featureFlagsService.isIncentiveReviewsMasteredOutsideNomisInIncentivesDatabase()).thenReturn(true)
+          whenever(featureFlagsService.isIncentivesDataSourceOfTruth()).thenReturn(true)
           whenever(prisonApiService.getIncentiveLevels()).thenReturn(incentiveLevels)
 
           // Given

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
@@ -232,13 +232,13 @@ class PrisonerIepLevelReviewServiceTest {
       runBlocking {
         coroutineScope {
           // Given
-          whenever(prisonApiService.getIEPSummaryForPrisoner(1234567, withDetails = false)).thenReturn(iepSummary())
+          whenever(prisonApiService.getIEPSummaryForPrisoner(1234567, withDetails = true)).thenReturn(iepSummaryWithDetail)
 
           // When
           prisonerIepLevelReviewService.getPrisonerIepLevelHistory(1234567, withDetails = false)
 
           // Then
-          verify(prisonApiService, times(1)).getIEPSummaryForPrisoner(1234567, false)
+          verify(prisonApiService, times(1)).getIEPSummaryForPrisoner(1234567, true)
           verifyNoInteractions(prisonerIepLevelRepository)
         }
       }
@@ -491,7 +491,7 @@ class PrisonerIepLevelReviewServiceTest {
           withDetails = true,
           useClientCredentials = true
         )
-      ).thenReturn(iepSummary(iepDetails = emptyList()))
+      ).thenReturn(iepSummaryWithDetail)
 
       // When
       prisonerIepLevelReviewService.processOffenderEvent(prisonOffenderEvent)


### PR DESCRIPTION
Requirements/rules
-------------------

> PF 5.16 Prisoners placed on Basic must be reviewed within 7 days and if
> not suitable to return to Standard level further reviews must be
> undertaken at least every 28 days thereafter

Ticket scope
-------------

Ticket INC-818: https://dsdmoj.atlassian.net/browse/INC-818

There are other rules but this ticket is about improving the next review
date for prisoners on 'Basic' level.

Technical implementation
-------------------------

The `nextReviewDate` property in `IepSummary` has now a getter which
delegates the calculation of the next review date to the `NextReviewDateService`.

The idea is that this service is stateless and given all the information
it needs, determines the next review date.

**NOTE**: At the moment this information is the last review date/level
and the reviews history (`iepDetails`) but in the future it may need more
information, e.g. ACCT or other.
