### PR TITLE
INC-820: Next review date calculation only takes in consideration real reviews

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IepSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IepSummary.kt
@@ -76,7 +76,7 @@ data class IepDetail(
   override val reviewType: ReviewType? = null,
   @Schema(description = "Internal audit field holding which system/screen recorded the review", required = true, example = "INCENTIVES_API")
   val auditModuleName: String? = null,
-): IsRealReview
+) : IsRealReview
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Current IEP Level")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IepSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IepSummary.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
-import uk.gov.justice.digital.hmpps.incentivesapi.jpa.ReviewType
 import uk.gov.justice.digital.hmpps.incentivesapi.util.ensure
 import java.time.Clock
 import java.time.Duration
@@ -74,10 +73,10 @@ data class IepDetail(
   @Schema(description = "Username of the reviewer", required = true, example = "USER_1_GEN")
   val userId: String?,
   @Schema(description = "Type of IEP Level change", required = true, example = "REVIEW")
-  val reviewType: ReviewType? = null,
+  override val reviewType: ReviewType? = null,
   @Schema(description = "Internal audit field holding which system/screen recorded the review", required = true, example = "INCENTIVES_API")
   val auditModuleName: String? = null,
-)
+): IsRealReview
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Current IEP Level")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/ReviewType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/ReviewType.kt
@@ -14,5 +14,4 @@ interface IsRealReview {
     // Eventually all reviews will come from our DB and have a "review type".
     return reviewType == null || listOf(ReviewType.REVIEW, ReviewType.MIGRATED).contains(reviewType)
   }
