### PR TITLE
INC-903: Tidy up code

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IsRealReviewTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IsRealReviewTest.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.incentivesapi.dto
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
 import org.junit.jupiter.api.Test
 
-internal class IsRealReviewTest {
+class IsRealReviewTest {
 
   inner class SomeReviewClass(override val reviewType: ReviewType?) : IsRealReview
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/helper/JwtAuthHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/helper/JwtAuthHelper.kt
@@ -41,7 +41,7 @@ class JwtAuthHelper {
     return { it.set(HttpHeaders.AUTHORIZATION, "Bearer $token") }
   }
 
-  internal fun createJwt(
+  fun createJwt(
     subject: String?,
     scope: List<String>? = listOf(),
     roles: List<String>? = listOf(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/IntegrationTestBase.kt
@@ -18,7 +18,6 @@ import uk.gov.justice.digital.hmpps.incentivesapi.integration.wiremock.PrisonApi
 @ActiveProfiles("test")
 abstract class IntegrationTestBase : TestBase() {
 
-  @Suppress("SpringJavaInjectionPointsAutowiringInspection")
   @Autowired
   lateinit var webTestClient: WebTestClient
 
@@ -35,7 +34,6 @@ abstract class IntegrationTestBase : TestBase() {
     @JvmField
     val offenderSearchMockServer = OffenderSearchMockServer()
 
-    @Suppress("unused")
     @BeforeAll
     @JvmStatic
     fun startMocks() {
@@ -46,7 +44,6 @@ abstract class IntegrationTestBase : TestBase() {
       offenderSearchMockServer.start()
     }
 
-    @Suppress("unused")
     @AfterAll
     @JvmStatic
     fun stopMocks() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/IntegrationTestBase.kt
@@ -27,13 +27,13 @@ abstract class IntegrationTestBase : TestBase() {
 
   companion object {
     @JvmField
-    internal val prisonApiMockServer = PrisonApiMockServer()
+    val prisonApiMockServer = PrisonApiMockServer()
 
     @JvmField
-    internal val hmppsAuthMockServer = HmppsAuthMockServer()
+    val hmppsAuthMockServer = HmppsAuthMockServer()
 
     @JvmField
-    internal val offenderSearchMockServer = OffenderSearchMockServer()
+    val offenderSearchMockServer = OffenderSearchMockServer()
 
     @Suppress("unused")
     @BeforeAll
@@ -61,7 +61,7 @@ abstract class IntegrationTestBase : TestBase() {
     System.setProperty("http.keepAlive", "false")
   }
 
-  internal fun setAuthorisation(
+  protected fun setAuthorisation(
     user: String = "INCENTIVES_ADM",
     roles: List<String> = listOf(),
     scopes: List<String> = listOf()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/SqsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/SqsIntegrationTestBase.kt
@@ -34,8 +34,8 @@ class SqsIntegrationTestBase : IntegrationTestBase() {
   protected val domainEventsTopicSnsClient by lazy { domainEventsTopic.snsClient }
   protected val domainEventsTopicArn by lazy { domainEventsTopic.arn }
 
-  internal val auditQueue by lazy { hmppsQueueService.findByQueueId("audit") as HmppsQueue }
-  internal val incentivesQueue by lazy { hmppsQueueService.findByQueueId("incentives") as HmppsQueue }
+  protected val auditQueue by lazy { hmppsQueueService.findByQueueId("audit") as HmppsQueue }
+  protected val incentivesQueue by lazy { hmppsQueueService.findByQueueId("incentives") as HmppsQueue }
 
   fun HmppsSqsProperties.domaineventsTopicConfig() =
     topics["domainevents"] ?: throw MissingTopicException("domainevents has not been loaded from configuration properties")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/SqsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/SqsIntegrationTestBase.kt
@@ -48,6 +48,7 @@ class SqsIntegrationTestBase : IntegrationTestBase() {
   companion object {
     private val localStackContainer = LocalStackContainer.instance
 
+    @Suppress("unused")
     @JvmStatic
     @DynamicPropertySource
     fun testcontainers(registry: DynamicPropertyRegistry) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/SqsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/SqsIntegrationTestBase.kt
@@ -10,7 +10,6 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import uk.gov.justice.digital.hmpps.incentivesapi.integration.LocalStackContainer.setLocalStackProperties
-import uk.gov.justice.digital.hmpps.incentivesapi.service.PrisonOffenderEventListenerTest
 import uk.gov.justice.hmpps.sqs.HmppsQueue
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.HmppsSqsProperties
@@ -57,9 +56,6 @@ class SqsIntegrationTestBase : IntegrationTestBase() {
   }
 
   protected fun jsonString(any: Any) = objectMapper.writeValueAsString(any) as String
-  protected fun String.readResourceAsText(): String {
-    return PrisonOffenderEventListenerTest::class.java.getResource(this)?.readText() ?: throw AssertionError("can not find file")
-  }
 
   fun getNumberOfMessagesCurrentlyOnQueue(): Int? {
     val queueAttributes = incentivesQueue.sqsClient.getQueueAttributes(incentivesQueue.queueUrl, listOf("ApproximateNumberOfMessages"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/health/HealthCheckTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/health/HealthCheckTest.kt
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.incentivesapi.integration.SqsIntegrationTestBase
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
-import java.util.function.Consumer
 
 class HealthCheckTest : SqsIntegrationTestBase() {
 
@@ -27,11 +26,9 @@ class HealthCheckTest : SqsIntegrationTestBase() {
     webTestClient.get().uri("/health")
       .exchange()
       .expectStatus().isOk
-      .expectBody().jsonPath("components.healthInfo.details.version").value(
-        Consumer<String> {
-          assertThat(it).startsWith(LocalDateTime.now().format(DateTimeFormatter.ISO_DATE))
-        }
-      )
+      .expectBody().jsonPath("components.healthInfo.details.version").value<String> {
+        assertThat(it).startsWith(LocalDateTime.now().format(DateTimeFormatter.ISO_DATE))
+      }
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/service/PrisonOffenderEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/service/PrisonOffenderEventListenerIntTest.kt
@@ -21,7 +21,7 @@ import java.time.Duration
 import java.time.Instant
 import java.time.LocalDateTime
 
-internal class PrisonOffenderEventListenerIntTest : SqsIntegrationTestBase() {
+class PrisonOffenderEventListenerIntTest : SqsIntegrationTestBase() {
 
   @Autowired
   private lateinit var repository: PrisonerIepLevelRepository

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/wiremock/OffenderSearchMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/wiremock/OffenderSearchMockServer.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.incentivesapi.integration.wiremock
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
@@ -15,6 +15,8 @@ class OffenderSearchMockServer : WireMockServer(WIREMOCK_PORT) {
     private const val WIREMOCK_PORT = 8094
   }
 
+  private val mapper = ObjectMapper().findAndRegisterModules()
+
   fun stubHealthPing(status: Int) {
     stubFor(
       get("/health/ping").willReturn(
@@ -27,7 +29,6 @@ class OffenderSearchMockServer : WireMockServer(WIREMOCK_PORT) {
   }
 
   fun stubFindOffenders(prisonId: String = "MDI", wing: String = "1", includeInvalid: Boolean = false) {
-    val mapper = jacksonObjectMapper().findAndRegisterModules()
     // <editor-fold desc="mocked offenders">
     val offenders = mutableListOf(
       OffenderSearchPrisoner(
@@ -169,7 +170,6 @@ class OffenderSearchMockServer : WireMockServer(WIREMOCK_PORT) {
       ),
     ) else emptyList()
 
-    val mapper = jacksonObjectMapper().findAndRegisterModules()
     stubFor(
       get("/prisoner/$prisonerNumber").willReturn(
         aResponse()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
@@ -35,7 +35,7 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
   }
 
   @Test
-  internal fun `requires a valid token to retrieve data`() {
+  fun `requires a valid token to retrieve data`() {
     webTestClient.get()
       .uri("/iep/levels/MDI")
       .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResourceTest.kt
@@ -17,7 +17,7 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
   private lateinit var repository: PrisonerIepLevelRepository
 
   @BeforeEach
-  internal fun setUp(): Unit = runBlocking {
+  fun setUp(): Unit = runBlocking {
     offenderSearchMockServer.resetAll()
     prisonApiMockServer.resetAll()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveSummaryMasteredResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveSummaryMasteredResourceTest.kt
@@ -20,7 +20,7 @@ import java.time.ZoneId
 class IncentiveSummaryMasteredResourceTest : SqsIntegrationTestBase() {
 
   @TestConfiguration
-  internal class FixedClockConfig {
+  class FixedClockConfig {
     @Primary
     @Bean
     fun fixedClock(): Clock {
@@ -35,7 +35,7 @@ class IncentiveSummaryMasteredResourceTest : SqsIntegrationTestBase() {
   private lateinit var repository: PrisonerIepLevelRepository
 
   @BeforeEach
-  internal fun setUp(): Unit = runBlocking {
+  fun setUp(): Unit = runBlocking {
     prisonApiMockServer.resetAll()
 
     // Prisoner A1234AA has 2 incentive entries current BAS

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveSummaryResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveSummaryResourceTest.kt
@@ -14,7 +14,7 @@ import java.time.ZoneId
 @ActiveProfiles("test", "test-nomis")
 class IncentiveSummaryResourceTest : SqsIntegrationTestBase() {
   @TestConfiguration
-  internal class FixedClockConfig {
+  class FixedClockConfig {
     @Primary
     @Bean
     fun fixedClock(): Clock {
@@ -25,7 +25,7 @@ class IncentiveSummaryResourceTest : SqsIntegrationTestBase() {
     }
   }
   @BeforeEach
-  internal fun setUp() {
+  fun setUp() {
     prisonApiMockServer.resetAll()
   }
 
@@ -42,7 +42,7 @@ class IncentiveSummaryResourceTest : SqsIntegrationTestBase() {
   }
 
   @Test
-  internal fun `requires a valid token to retrieve data`() {
+  fun `requires a valid token to retrieve data`() {
     webTestClient.get()
       .uri("/incentives-summary/prison/MDI/location/MDI-1")
       .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/OpenApiDocsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/OpenApiDocsTest.kt
@@ -1,4 +1,3 @@
-
 package uk.gov.justice.digital.hmpps.incentivesapi.resource
 
 import io.swagger.v3.parser.OpenAPIV3Parser
@@ -6,7 +5,7 @@ import net.minidev.json.JSONArray
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.web.server.LocalServerPort
+import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.incentivesapi.integration.SqsIntegrationTestBase

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/OpenApiDocsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/OpenApiDocsTest.kt
@@ -12,7 +12,6 @@ import uk.gov.justice.digital.hmpps.incentivesapi.integration.SqsIntegrationTest
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
-@Suppress("SpringJavaInjectionPointsAutowiringInspection")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 class OpenApiDocsTest : SqsIntegrationTestBase() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateServiceTest.kt
@@ -7,7 +7,7 @@ import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepDetail
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
 import java.time.LocalDate
 
-internal class NextReviewDateServiceTest {
+class NextReviewDateServiceTest {
 
   @Test
   fun `when IEP level is not Basic, returns +1 year`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonOffenderEventListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonOffenderEventListenerTest.kt
@@ -23,7 +23,7 @@ class PrisonOffenderEventListenerTest {
   }
 
   @BeforeEach
-  internal fun setUp() {
+  fun setUp() {
     listener = PrisonOffenderEventListener(prisonerIepLevelReviewService, objectMapper)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonOffenderEventListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonOffenderEventListenerTest.kt
@@ -2,8 +2,6 @@ package uk.gov.justice.digital.hmpps.incentivesapi.service
 
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeEach
@@ -17,9 +15,8 @@ import org.mockito.kotlin.verifyNoInteractions
 class PrisonOffenderEventListenerTest {
   private lateinit var listener: PrisonOffenderEventListener
   private val prisonerIepLevelReviewService: PrisonerIepLevelReviewService = mock()
-  private val objectMapper: ObjectMapper = ObjectMapper().registerKotlinModule().apply {
-    this.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-    this.registerModule(JavaTimeModule())
+  private val objectMapper = ObjectMapper().findAndRegisterModules().apply {
+    configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
   }
 
   @BeforeEach


### PR DESCRIPTION
Mostly: `internal` visibility modifier is effectively "public" because this only contains one module, so it might as well be removed or replaced with something more private.
Minor tidy-up: removal of unnecessary suppressions, import fix, more consistent use of object mappers in tests.