### PR TITLE
Have renovate-bot preserve existing semver ranges

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "extends": [
     "config:base",
-    ":disableDependencyDashboard"
+    ":disableDependencyDashboard",
+    ":preserveSemverRanges"
   ],
   "assigneesFromCodeOwners": true,
   "timezone": "Europe/London",


### PR DESCRIPTION
…so that it does not suggest too many unnecessary updates to patch-level versions.

E.g. the HMPPS CircleCI orb is fine being pinned at the minor level because CircleCI will always use the latest patch version then anyway