### PR TITLE
INC-896: Added "young people" exception for next review when on Basic

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateService.kt
@@ -28,19 +28,21 @@ class NextReviewDateService(private val input: NextReviewDateInput) {
   }
 
   private fun rulesForBasic(): LocalDate {
+    val lastReviewDate = lastReviewDate()
+
     // "if not suitable to return to Standard level further reviews must be undertaken at least every 28 days thereafter"
     if (wasConfirmedBasic()) {
       // "Exception for those identified as at Risk of Suicide and Self-harm (ACCT) and for young people,
       // where further reviews must be undertaken at least every 14 days thereafter"
-      if (input.hasAcctOpen) {
-        return lastReviewDate().plusDays(14)
+      if (input.hasAcctOpen || wasYoungPersonOnDate(lastReviewDate)) {
+        return lastReviewDate.plusDays(14)
       }
 
-      return lastReviewDate().plusDays(28)
+      return lastReviewDate.plusDays(28)
     }
 
     // "PF 5.16 Prisoners placed on Basic must be reviewed within 7 days"
-    return lastReviewDate().plusDays(7)
+    return lastReviewDate.plusDays(7)
   }
 
   private fun ruleForNewPrisoners(): LocalDate {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateServiceTest.kt
@@ -122,6 +122,24 @@ internal class NextReviewDateServiceTest {
     }
 
     @Test
+    fun `when last two IEP levels were Basic but is "young person", returns +14 days`() {
+      val input = NextReviewDateInput(
+        iepDetails = listOf(
+          iepDetail(iepLevel = "Basic", iepTime = LocalDateTime.now()),
+          iepDetail(iepLevel = "Basic", iepTime = LocalDateTime.now().minusDays(10)),
+        ),
+        hasAcctOpen = false,
+        dateOfBirth = LocalDate.now().minusYears(16),
+        receptionDate = LocalDate.now(),
+      )
+      val expectedNextReviewDate = input.iepDetails[0].iepDate.plusDays(14)
+
+      val nextReviewDate = NextReviewDateService(input).calculate()
+
+      assertThat(nextReviewDate).isEqualTo(expectedNextReviewDate)
+    }
+
+    @Test
     fun `when IEP level is Basic, previous review is at different level but has open ACCT, returns +7 days`() {
       val input = NextReviewDateInput(
         iepDetails = listOf(


### PR DESCRIPTION
> [...] if not suitable to return to Standard level further reviews must
> be undertaken at least every 28 days thereafter.
>
> Exception for those identified as at Risk of Suicide and Self-harm (ACCT)
> and for young people, where further reviews must be undertaken at least
> every 14 days thereafter

This change adds this exception for "young people" to the 'Basic' rule.