### PR TITLE
INC-816: Wire up offender search service to return a single offender by prisoner number

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/WebClientConfiguration.kt
@@ -59,12 +59,15 @@ class WebClientConfiguration(
   }
 
   @Bean
-  fun offenderSearchWebClient(): WebClient {
+  fun offenderSearchWebClient(authorizedClientManager: ReactiveOAuth2AuthorizedClientManager): WebClient {
+    val oauth2Client = ServerOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager)
+    oauth2Client.setDefaultClientRegistrationId("incentives-api")
+
     val httpClient = HttpClient.create().responseTimeout(Duration.ofMinutes(2))
     return WebClient.builder()
       .baseUrl(offenderSearchUri)
       .clientConnector(ReactorClientHttpConnector(httpClient))
-      .filter(AuthTokenFilterFunction())
+      .filter(oauth2Client)
       .build()
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/OffenderSearch.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/OffenderSearch.kt
@@ -24,7 +24,7 @@ data class OffenderSearchPrisonerAlert(
   val expired: Boolean,
 )
 
-data class OffenderSearchPrisonerResponse(
+data class OffenderSearchPrisonerList(
   val totalElements: Int,
   val content: List<OffenderSearchPrisoner>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/OffenderSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/OffenderSearchService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.incentivesapi.service
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.awaitBody
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.OffenderSearchPrisoner
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.OffenderSearchPrisonerList
 
 @Service
@@ -25,4 +26,14 @@ class OffenderSearchService(private val offenderSearchWebClient: WebClient) {
       )
       .retrieve()
       .awaitBody<OffenderSearchPrisonerList>()
+
+  /**
+   * Gets one offender record
+   * Requires ROLE_PRISONER_SEARCH or ROLE_VIEW_PRISONER_DATA role
+   */
+  suspend fun getOffender(prisonerNumber: String) =
+    offenderSearchWebClient.get()
+      .uri("/prisoner/$prisonerNumber")
+      .retrieve()
+      .awaitBody<OffenderSearchPrisoner>()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/OffenderSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/OffenderSearchService.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.incentivesapi.service
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.awaitBody
-import uk.gov.justice.digital.hmpps.incentivesapi.dto.OffenderSearchPrisonerResponse
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.OffenderSearchPrisonerList
 
 @Service
 class OffenderSearchService(private val offenderSearchWebClient: WebClient) {
@@ -24,5 +24,5 @@ class OffenderSearchService(private val offenderSearchWebClient: WebClient) {
         )
       )
       .retrieve()
-      .awaitBody<OffenderSearchPrisonerResponse>()
+      .awaitBody<OffenderSearchPrisonerList>()
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/wiremock/OffenderSearchMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/wiremock/OffenderSearchMockServer.kt
@@ -77,4 +77,39 @@ class OffenderSearchMockServer : WireMockServer(WIREMOCK_PORT) {
       )
     )
   }
+
+  fun stubGetOffender(prisonId: String, prisonerNumber: String) {
+    val mapper = jacksonObjectMapper()
+    stubFor(
+      get("/prisoner/$prisonerNumber").willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withBody(
+            mapper.writeValueAsBytes(
+              OffenderSearchPrisoner(
+                prisonerNumber = prisonerNumber,
+                bookingId = "110001",
+                firstName = "JAMES",
+                middleNames = "",
+                lastName = "HALLS",
+                status = "ACTIVE IN",
+                inOutStatus = "IN",
+                prisonId = prisonId,
+                prisonName = "$prisonId prison",
+                cellLocation = "2-1-002",
+                locationDescription = "$prisonId prison",
+                alerts = listOf(
+                  OffenderSearchPrisonerAlert(
+                    alertType = "H",
+                    alertCode = "HA",
+                    active = true,
+                    expired = false,
+                  ),
+                ),
+              )
+            )
+          )
+      )
+    )
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/wiremock/OffenderSearchMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/wiremock/OffenderSearchMockServer.kt
@@ -6,7 +6,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.OffenderSearchPrisoner
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.OffenderSearchPrisonerAlert
-import uk.gov.justice.digital.hmpps.incentivesapi.dto.OffenderSearchPrisonerResponse
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.OffenderSearchPrisonerList
 
 class OffenderSearchMockServer : WireMockServer(WIREMOCK_PORT) {
   companion object {
@@ -32,7 +32,7 @@ class OffenderSearchMockServer : WireMockServer(WIREMOCK_PORT) {
           .withHeader("Content-Type", "application/json")
           .withBody(
             mapper.writeValueAsBytes(
-              OffenderSearchPrisonerResponse(
+              OffenderSearchPrisonerList(
                 totalElements = 2,
                 content = listOf(
                   OffenderSearchPrisoner(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsServiceTest.kt
@@ -13,7 +13,7 @@ import org.mockito.stubbing.OngoingStubbing
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IncentiveReview
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.OffenderSearchPrisoner
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.OffenderSearchPrisonerAlert
-import uk.gov.justice.digital.hmpps.incentivesapi.dto.OffenderSearchPrisonerResponse
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.OffenderSearchPrisonerList
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.PrisonLocation
 
 class IncentiveReviewsServiceTest {
@@ -120,9 +120,9 @@ class IncentiveReviewsServiceTest {
     )
   }
 
-  private fun OngoingStubbing<OffenderSearchPrisonerResponse>.thenReturnOffenders(offenders: List<OffenderSearchPrisoner> = emptyList()) {
+  private fun OngoingStubbing<OffenderSearchPrisonerList>.thenReturnOffenders(offenders: List<OffenderSearchPrisoner> = emptyList()) {
     thenReturn(
-      OffenderSearchPrisonerResponse(
+      OffenderSearchPrisonerList(
         totalElements = offenders.size,
         content = offenders,
       )


### PR DESCRIPTION
…which will be needed for future "date of next review" calculations.

Also, changes to use system token to access offender search: Essentially, we only require the `MAINTAIN_IEP` role, and this makes sense for the data we actually return to the caller. But to calculate next review dates, we need to load more information on the given offender and the calling user may not have the roles to do so.