### PR TITLE
INC-921: Fix situation during migration where assigned living unit is not known

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -130,7 +130,7 @@ class PrisonerIepLevelReviewService(
   ): IepDetail {
     val prisonerInfo = prisonApiService.getPrisonerInfo(bookingId, true)
     var locationInfo: Location? = null
-    if (includeLocation) {
+    if (includeLocation && prisonerInfo.assignedLivingUnitId > 0) {
       locationInfo = prisonApiService.getLocationById(prisonerInfo.assignedLivingUnitId, true)
     }
 


### PR DESCRIPTION
`assignedLivingUnitId` can be 0 which is not a location that can be looked up in prison-api (cf. `GET /api/bookings/{bookingId}`)