-
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/ReviewType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/ReviewType.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.incentivesapi.dto
+
+enum class ReviewType {
+  INITIAL, REVIEW, TRANSFER, MIGRATED
+}
+
+interface IsRealReview {
+  val reviewType: ReviewType?
+
+  fun isRealReview(): Boolean {
+    // NOTE: Reviews from NOMIS wouldn't have a review type.
+    // We consider these and `MIGRATED` reviews as "real" as we don't have a way to discriminate
+    // real incentives reviews in these cases.
+    // Eventually all reviews will come from our DB and have a "review type".
+    return reviewType == null || listOf(ReviewType.REVIEW, ReviewType.MIGRATED).contains(reviewType)
+  }
+
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/PrisonerIepLevel.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/PrisonerIepLevel.kt
@@ -4,6 +4,8 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.annotation.Id
 import org.springframework.data.annotation.Transient
 import org.springframework.data.domain.Persistable
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.IsRealReview
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
 import java.time.LocalDateTime
 
 data class PrisonerIepLevel(
@@ -19,7 +21,7 @@ data class PrisonerIepLevel(
   val iepCode: String,
   val commentText: String? = null,
   val current: Boolean = true,
-  val reviewType: ReviewType = ReviewType.REVIEW,
+  override val reviewType: ReviewType = ReviewType.REVIEW,
 
   @Transient
   @Value("false")
@@ -27,13 +29,10 @@ data class PrisonerIepLevel(
 
   val whenCreated: LocalDateTime? = null
 
-) : Persistable<Long> {
+) : Persistable<Long>, IsRealReview {
 
   override fun isNew(): Boolean = new
 
   override fun getId(): Long = id
 }
 
-enum class ReviewType {
-  INITIAL, REVIEW, TRANSFER, MIGRATED,
-}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/PrisonerIepLevel.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/PrisonerIepLevel.kt
@@ -35,4 +35,3 @@ data class PrisonerIepLevel(
 
   override fun getId(): Long = id
 }
-

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveSummaryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveSummaryService.kt
@@ -16,7 +16,7 @@ import uk.gov.justice.digital.hmpps.incentivesapi.dto.PrisonerIncentiveSummary
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.CaseNoteUsage
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.IepLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.ProvenAdjudication
-import uk.gov.justice.digital.hmpps.incentivesapi.jpa.ReviewType
+import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonerIepLevelRepository
 import java.time.Clock
 import java.time.Duration
@@ -157,12 +157,7 @@ class IncentiveSummaryService(
       .groupBy { it.bookingId }
       .map {
         val review = it.value
-        val latestReview = review.firstOrNull { possibleReview ->
-          possibleReview.reviewType in listOf(
-            ReviewType.REVIEW,
-            ReviewType.MIGRATED
-          )
-        }
+        val latestReview = review.firstOrNull(PrisonerIepLevel::isRealReview)
         IepResult(
           bookingId = it.key,
           iepLevel = latestReview?.let { incentiveLevels[latestReview.iepCode]?.iepDescription ?: "Unmapped" }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateService.kt
@@ -65,25 +65,29 @@ class NextReviewDateService(private val input: NextReviewDateInput) {
     return ageOnDate < 18
   }
 
-  private fun lastReview(): IepDetail {
-    return input.iepDetails.first()
+  private fun lastReview(): IepDetail? {
+    return reviews().firstOrNull()
   }
 
   private fun isOnBasic(): Boolean {
-    return lastReview().iepLevel == BASIC
+    return lastReview()?.iepLevel == BASIC
   }
 
   private fun lastReviewDate(): LocalDate {
-    return lastReview().iepDate
+    return lastReview()?.iepDate ?: input.receptionDate
   }
 
   private fun wasConfirmedBasic(): Boolean {
-    val iepDetails = input.iepDetails
+    val reviews = reviews()
 
-    return isOnBasic() && iepDetails.size >= 2 && iepDetails[1].iepLevel == BASIC
+    return isOnBasic() && reviews.size >= 2 && reviews[1].iepLevel == BASIC
   }
 
   private fun isNewPrisoner(): Boolean {
-    return input.iepDetails.isEmpty()
+    return reviews().isEmpty()
+  }
+
+  private fun reviews(): List<IepDetail> {
+    return input.iepDetails.filter(IepDetail::isRealReview)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -26,7 +26,7 @@ import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.IepReviewInNomis
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.Location
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.PrisonerAtLocation
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
-import uk.gov.justice.digital.hmpps.incentivesapi.jpa.ReviewType
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonerIepLevelRepository
 import java.time.Clock
 import java.time.LocalDateTime

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.incentivesapi.dto.CurrentIepLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepDetail
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepReview
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepSummary
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.SyncPatchRequest
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.SyncPostRequest
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.IepLevel
@@ -26,7 +27,6 @@ import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.IepReviewInNomis
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.Location
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.PrisonerAtLocation
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
-import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonerIepLevelRepository
 import java.time.Clock
 import java.time.LocalDateTime

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IsRealReviewTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IsRealReviewTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test
 
 internal class IsRealReviewTest {
 
-  inner class SomeReviewClass(override val reviewType: ReviewType?): IsRealReview
+  inner class SomeReviewClass(override val reviewType: ReviewType?) : IsRealReview
 
   @Test
   fun `when reviewType is REVIEW it is a real review`() {
@@ -36,5 +36,4 @@ internal class IsRealReviewTest {
     val review = SomeReviewClass(reviewType = ReviewType.TRANSFER)
     assertThat(review.isRealReview()).isFalse
   }
-
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IsRealReviewTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IsRealReviewTest.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.incentivesapi.dto
+
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.jupiter.api.Test
+
+internal class IsRealReviewTest {
+
+  inner class SomeReviewClass(override val reviewType: ReviewType?): IsRealReview
+
+  @Test
+  fun `when reviewType is REVIEW it is a real review`() {
+    val review = SomeReviewClass(reviewType = ReviewType.REVIEW)
+    assertThat(review.isRealReview()).isTrue
+  }
+
+  @Test
+  fun `when reviewType is null review (eg data coming from NOMIS) is considered real`() {
+    val review = SomeReviewClass(reviewType = null)
+    assertThat(review.isRealReview()).isTrue
+  }
+
+  @Test
+  fun `when reviewType is MIGRATED (eg data migrated from NOMIS) is considered real`() {
+    val review = SomeReviewClass(reviewType = ReviewType.MIGRATED)
+    assertThat(review.isRealReview()).isTrue
+  }
+
+  @Test
+  fun `when reviewType is INITIAL (admission) it is not considered real review`() {
+    val review = SomeReviewClass(reviewType = ReviewType.INITIAL)
+    assertThat(review.isRealReview()).isFalse
+  }
+
+  @Test
+  fun `when reviewType is TRANSFER it is not considered real review`() {
+    val review = SomeReviewClass(reviewType = ReviewType.TRANSFER)
+    assertThat(review.isRealReview()).isFalse
+  }
+
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/service/PrisonOffenderEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/service/PrisonOffenderEventListenerIntTest.kt
@@ -11,9 +11,9 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
 import uk.gov.justice.digital.hmpps.incentivesapi.integration.SqsIntegrationTestBase
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
-import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonerIepLevelRepository
 import uk.gov.justice.digital.hmpps.incentivesapi.service.AdditionalInformation
 import uk.gov.justice.digital.hmpps.incentivesapi.service.HMPPSDomainEvent

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/service/PrisonOffenderEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/service/PrisonOffenderEventListenerIntTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.incentivesapi.integration.SqsIntegrationTestBase
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
-import uk.gov.justice.digital.hmpps.incentivesapi.jpa.ReviewType
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonerIepLevelRepository
 import uk.gov.justice.digital.hmpps.incentivesapi.service.AdditionalInformation
 import uk.gov.justice.digital.hmpps.incentivesapi.service.HMPPSDomainEvent

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepReview
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.SyncPostRequest
 import uk.gov.justice.digital.hmpps.incentivesapi.integration.SqsIntegrationTestBase
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
-import uk.gov.justice.digital.hmpps.incentivesapi.jpa.ReviewType
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonerIepLevelRepository
 import java.time.LocalDate.now
 import java.time.LocalDateTime

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
@@ -9,10 +9,10 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepReview
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.SyncPostRequest
 import uk.gov.justice.digital.hmpps.incentivesapi.integration.SqsIntegrationTestBase
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
-import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonerIepLevelRepository
 import java.time.LocalDate.now
 import java.time.LocalDateTime

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResourceTest.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.incentivesapi.integration.SqsIntegrationTestBase
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
-import uk.gov.justice.digital.hmpps.incentivesapi.jpa.ReviewType
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonerIepLevelRepository
 import java.time.LocalDateTime
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResourceTest.kt
@@ -6,9 +6,9 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
 import uk.gov.justice.digital.hmpps.incentivesapi.integration.SqsIntegrationTestBase
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
-import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonerIepLevelRepository
 import java.time.LocalDateTime
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveSummaryMasteredResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveSummaryMasteredResourceTest.kt
@@ -7,9 +7,9 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Primary
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
 import uk.gov.justice.digital.hmpps.incentivesapi.integration.SqsIntegrationTestBase
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
-import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonerIepLevelRepository
 import java.time.Clock
 import java.time.Instant

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveSummaryMasteredResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveSummaryMasteredResourceTest.kt
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Primary
 import uk.gov.justice.digital.hmpps.incentivesapi.integration.SqsIntegrationTestBase
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
-import uk.gov.justice.digital.hmpps.incentivesapi.jpa.ReviewType
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonerIepLevelRepository
 import java.time.Clock
 import java.time.Instant

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepDetail
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepReview
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepSummary
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.OffenderSearchPrisoner
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.SyncPatchRequest
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.SyncPostRequest
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.IepLevel
@@ -31,7 +32,6 @@ import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.IepReviewInNomis
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.Location
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.PrisonerAtLocation
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
-import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonerIepLevelRepository
 import java.time.Clock
 import java.time.Instant

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
@@ -31,7 +31,7 @@ import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.IepReviewInNomis
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.Location
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.PrisonerAtLocation
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
-import uk.gov.justice.digital.hmpps.incentivesapi.jpa.ReviewType
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonerIepLevelRepository
 import java.time.Clock
 import java.time.Instant


### PR DESCRIPTION
If reviews come from our database they'll have a `reviewType`.
- if this is `REVIEW` they're real reviews
- if this is `MIGRATED` these were migrated from NOMIS and we assume they're
  "real"
- when the data is coming from Prison API/NOMIS (as it currently does
for the time being in production) we don't have the review type information
and we cannot discriminate but we consider them real reviews as in the case of `reviewType='MIGRATED'`
(ultimately this will not matter as we'll only get data from our DB and
these "legacy" reviews will have 'MIGRATED' type)