### PR TITLE
INC-852: Take open ACCT status when determining next review date

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveSummaryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveSummaryService.kt
@@ -38,7 +38,7 @@ class IncentiveSummaryService(
     sortBy: SortColumn = SortColumn.NAME,
     sortDirection: Sort.Direction = Sort.Direction.ASC
   ): BehaviourSummary = coroutineScope {
-    val prisoners = prisonApiService.findPrisonersAtLocation(prisonId, locationId).toList()
+    val prisoners = prisonApiService.findPrisonersAtLocation(locationId).toList()
     if (prisoners.isEmpty()) throw NoPrisonersAtLocationException(prisonId, locationId)
 
     val iepLevelsDeferred = async { iepLevelService.getIepLevelsForPrison(prisonId) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateService.kt
@@ -53,5 +53,4 @@ class NextReviewDateService(private val input: NextReviewDateInput) {
 
     return isOnBasic() && iepDetails.size >= 2 && iepDetails[1].iepLevel == BASIC
   }
-
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateService.kt
@@ -7,6 +7,7 @@ private const val BASIC = "Basic"
 
 data class NextReviewDateInput(
   val iepDetails: List<IepDetail>,
+  val hasAcctOpen: Boolean,
 )
 
 class NextReviewDateService {
@@ -15,29 +16,47 @@ class NextReviewDateService {
     val (iepDetails) = input
     val lastReviewDate = iepDetails[0].iepDate
 
-    if (iepDetails[0].iepLevel == BASIC) {
-      return nextReviewDateForBasic(input)
+    var nextReviewDateCandidates = mutableListOf<LocalDate?>(
+      lastReviewDate.plusYears(1),
+    )
+
+    val rules = listOf(
+      ::ruleForBasic,
+      ::ruleForAcct,
+    )
+    for (rule in rules) {
+      nextReviewDateCandidates.add(rule(input))
     }
 
-    return lastReviewDate.plusYears(1)
+    // Returns the earliest next review date that applies
+    return nextReviewDateCandidates.filterNotNull().min()
   }
 
-  private fun nextReviewDateForBasic(input: NextReviewDateInput): LocalDate {
+  private fun ruleForBasic(input: NextReviewDateInput): LocalDate? {
     val (iepDetails) = input
-    val lastReviewDate = iepDetails[0].iepDate
+    val lastReview = iepDetails[0]
 
-    val lastReviewLevel = iepDetails[0].iepLevel
-    if (lastReviewLevel != BASIC) {
-      throw IllegalArgumentException("Programming error: private method nextReviewDateForBasic() called when lastReviewLevel was $lastReviewLevel")
+    if (lastReview.iepLevel != BASIC) {
+      return null
     }
 
     // "if not suitable to return to Standard level further reviews must be undertaken at least every 28 days thereafter"
     if (iepDetails.size >= 2 && iepDetails[1].iepLevel == BASIC) {
       // IEP level was 'Basic' for last 2 reviews
-      return lastReviewDate.plusDays(28)
+      return lastReview.iepDate.plusDays(28)
     }
 
     // "PF 5.16 Prisoners placed on Basic must be reviewed within 7 days"
-    return lastReviewDate.plusDays(7)
+    return lastReview.iepDate.plusDays(7)
   }
+
+  private fun ruleForAcct(input: NextReviewDateInput): LocalDate? {
+    val (iepDetails, hasAcctOpen) = input
+    val lastReviewDate = iepDetails[0].iepDate
+
+    // "Exception for those identified as at Risk of Suicide and Self-harm (ACCT) and for young people,
+    // where further reviews must be undertaken at least every 14 days thereafter"
+    return if (hasAcctOpen) lastReviewDate.plusDays(14) else null
+  }
+
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateService.kt
@@ -10,52 +10,48 @@ data class NextReviewDateInput(
   val hasAcctOpen: Boolean,
 )
 
-class NextReviewDateService {
+class NextReviewDateService(private val input: NextReviewDateInput) {
 
-  fun calculate(input: NextReviewDateInput): LocalDate {
-    val (iepDetails) = input
-    val lastReviewDate = iepDetails[0].iepDate
-
-    var nextReviewDateCandidates = mutableListOf<LocalDate?>(
-      lastReviewDate.plusYears(1),
-    )
-
-    val rules = listOf(
-      ::ruleForBasic,
-      ::ruleForAcct,
-    )
-    for (rule in rules) {
-      nextReviewDateCandidates.add(rule(input))
+  fun calculate(): LocalDate {
+    if (isOnBasic()) {
+      return rulesForBasic()
     }
 
-    // Returns the earliest next review date that applies
-    return nextReviewDateCandidates.filterNotNull().min()
+    return lastReviewDate().plusYears(1)
   }
 
-  private fun ruleForBasic(input: NextReviewDateInput): LocalDate? {
-    val (iepDetails) = input
-    val lastReview = iepDetails[0]
-
-    if (lastReview.iepLevel != BASIC) {
-      return null
-    }
-
+  private fun rulesForBasic(): LocalDate {
     // "if not suitable to return to Standard level further reviews must be undertaken at least every 28 days thereafter"
-    if (iepDetails.size >= 2 && iepDetails[1].iepLevel == BASIC) {
-      // IEP level was 'Basic' for last 2 reviews
-      return lastReview.iepDate.plusDays(28)
+    if (wasConfirmedBasic()) {
+      // "Exception for those identified as at Risk of Suicide and Self-harm (ACCT) and for young people,
+      // where further reviews must be undertaken at least every 14 days thereafter"
+      if (input.hasAcctOpen) {
+        return lastReviewDate().plusDays(14)
+      }
+
+      return lastReviewDate().plusDays(28)
     }
 
     // "PF 5.16 Prisoners placed on Basic must be reviewed within 7 days"
-    return lastReview.iepDate.plusDays(7)
+    return lastReviewDate().plusDays(7)
   }
 
-  private fun ruleForAcct(input: NextReviewDateInput): LocalDate? {
-    val (iepDetails, hasAcctOpen) = input
-    val lastReviewDate = iepDetails[0].iepDate
-
-    // "Exception for those identified as at Risk of Suicide and Self-harm (ACCT) and for young people,
-    // where further reviews must be undertaken at least every 14 days thereafter"
-    return if (hasAcctOpen) lastReviewDate.plusDays(14) else null
+  private fun lastReview(): IepDetail {
+    return input.iepDetails.first()
   }
+
+  private fun isOnBasic(): Boolean {
+    return lastReview().iepLevel == BASIC
+  }
+
+  private fun lastReviewDate(): LocalDate {
+    return lastReview().iepDate
+  }
+
+  private fun wasConfirmedBasic(): Boolean {
+    val (iepDetails) = input
+
+    return isOnBasic() && iepDetails.size >= 2 && iepDetails[1].iepLevel == BASIC
+  }
+
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateService.kt
@@ -58,5 +58,4 @@ class NextReviewDateService {
     // where further reviews must be undertaken at least every 14 days thereafter"
     return if (hasAcctOpen) lastReviewDate.plusDays(14) else null
   }
-
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonApiService.kt
@@ -56,7 +56,7 @@ class PrisonApiService(
       }
   }
 
-  suspend fun findPrisonersAtLocation(prisonId: String, locationId: String): Flow<PrisonerAtLocation> =
+  suspend fun findPrisonersAtLocation(locationId: String): Flow<PrisonerAtLocation> =
     prisonWebClient.get()
       .uri("/api/locations/description/$locationId/inmates")
       .header("Page-Limit", "3000")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -65,12 +65,12 @@ class PrisonerIepLevelReviewService(
     // Get Prisoner/ACCT info from Offender Search API
     val prisoner = offenderSearchService.getOffender(prisonerNumber)
 
-    iepSummary.nextReviewDate = NextReviewDateService().calculate(
+    iepSummary.nextReviewDate = NextReviewDateService(
       NextReviewDateInput(
         iepDetails = iepSummary.iepDetails,
         hasAcctOpen = prisoner.acctOpen,
-      ),
-    )
+      )
+    ).calculate()
 
     return iepSummary
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -45,19 +45,30 @@ class PrisonerIepLevelReviewService(
   private val authenticationFacade: AuthenticationFacade,
   private val clock: Clock,
   private val featureFlagsService: FeatureFlagsService,
+  private val offenderSearchService: OffenderSearchService,
 ) {
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  private fun setNextReviewDate(iepSummary: IepSummary): IepSummary {
+  private suspend fun setNextReviewDate(iepSummary: IepSummary): IepSummary {
     if (iepSummary.iepDetails.isEmpty()) {
       throw IllegalArgumentException("Cannot set nextReviewDate without iepDetails for bookingId = ${iepSummary.bookingId}")
     }
 
+    // NOTE: `iepSummary.prisonerNumber` could be `null` (when data is coming from NOMIS)
+    val prisonerNumber = iepSummary.prisonerNumber ?: run {
+      val locationInfo = prisonApiService.getPrisonerInfo(iepSummary.bookingId, useClientCredentials = true)
+      locationInfo.offenderNo
+    }
+
+    // Get Prisoner/ACCT info from Offender Search API
+    val prisoner = offenderSearchService.getOffender(prisonerNumber)
+
     iepSummary.nextReviewDate = NextReviewDateService().calculate(
       NextReviewDateInput(
         iepDetails = iepSummary.iepDetails,
+        hasAcctOpen = prisoner.acctOpen,
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/service/PrisonOffenderEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/service/PrisonOffenderEventListenerIntTest.kt
@@ -70,12 +70,14 @@ internal class PrisonOffenderEventListenerIntTest : SqsIntegrationTestBase() {
     // Given
     val bookingId = 1294134L
     val prisonerNumber = "A1244AB"
+    val prisonId = "MDI"
     val locationId = 77777L
     prisonApiMockServer.stubIepLevels()
-    prisonApiMockServer.stubAgenciesIepLevels("MDI")
+    prisonApiMockServer.stubAgenciesIepLevels(prisonId)
     prisonApiMockServer.stubGetPrisonerInfoByNoms(bookingId = bookingId, prisonerNumber = prisonerNumber, locationId = locationId)
     prisonApiMockServer.stubGetLocationById(locationId = locationId, locationDesc = "1-2-003")
     prisonApiMockServer.stubIEPSummaryForBooking(bookingId = bookingId)
+    offenderSearchMockServer.stubGetOffender(prisonId, prisonerNumber)
 
     // When
     publishPrisonerReceivedMessage("TRANSFERRED")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/wiremock/OffenderSearchMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/wiremock/OffenderSearchMockServer.kt
@@ -78,7 +78,16 @@ class OffenderSearchMockServer : WireMockServer(WIREMOCK_PORT) {
     )
   }
 
-  fun stubGetOffender(prisonId: String, prisonerNumber: String) {
+  fun stubGetOffender(prisonId: String, prisonerNumber: String, withOpenAcct: Boolean = true) {
+    val alerts = if (withOpenAcct) listOf(
+      OffenderSearchPrisonerAlert(
+        alertType = "H",
+        alertCode = "HA",
+        active = true,
+        expired = false,
+      ),
+    ) else emptyList()
+
     val mapper = jacksonObjectMapper()
     stubFor(
       get("/prisoner/$prisonerNumber").willReturn(
@@ -98,14 +107,7 @@ class OffenderSearchMockServer : WireMockServer(WIREMOCK_PORT) {
                 prisonName = "$prisonId prison",
                 cellLocation = "2-1-002",
                 locationDescription = "$prisonId prison",
-                alerts = listOf(
-                  OffenderSearchPrisonerAlert(
-                    alertType = "H",
-                    alertCode = "HA",
-                    active = true,
-                    expired = false,
-                  ),
-                ),
+                alerts = alerts,
               )
             )
           )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceForNomisDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceForNomisDataTest.kt
@@ -31,7 +31,13 @@ class IepLevelResourceForNomisDataTest : SqsIntegrationTestBase() {
 
   @Test
   fun `get IEP Levels for a prisoner`() {
+    val bookingId = 1234134L
+    val prisonerNumber = "A1234BC"
+    val prisonId = "MDI"
+
     prisonApiMockServer.stubIEPSummaryForBooking()
+    prisonApiMockServer.stubGetPrisonerInfoByBooking(bookingId, prisonerNumber, locationId = 77778L)
+    offenderSearchMockServer.stubGetOffender(prisonId, prisonerNumber, withOpenAcct = false)
 
     val lastReviewDate = LocalDate.of(2021, 12, 2)
     val daysSinceReview = Duration.between(lastReviewDate.atStartOfDay(), now().atStartOfDay()).toDays().toInt()
@@ -43,7 +49,7 @@ class IepLevelResourceForNomisDataTest : SqsIntegrationTestBase() {
       .expectBody().json(
         """
             {
-             "bookingId":1234134,
+             "bookingId": $bookingId,
              "daysSinceReview": $daysSinceReview,
              "iepDate":"2021-12-02",
              "iepLevel":"Basic",
@@ -51,16 +57,16 @@ class IepLevelResourceForNomisDataTest : SqsIntegrationTestBase() {
              "nextReviewDate": "2021-12-09",
              "iepDetails":[
                 {
-                   "bookingId":1234134,
+                   "bookingId": $bookingId,
                    "iepDate":"2021-12-02",
                    "iepTime":"2021-12-02T09:24:42.894",
-                   "agencyId":"MDI",
+                   "agencyId": $prisonId,
                    "iepLevel":"Basic",
                    "userId":"TEST_USER",
                    "auditModuleName":"PRISON_API"
                 },
                 {
-                   "bookingId":1234134,
+                   "bookingId": $bookingId,
                    "iepDate":"2020-11-02",
                    "iepTime":"2021-11-02T09:00:42.894",
                    "agencyId":"BXI",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
@@ -127,11 +127,13 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
   fun `add IEP Level for a prisoner by booking Id`() {
     val bookingId = 3330000L
     val prisonerNumber = "A1234AC"
+    val prisonId = "MDI"
 
     prisonApiMockServer.stubIepLevels()
     prisonApiMockServer.stubGetPrisonerInfoByBooking(bookingId = bookingId, prisonerNumber = prisonerNumber, locationId = 77778L)
     prisonApiMockServer.stubGetLocationById(locationId = 77778L, locationDesc = "1-2-003")
     prisonApiMockServer.stubAddIep(bookingId = bookingId)
+    offenderSearchMockServer.stubGetOffender(prisonId, prisonerNumber, withOpenAcct = false)
 
     webTestClient.post().uri("/iep/reviews/booking/$bookingId")
       .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_IEP"), scopes = listOf("read", "write")))
@@ -174,11 +176,13 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
   fun `add IEP Level for a prisoner by noms`() {
     val bookingId = 1294134L
     val prisonerNumber = "A1244AB"
+    val prisonId = "MDI"
 
     prisonApiMockServer.stubGetPrisonerInfoByNoms(bookingId = bookingId, prisonerNumber = prisonerNumber, locationId = 77777L)
     prisonApiMockServer.stubGetLocationById(locationId = 77777L, locationDesc = "1-2-003")
     prisonApiMockServer.stubAddIep(bookingId = bookingId)
     prisonApiMockServer.stubIepLevels()
+    offenderSearchMockServer.stubGetOffender(prisonId, prisonerNumber, withOpenAcct = false)
 
     webTestClient.post().uri("/iep/reviews/prisoner/$prisonerNumber")
       .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_IEP"), scopes = listOf("read", "write")))
@@ -212,7 +216,7 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
                    "prisonerNumber": $prisonerNumber,
                    "bookingId":$bookingId,
                    "iepDate":"$today",
-                   "agencyId":"MDI",
+                   "agencyId": $prisonId,
                    "iepLevel":"Enhanced",
                    "iepCode": "ENH",
                    "comments":"A different comment",
@@ -225,7 +229,7 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
                    "prisonerNumber": $prisonerNumber,
                    "bookingId":$bookingId,
                    "iepDate":"$today",
-                   "agencyId":"MDI",
+                   "agencyId": $prisonId,
                    "iepLevel":"Basic",
                    "iepCode": "BAS",
                    "comments":"Basic Level",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateServiceTest.kt
@@ -18,7 +18,7 @@ internal class NextReviewDateServiceTest {
     )
     val expectedNextReviewDate = input.iepDetails[0].iepDate.plusYears(1)
 
-    val nextReviewDate = NextReviewDateService().calculate(input)
+    val nextReviewDate = NextReviewDateService(input).calculate()
 
     assertThat(nextReviewDate).isEqualTo(expectedNextReviewDate)
   }
@@ -36,7 +36,7 @@ internal class NextReviewDateServiceTest {
       )
       val expectedNextReviewDate = input.iepDetails[0].iepDate.plusDays(7)
 
-      val nextReviewDate = NextReviewDateService().calculate(input)
+      val nextReviewDate = NextReviewDateService(input).calculate()
 
       assertThat(nextReviewDate).isEqualTo(expectedNextReviewDate)
     }
@@ -52,7 +52,7 @@ internal class NextReviewDateServiceTest {
       )
       val expectedNextReviewDate = input.iepDetails[0].iepDate.plusDays(7)
 
-      val nextReviewDate = NextReviewDateService().calculate(input)
+      val nextReviewDate = NextReviewDateService(input).calculate()
 
       assertThat(nextReviewDate).isEqualTo(expectedNextReviewDate)
     }
@@ -68,7 +68,7 @@ internal class NextReviewDateServiceTest {
       )
       val expectedNextReviewDate = input.iepDetails[0].iepDate.plusDays(28)
 
-      val nextReviewDate = NextReviewDateService().calculate(input)
+      val nextReviewDate = NextReviewDateService(input).calculate()
 
       assertThat(nextReviewDate).isEqualTo(expectedNextReviewDate)
     }
@@ -78,16 +78,16 @@ internal class NextReviewDateServiceTest {
   inner class AcctRuleTest {
 
     @Test
-    fun `when prisoner has open ACCT and they're not on Basic, returns +14 days`() {
+    fun `when prisoner has open ACCT but they're not on Basic, returns +1 year`() {
       val input = NextReviewDateInput(
         iepDetails = listOf(
           iepDetail(iepLevel = "Standard", iepTime = LocalDateTime.now()),
         ),
         hasAcctOpen = true,
       )
-      val expectedNextReviewDate = input.iepDetails[0].iepDate.plusDays(14)
+      val expectedNextReviewDate = input.iepDetails[0].iepDate.plusYears(1)
 
-      val nextReviewDate = NextReviewDateService().calculate(input)
+      val nextReviewDate = NextReviewDateService(input).calculate()
 
       assertThat(nextReviewDate).isEqualTo(expectedNextReviewDate)
     }
@@ -103,7 +103,7 @@ internal class NextReviewDateServiceTest {
       )
       val expectedNextReviewDate = input.iepDetails[0].iepDate.plusDays(14)
 
-      val nextReviewDate = NextReviewDateService().calculate(input)
+      val nextReviewDate = NextReviewDateService(input).calculate()
 
       assertThat(nextReviewDate).isEqualTo(expectedNextReviewDate)
     }
@@ -119,7 +119,7 @@ internal class NextReviewDateServiceTest {
       )
       val expectedNextReviewDate = input.iepDetails[0].iepDate.plusDays(7)
 
-      val nextReviewDate = NextReviewDateService().calculate(input)
+      val nextReviewDate = NextReviewDateService(input).calculate()
 
       assertThat(nextReviewDate).isEqualTo(expectedNextReviewDate)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateServiceTest.kt
@@ -123,7 +123,6 @@ internal class NextReviewDateServiceTest {
 
       assertThat(nextReviewDate).isEqualTo(expectedNextReviewDate)
     }
-
   }
 }
 


### PR DESCRIPTION
The rule to determine the next review date _for prisoners on 'Basic'_ is slightly different for prisoners at risk of self harm (have an ACCT alert active and not expired, aka is a prisoner "with open ACCT") their next review date is earlier.

When someone was on 'Basic' and they couldn't move up to an higher level (e.g. they were confirmed on 'Basic' level) the next review would normally be after 28 days. However for prisoners with an open ACCT in this case it would be after 14 days instead.

> PF 5.16 _Prisoners placed on Basic_ must be reviewed within 7 days and if not suitable to return to Standard level further reviews must be undertaken at least every 28 days thereafter
>
> _Exception for those identified as at Risk of Suicide and Self-harm (ACCT)_ and for young people, where further reviews must be undertaken at least every 14 days thereafter

(emphasis on bits relative for this PR/ticket mine)

**NOTE**: ACCT is only affecting prisoners on Basic, not on other levels. This is why in the code this is part of the "basic rules" calculation.