### PR TITLE
INC-817: Store next review date in the database

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/HmppsIncentivesApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/HmppsIncentivesApiExceptionHandler.kt
@@ -153,20 +153,6 @@ class HmppsIncentivesApiExceptionHandler {
       )
   }
 
-  @ExceptionHandler(ListOfDataNotFoundException::class)
-  fun handleListOfDataNotFoundException(e: ListOfDataNotFoundException): ResponseEntity<ErrorResponse?>? {
-    log.debug("No data found exception caught: {}", e.message)
-    return ResponseEntity
-      .status(NOT_FOUND)
-      .body(
-        ErrorResponse(
-          status = NOT_FOUND,
-          userMessage = "Not Found: ${e.message}",
-          developerMessage = e.message
-        )
-      )
-  }
-
   @ExceptionHandler(DataIntegrityException::class)
   fun handleDataIntegrityException(e: DataIntegrityException): ResponseEntity<ErrorResponse?>? {
     log.error("Data integrity exception: {}", e.message)
@@ -230,9 +216,6 @@ class HmppsIncentivesApiExceptionHandler {
 
 class NoDataFoundException(id: Long) :
   Exception("No Data found for ID $id")
-
-class ListOfDataNotFoundException(ids: Collection<Long>) :
-  Exception("No Data found for ID(s) $ids")
 
 class DataIntegrityException(message: String) :
   Exception(message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/NextReviewDate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/NextReviewDate.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.incentivesapi.jpa
 
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.ReadOnlyProperty
 import org.springframework.data.annotation.Transient
 import org.springframework.data.domain.Persistable
 import java.time.LocalDate
@@ -13,6 +14,7 @@ data class NextReviewDate(
 
   val nextReviewDate: LocalDate,
 
+  @ReadOnlyProperty
   val whenCreated: LocalDateTime? = null,
 
   @Transient

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/NextReviewDate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/NextReviewDate.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.incentivesapi.jpa
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.Transient
+import org.springframework.data.domain.Persistable
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class NextReviewDate(
+  @Id
+  val bookingId: Long,
+
+  val nextReviewDate: LocalDate,
+
+  val whenCreated: LocalDateTime? = null,
+
+  @Transient
+  @Value("false")
+  val new: Boolean = true,
+) : Persistable<Long> {
+  override fun getId(): Long = bookingId
+  override fun isNew(): Boolean = new
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/NextReviewDateRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/NextReviewDateRepository.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository
+
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.incentivesapi.jpa.NextReviewDate
+
+@Repository
+interface NextReviewDateRepository : CoroutineCrudRepository<NextReviewDate, Long>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonerIepLevelRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonerIepLevelRepository.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository
 
 import kotlinx.coroutines.flow.Flow
-import org.springframework.data.r2dbc.repository.Query
 import org.springframework.data.repository.kotlin.CoroutineCrudRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
@@ -13,7 +12,4 @@ interface PrisonerIepLevelRepository : CoroutineCrudRepository<PrisonerIepLevel,
   fun findAllByBookingIdInAndCurrentIsTrueOrderByReviewTimeDesc(bookingIds: List<Long>): Flow<PrisonerIepLevel>
   fun findAllByBookingIdInOrderByReviewTimeDesc(bookingIds: List<Long>): Flow<PrisonerIepLevel>
   suspend fun findFirstByBookingIdOrderByReviewTimeDesc(bookingId: Long): PrisonerIepLevel?
-
-  @Query("SELECT DISTINCT(booking_id) FROM prisoner_iep_level")
-  suspend fun getAllBookingIds(): Flow<Long>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonerIepLevelRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonerIepLevelRepository.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository
 
 import kotlinx.coroutines.flow.Flow
+import org.springframework.data.r2dbc.repository.Query
 import org.springframework.data.repository.kotlin.CoroutineCrudRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
@@ -12,4 +13,7 @@ interface PrisonerIepLevelRepository : CoroutineCrudRepository<PrisonerIepLevel,
   fun findAllByBookingIdInAndCurrentIsTrueOrderByReviewTimeDesc(bookingIds: List<Long>): Flow<PrisonerIepLevel>
   fun findAllByBookingIdInOrderByReviewTimeDesc(bookingIds: List<Long>): Flow<PrisonerIepLevel>
   suspend fun findFirstByBookingIdOrderByReviewTimeDesc(bookingId: Long): PrisonerIepLevel?
+
+  @Query("SELECT DISTINCT(booking_id) FROM prisoner_iep_level")
+  suspend fun getAllBookingIds(): Flow<Long>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateGetterService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateGetterService.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.incentivesapi.service
+
+import kotlinx.coroutines.flow.toList
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.OffenderSearchPrisoner
+import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.NextReviewDateRepository
+import java.time.LocalDate
+
+/**
+ * Get the next review dates for the given offender(s). Calculates/persists these if not present in the database.
+ */
+@Service
+class NextReviewDateGetterService(
+  private val nextReviewDateRepository: NextReviewDateRepository,
+  private val prisonApiService: PrisonApiService,
+  private val offenderSearchService: OffenderSearchService,
+  private val nextReviewDateUpdaterService: NextReviewDateUpdaterService,
+) {
+
+  suspend fun get(bookingId: Long): LocalDate {
+    return nextReviewDateRepository.findById(bookingId)?.nextReviewDate ?: run {
+      val locationInfo = prisonApiService.getPrisonerInfo(bookingId, useClientCredentials = true)
+      val prisonerNumber = locationInfo.offenderNo
+      val offender = offenderSearchService.getOffender(prisonerNumber)
+
+      return getMany(listOf(offender))[offender.bookingId]!!
+    }
+  }
+
+  /**
+   * Get the next review dates for the given offender(s)
+   *
+   * Tries to get next review dates from the database. For bookingIds without a next review date record it calculates
+   * and persist the next review dates before returning it with the ones already present.
+   *
+   * @param offenders is the list of offenders to get the next review dates for
+   *
+   * @return a Map with bookingIds as keys and next review dates as values
+   */
+  suspend fun getMany(offenders: List<OffenderSearchPrisoner>): Map<Long, LocalDate> {
+    val bookingIds = offenders.map(OffenderSearchPrisoner::bookingId)
+    var existingNextReviewDates = nextReviewDateRepository.findAllById(bookingIds).toList().toMap()
+
+    val bookingIdsWithDate = existingNextReviewDates.keys
+    val bookingIdsWithoutDate = bookingIds.subtract(bookingIdsWithDate)
+
+    val offendersWithoutDate = offenders.filter { offender -> offender.bookingId in bookingIdsWithoutDate }
+
+    val newNextReviewDates = nextReviewDateUpdaterService.updateMany(offendersWithoutDate)
+
+    return existingNextReviewDates + newNextReviewDates
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateGetterService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateGetterService.kt
@@ -39,7 +39,7 @@ class NextReviewDateGetterService(
    */
   suspend fun getMany(offenders: List<OffenderSearchPrisoner>): Map<Long, LocalDate> {
     val bookingIds = offenders.map(OffenderSearchPrisoner::bookingId)
-    val existingNextReviewDates = nextReviewDateRepository.findAllById(bookingIds).toList().toMap()
+    val existingNextReviewDates = nextReviewDateRepository.findAllById(bookingIds).toList().toMapByBookingId()
 
     val bookingIdsWithDate = existingNextReviewDates.keys
     val bookingIdsWithoutDate = bookingIds.subtract(bookingIdsWithDate)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateGetterService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateGetterService.kt
@@ -39,7 +39,7 @@ class NextReviewDateGetterService(
    */
   suspend fun getMany(offenders: List<OffenderSearchPrisoner>): Map<Long, LocalDate> {
     val bookingIds = offenders.map(OffenderSearchPrisoner::bookingId)
-    var existingNextReviewDates = nextReviewDateRepository.findAllById(bookingIds).toList().toMap()
+    val existingNextReviewDates = nextReviewDateRepository.findAllById(bookingIds).toList().toMap()
 
     val bookingIdsWithDate = existingNextReviewDates.keys
     val bookingIdsWithoutDate = bookingIds.subtract(bookingIdsWithDate)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterService.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.incentivesapi.service
 
 import kotlinx.coroutines.flow.toList
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepDetail
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.OffenderSearchPrisoner
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.IepLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.NextReviewDate
@@ -84,23 +83,4 @@ class NextReviewDateUpdaterService(
 
     return nextReviewDateRecords.toMap()
   }
-}
-
-fun List<PrisonerIepLevel>.toIepDetails(iepLevels: Map<String, IepLevel>): List<IepDetail> {
-  return this.map { review ->
-    IepDetail(
-      bookingId = review.bookingId,
-      prisonerNumber = review.prisonerNumber,
-      iepCode = review.iepCode,
-      iepLevel = iepLevels[review.iepCode]?.iepDescription ?: "Unmapped",
-      iepTime = review.reviewTime,
-      iepDate = review.reviewTime.toLocalDate(),
-      agencyId = review.prisonId,
-      userId = review.reviewedBy,
-    )
-  }
-}
-
-fun List<NextReviewDate>.toMap(): Map<Long, LocalDate> {
-  return this.associate { record -> Pair(record.bookingId, record.nextReviewDate) }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterService.kt
@@ -77,6 +77,7 @@ class NextReviewDateUpdaterService(
       NextReviewDate(
         bookingId = bookingId,
         nextReviewDate = nextReviewDate,
+        new = !nextReviewDateRepository.existsById(bookingId),
       )
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.incentivesapi.service
 
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.toList
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.OffenderSearchPrisoner
@@ -79,7 +80,7 @@ class NextReviewDateUpdaterService(
       )
     }
 
-    nextReviewDateRepository.saveAll(nextReviewDateRecords)
+    nextReviewDateRepository.saveAll(nextReviewDateRecords).collect()
 
     return nextReviewDateRecords.toMap()
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterService.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.incentivesapi.service
 
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.toList
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.OffenderSearchPrisoner
@@ -81,8 +80,6 @@ class NextReviewDateUpdaterService(
       )
     }
 
-    nextReviewDateRepository.saveAll(nextReviewDateRecords).collect()
-
-    return nextReviewDateRecords.toMap()
+    return nextReviewDateRepository.saveAll(nextReviewDateRecords).toList().toMap()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterService.kt
@@ -19,7 +19,23 @@ class NextReviewDateUpdaterService(
   private val prisonerIepLevelRepository: PrisonerIepLevelRepository,
   private val nextReviewDateRepository: NextReviewDateRepository,
   private val prisonApiService: PrisonApiService,
+  private val offenderSearchService: OffenderSearchService,
 ) {
+
+  /**
+   * Update next review date for the given bookingId
+   *
+   * @param bookingId of the offender to update
+   *
+   * @return the nextReviewDate for the given bookingId
+   * */
+  suspend fun update(bookingId: Long): LocalDate {
+    val locationInfo = prisonApiService.getPrisonerInfo(bookingId, useClientCredentials = true)
+    val prisonerNumber = locationInfo.offenderNo
+    val offender = offenderSearchService.getOffender(prisonerNumber)
+
+    return updateMany(listOf(offender))[offender.bookingId]!!
+  }
 
   /**
    * Update next review date for the given offenders

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterService.kt
@@ -80,6 +80,6 @@ class NextReviewDateUpdaterService(
       )
     }
 
-    return nextReviewDateRepository.saveAll(nextReviewDateRecords).toList().toMap()
+    return nextReviewDateRepository.saveAll(nextReviewDateRecords).toList().toMapByBookingId()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterService.kt
@@ -1,0 +1,90 @@
+package uk.gov.justice.digital.hmpps.incentivesapi.service
+
+import kotlinx.coroutines.flow.toList
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepDetail
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.OffenderSearchPrisoner
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.IepLevel
+import uk.gov.justice.digital.hmpps.incentivesapi.jpa.NextReviewDate
+import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
+import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.NextReviewDateRepository
+import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonerIepLevelRepository
+import java.time.LocalDate
+
+/**
+ * Recalculates and persists next review dates
+ */
+@Service
+class NextReviewDateUpdaterService(
+  private val prisonerIepLevelRepository: PrisonerIepLevelRepository,
+  private val nextReviewDateRepository: NextReviewDateRepository,
+  private val prisonApiService: PrisonApiService,
+) {
+
+  /**
+   * Update next review date for the given offenders
+   *
+   * @param offenders is the list of offenders to update
+   *
+   * @return a map with bookingIds as keys and nextReviewDate as value
+   * */
+  suspend fun updateMany(offenders: List<OffenderSearchPrisoner>): Map<Long, LocalDate> {
+    if (offenders.isEmpty()) {
+      return emptyMap()
+    }
+
+    val offendersMap = offenders.associateBy(OffenderSearchPrisoner::bookingId)
+    val bookingIds = offendersMap.keys.toList()
+
+    val iepLevels: Map<String, IepLevel> = prisonApiService.getIncentiveLevels()
+
+    // NOTE: This is to account for bookingIds potentially without any review record
+    val bookingIdsNoReviews = bookingIds.associateWith { emptyList<PrisonerIepLevel>() }
+    val reviewsMap = bookingIdsNoReviews + prisonerIepLevelRepository.findAllByBookingIdInOrderByReviewTimeDesc(bookingIds)
+      .toList()
+      .groupBy(PrisonerIepLevel::bookingId)
+
+    val nextReviewDateRecords = reviewsMap.map {
+      val bookingId = it.key
+      val iepDetails = it.value.toIepDetails(iepLevels)
+      val offender = offendersMap[bookingId]!!
+
+      val nextReviewDate = NextReviewDateService(
+        NextReviewDateInput(
+          dateOfBirth = offender.dateOfBirth,
+          receptionDate = offender.receptionDate,
+          hasAcctOpen = offender.acctOpen,
+          iepDetails = iepDetails,
+        )
+      ).calculate()
+
+      NextReviewDate(
+        bookingId = bookingId,
+        nextReviewDate = nextReviewDate,
+      )
+    }
+
+    nextReviewDateRepository.saveAll(nextReviewDateRecords)
+
+    return nextReviewDateRecords.toMap()
+  }
+}
+
+fun List<PrisonerIepLevel>.toIepDetails(iepLevels: Map<String, IepLevel>): List<IepDetail> {
+  return this.map { review ->
+    IepDetail(
+      bookingId = review.bookingId,
+      prisonerNumber = review.prisonerNumber,
+      iepCode = review.iepCode,
+      iepLevel = iepLevels[review.iepCode]?.iepDescription ?: "Unmapped",
+      iepTime = review.reviewTime,
+      iepDate = review.reviewTime.toLocalDate(),
+      agencyId = review.prisonId,
+      userId = review.reviewedBy,
+    )
+  }
+}
+
+fun List<NextReviewDate>.toMap(): Map<Long, LocalDate> {
+  return this.associate { record -> Pair(record.bookingId, record.nextReviewDate) }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -474,7 +474,9 @@ class PrisonerIepLevelReviewService(
         .map { review -> review.copy(bookingId = remainingBookingId, current = false) }
 
     val reviewsToUpdate = merge(activeReviews, inactiveReviews)
-    prisonerIepLevelRepository.saveAll(reviewsToUpdate).collect()
+    reviewsToUpdate.collect {
+      prisonerIepLevelRepository.save(it)
+    }
     nextReviewDateUpdaterService.update(remainingBookingId)
 
     val numberUpdated = reviewsToUpdate.count()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -400,7 +400,7 @@ class PrisonerIepLevelReviewService(
   ): PrisonerIepLevel {
     updateIepLevelsWithCurrentFlagToFalse(prisonerInfo.bookingId)
 
-    return prisonerIepLevelRepository.save(
+    val review = prisonerIepLevelRepository.save(
       PrisonerIepLevel(
         iepCode = iepReview.iepLevel,
         commentText = iepReview.comment,
@@ -414,6 +414,10 @@ class PrisonerIepLevelReviewService(
         prisonerNumber = prisonerInfo.offenderNo
       )
     )
+
+    nextReviewDateUpdaterService.update(prisonerInfo.bookingId)
+
+    return review
   }
 
   private suspend fun publishDomainEvent(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -490,9 +490,8 @@ class PrisonerIepLevelReviewService(
         .map { review -> review.copy(bookingId = remainingBookingId, current = false) }
 
     val reviewsToUpdate = merge(activeReviews, inactiveReviews)
-    reviewsToUpdate.collect {
-      prisonerIepLevelRepository.save(it)
-    }
+    prisonerIepLevelRepository.saveAll(reviewsToUpdate)
+    nextReviewDateUpdaterService.update(remainingBookingId)
 
     val numberUpdated = reviewsToUpdate.count()
     if (numberUpdated > 0) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.incentivesapi.service
 
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.count
 import kotlinx.coroutines.flow.flattenMerge
 import kotlinx.coroutines.flow.flowOf
@@ -473,7 +474,7 @@ class PrisonerIepLevelReviewService(
         .map { review -> review.copy(bookingId = remainingBookingId, current = false) }
 
     val reviewsToUpdate = merge(activeReviews, inactiveReviews)
-    prisonerIepLevelRepository.saveAll(reviewsToUpdate)
+    prisonerIepLevelRepository.saveAll(reviewsToUpdate).collect()
     nextReviewDateUpdaterService.update(remainingBookingId)
 
     val numberUpdated = reviewsToUpdate.count()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -196,8 +196,10 @@ class PrisonerIepLevelReviewService(
       current = syncPatchRequest.current ?: prisonerIepLevel.current,
     )
 
-    val iepDetail = prisonerIepLevelRepository.save(prisonerIepLevel).translate(prisonApiService.getIncentiveLevels())
+    val updatedReview = prisonerIepLevelRepository.save(prisonerIepLevel)
+    nextReviewDateUpdaterService.update(updatedReview.bookingId)
 
+    val iepDetail = updatedReview.translate(prisonApiService.getIncentiveLevels())
     publishDomainEvent(iepDetail, IncentivesDomainEventType.IEP_REVIEW_UPDATED)
     publishAuditEvent(iepDetail, AuditType.IEP_REVIEW_UPDATED)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -219,6 +219,7 @@ class PrisonerIepLevelReviewService(
     }
 
     prisonerIepLevelRepository.delete(prisonerIepLevel)
+    nextReviewDateUpdaterService.update(bookingId)
 
     // If the deleted record had `current=true`, the latest IEP review becomes current
     prisonerIepLevel.current.let {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -457,23 +457,6 @@ class PrisonerIepLevelReviewService(
       }
   }
 
-  private suspend fun PrisonerIepLevel.translate(incentiveLevels: Map<String, IepLevel>) =
-    IepDetail(
-      id = id,
-      bookingId = bookingId,
-      iepDate = reviewTime.toLocalDate(),
-      iepTime = reviewTime,
-      agencyId = prisonId,
-      iepLevel = incentiveLevels[iepCode]?.iepDescription ?: "Unmapped",
-      iepCode = iepCode,
-      reviewType = reviewType,
-      comments = commentText,
-      userId = reviewedBy,
-      locationId = locationId,
-      prisonerNumber = prisonerNumber,
-      auditModuleName = "INCENTIVES_API",
-    )
-
   @Transactional
   suspend fun mergedPrisonerDetails(prisonerMergeEvent: HMPPSDomainEvent) {
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/adapters.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/adapters.kt
@@ -6,7 +6,7 @@ import uk.gov.justice.digital.hmpps.incentivesapi.jpa.NextReviewDate
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
 import java.time.LocalDate
 
-fun PrisonerIepLevel.translate(incentiveLevels: Map<String, IepLevel>) =
+fun PrisonerIepLevel.toIepDetail(incentiveLevels: Map<String, IepLevel>) =
   IepDetail(
     id = id,
     bookingId = bookingId,
@@ -24,9 +24,9 @@ fun PrisonerIepLevel.translate(incentiveLevels: Map<String, IepLevel>) =
   )
 
 fun List<PrisonerIepLevel>.toIepDetails(iepLevels: Map<String, IepLevel>): List<IepDetail> {
-  return map { review -> review.translate(iepLevels) }
+  return map { review -> review.toIepDetail(iepLevels) }
 }
 
-fun List<NextReviewDate>.toMap(): Map<Long, LocalDate> {
+fun List<NextReviewDate>.toMapByBookingId(): Map<Long, LocalDate> {
   return associate { it.bookingId to it.nextReviewDate }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/adapters.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/adapters.kt
@@ -24,9 +24,9 @@ fun PrisonerIepLevel.translate(incentiveLevels: Map<String, IepLevel>) =
   )
 
 fun List<PrisonerIepLevel>.toIepDetails(iepLevels: Map<String, IepLevel>): List<IepDetail> {
-  return this.map { review -> review.translate(iepLevels) }
+  return map { review -> review.translate(iepLevels) }
 }
 
 fun List<NextReviewDate>.toMap(): Map<Long, LocalDate> {
-  return this.associate { it.bookingId to it.nextReviewDate }
+  return associate { it.bookingId to it.nextReviewDate }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/adapters.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/adapters.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.incentivesapi.service
+
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepDetail
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.IepLevel
+import uk.gov.justice.digital.hmpps.incentivesapi.jpa.NextReviewDate
+import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
+import java.time.LocalDate
+
+fun PrisonerIepLevel.translate(incentiveLevels: Map<String, IepLevel>) =
+  IepDetail(
+    id = id,
+    bookingId = bookingId,
+    iepDate = reviewTime.toLocalDate(),
+    iepTime = reviewTime,
+    agencyId = prisonId,
+    iepLevel = incentiveLevels[iepCode]?.iepDescription ?: "Unmapped",
+    iepCode = iepCode,
+    reviewType = reviewType,
+    comments = commentText,
+    userId = reviewedBy,
+    locationId = locationId,
+    prisonerNumber = prisonerNumber,
+    auditModuleName = "INCENTIVES_API",
+  )
+
+fun List<PrisonerIepLevel>.toIepDetails(iepLevels: Map<String, IepLevel>): List<IepDetail> {
+  return this.map { review -> review.translate(iepLevels) }
+}
+
+fun List<NextReviewDate>.toMap(): Map<Long, LocalDate> {
+  return this.associate { record -> Pair(record.bookingId, record.nextReviewDate) }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/adapters.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/adapters.kt
@@ -28,5 +28,5 @@ fun List<PrisonerIepLevel>.toIepDetails(iepLevels: Map<String, IepLevel>): List<
 }
 
 fun List<NextReviewDate>.toMap(): Map<Long, LocalDate> {
-  return this.associate { record -> Pair(record.bookingId, record.nextReviewDate) }
+  return this.associate { it.bookingId to it.nextReviewDate }
 }

--- a/src/main/resources/db/migration/V1_18__next_review_date.sql
+++ b/src/main/resources/db/migration/V1_18__next_review_date.sql
@@ -1,0 +1,8 @@
+create table next_review_date
+(
+    booking_id       numeric PRIMARY KEY      not null,
+    next_review_date date                     not null,
+    when_created     timestamp with time zone not null default now()
+);
+
+create index next_review_date_idx on next_review_date (next_review_date);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/service/PrisonOffenderEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/service/PrisonOffenderEventListenerIntTest.kt
@@ -78,6 +78,7 @@ class PrisonOffenderEventListenerIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubIepLevels()
     prisonApiMockServer.stubAgenciesIepLevels(prisonId)
     prisonApiMockServer.stubGetPrisonerInfoByNoms(bookingId = bookingId, prisonerNumber = prisonerNumber, locationId = locationId)
+    prisonApiMockServer.stubGetPrisonerInfoByBooking(bookingId = bookingId, prisonerNumber = prisonerNumber, locationId = locationId)
     prisonApiMockServer.stubGetLocationById(locationId = locationId, locationDesc = "1-2-003")
     prisonApiMockServer.stubIEPSummaryForBooking(bookingId = bookingId)
     offenderSearchMockServer.stubGetOffender(prisonId, prisonerNumber, bookingId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/service/PrisonOffenderEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/service/PrisonOffenderEventListenerIntTest.kt
@@ -46,11 +46,14 @@ class PrisonOffenderEventListenerIntTest : SqsIntegrationTestBase() {
     // Given
     val bookingId = 1294134L
     val prisonerNumber = "A1244AB"
+    val prisonId = "MDI"
     val locationId = 77777L
     prisonApiMockServer.stubIepLevels()
-    prisonApiMockServer.stubAgenciesIepLevels("MDI")
+    prisonApiMockServer.stubAgenciesIepLevels(prisonId)
     prisonApiMockServer.stubGetPrisonerInfoByNoms(bookingId = bookingId, prisonerNumber = prisonerNumber, locationId = locationId)
     prisonApiMockServer.stubGetLocationById(locationId = locationId, locationDesc = "1-2-003")
+    prisonApiMockServer.stubGetPrisonerInfoByBooking(bookingId, prisonerNumber, locationId)
+    offenderSearchMockServer.stubGetOffender(prisonId, prisonerNumber, bookingId)
 
     // When
     publishPrisonerReceivedMessage(reason)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/service/PrisonOffenderEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/service/PrisonOffenderEventListenerIntTest.kt
@@ -80,7 +80,7 @@ class PrisonOffenderEventListenerIntTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubGetPrisonerInfoByNoms(bookingId = bookingId, prisonerNumber = prisonerNumber, locationId = locationId)
     prisonApiMockServer.stubGetLocationById(locationId = locationId, locationDesc = "1-2-003")
     prisonApiMockServer.stubIEPSummaryForBooking(bookingId = bookingId)
-    offenderSearchMockServer.stubGetOffender(prisonId, prisonerNumber)
+    offenderSearchMockServer.stubGetOffender(prisonId, prisonerNumber, bookingId)
 
     // When
     publishPrisonerReceivedMessage("TRANSFERRED")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/wiremock/OffenderSearchMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/wiremock/OffenderSearchMockServer.kt
@@ -160,7 +160,7 @@ class OffenderSearchMockServer : WireMockServer(WIREMOCK_PORT) {
     )
   }
 
-  fun stubGetOffender(prisonId: String, prisonerNumber: String, withOpenAcct: Boolean = true) {
+  fun stubGetOffender(prisonId: String, prisonerNumber: String, bookingId: Long, withOpenAcct: Boolean = true) {
     val alerts = if (withOpenAcct) listOf(
       OffenderSearchPrisonerAlert(
         alertType = "H",
@@ -178,7 +178,7 @@ class OffenderSearchMockServer : WireMockServer(WIREMOCK_PORT) {
             mapper.writeValueAsBytes(
               OffenderSearchPrisoner(
                 prisonerNumber = prisonerNumber,
-                bookingId = 110001,
+                bookingId = bookingId,
                 firstName = "JAMES",
                 middleNames = null,
                 lastName = "HALLS",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/NextReviewDateRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/NextReviewDateRepositoryTest.kt
@@ -1,0 +1,125 @@
+package uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository
+
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
+import org.junit.Assert
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.data.r2dbc.DataR2dbcTest
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.incentivesapi.helper.TestBase
+import uk.gov.justice.digital.hmpps.incentivesapi.jpa.NextReviewDate
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+@DataR2dbcTest
+@ActiveProfiles("test")
+@WithMockUser
+class NextReviewDateRepositoryTest : TestBase() {
+  @Autowired
+  lateinit var repository: NextReviewDateRepository
+
+  @BeforeEach
+  fun setUp(): Unit = runBlocking {
+    repository.deleteAll()
+  }
+
+  @AfterEach
+  fun tearDown(): Unit = runBlocking {
+    repository.deleteAll()
+  }
+
+  @Test
+  fun saveAndFindTest(): Unit = runBlocking {
+    val bookingId = 1234567L
+    val nextReviewDate = LocalDate.parse("2022-12-25")
+
+    repository.save(
+      NextReviewDate(bookingId, nextReviewDate)
+    )
+
+    coroutineScope {
+      val result: NextReviewDate? = repository.findById(bookingId)
+
+      assertThat(result).isNotNull
+
+      with(result) {
+        assertThat(this!!.nextReviewDate).isEqualTo(nextReviewDate)
+        assertThat(this!!.whenCreated).isCloseTo(LocalDateTime.now(), within(5, ChronoUnit.MINUTES))
+        assertThat(this!!.id).isEqualTo(bookingId)
+        assertThat(this!!.new).isFalse()
+      }
+    }
+  }
+
+  @Test
+  fun bookingIdPrimaryKeyConstraintTest(): Unit = runBlocking {
+    val bookingId = 1234567L
+
+    repository.save(
+      NextReviewDate(bookingId, LocalDate.parse("2022-12-25"))
+    )
+
+    Assert.assertThrows(DataIntegrityViolationException::class.java) {
+      runBlocking {
+        // Save another record with same bookingId fails because it's primary key
+        repository.save(
+          NextReviewDate(bookingId, LocalDate.parse("2030-01-31"))
+        )
+      }
+    }
+  }
+
+  @Test
+  fun updateExistingRecordTest(): Unit = runBlocking {
+    val bookingId = 1234567L
+    val updatedDate = LocalDate.parse("2030-01-31")
+
+    repository.save(
+      NextReviewDate(bookingId, LocalDate.parse("2022-12-25"))
+    )
+
+    // NOTE: Use value returned by `save()` yields unexpected results in conjunction with `copy()`
+    val existingRecord = repository.findById(bookingId)
+    repository.save(
+      existingRecord!!.copy(nextReviewDate = updatedDate)
+    )
+
+    val updatedRecord = repository.findById(bookingId)
+    assertThat(updatedRecord!!.nextReviewDate).isEqualTo(updatedDate)
+  }
+
+  @Test
+  fun findAllByIdTest(): Unit = runBlocking {
+    val reviewDates = mapOf(
+      123L to LocalDate.parse("2023-01-31"),
+      456L to LocalDate.parse("2023-02-28"),
+    )
+
+    for ((bookingId, reviewDate) in reviewDates.entries) {
+      repository.save(NextReviewDate(bookingId, reviewDate))
+    }
+
+    coroutineScope {
+      val bookingIds = reviewDates.keys.toList()
+      val result = repository.findAllById(bookingIds).toList()
+
+      assertThat(result.size).isEqualTo(reviewDates.size)
+
+      for ((index, bookingId) in bookingIds.withIndex()) {
+        with(result[index]) {
+          assertThat(this.bookingId).isEqualTo(bookingId)
+          assertThat(this.nextReviewDate).isEqualTo(reviewDates[bookingId])
+        }
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonerIepLevelRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonerIepLevelRepositoryTest.kt
@@ -27,6 +27,18 @@ class PrisonerIepLevelRepositoryTest : TestBase() {
   @Autowired
   lateinit var repository: PrisonerIepLevelRepository
 
+  private fun entity(bookingId: Long, current: Boolean): PrisonerIepLevel =
+    PrisonerIepLevel(
+      iepCode = "BAS",
+      prisonId = "LEI",
+      locationId = "LEI-1-1-001",
+      bookingId = bookingId,
+      current = current,
+      reviewedBy = "TEST_STAFF1",
+      reviewTime = LocalDateTime.now(),
+      prisonerNumber = "A1234AB",
+    )
+
   @BeforeEach
   fun setUp(): Unit = runBlocking {
     repository.deleteAll()
@@ -35,6 +47,20 @@ class PrisonerIepLevelRepositoryTest : TestBase() {
   @AfterEach
   fun tearDown(): Unit = runBlocking {
     repository.deleteAll()
+  }
+
+  @Test
+  fun `getAllBookingIds() returns all the bookingIds`(): Unit = runBlocking {
+    // Given some records
+    repository.save(entity(2, true))
+    repository.save(entity(4, true))
+    repository.save(entity(8, true))
+
+    // When I get the list of bookingIds
+    val bookingIds = repository.getAllBookingIds().toList().sorted()
+
+    // Then
+    assertThat(bookingIds).isEqualTo(listOf<Long>(2, 4, 8))
   }
 
   @Test
@@ -94,17 +120,6 @@ class PrisonerIepLevelRepositoryTest : TestBase() {
   @Nested
   inner class CurrentTrueConstraint {
     private val bookingId = 1234567L
-    private fun entity(bookingId: Long, current: Boolean): PrisonerIepLevel =
-      PrisonerIepLevel(
-        iepCode = "BAS",
-        prisonId = "LEI",
-        locationId = "LEI-1-1-001",
-        bookingId = bookingId,
-        current = current,
-        reviewedBy = "TEST_STAFF1",
-        reviewTime = LocalDateTime.now(),
-        prisonerNumber = "A1234AB",
-      )
 
     @Test
     fun `cannot persist another record for the same bookingId where current=true already exists`(): Unit = runBlocking {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonerIepLevelRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonerIepLevelRepositoryTest.kt
@@ -50,20 +50,6 @@ class PrisonerIepLevelRepositoryTest : TestBase() {
   }
 
   @Test
-  fun `getAllBookingIds() returns all the bookingIds`(): Unit = runBlocking {
-    // Given some records
-    repository.save(entity(2, true))
-    repository.save(entity(4, true))
-    repository.save(entity(8, true))
-
-    // When I get the list of bookingIds
-    val bookingIds = repository.getAllBookingIds().toList().sorted()
-
-    // Then
-    assertThat(bookingIds).isEqualTo(listOf<Long>(2, 4, 8))
-  }
-
-  @Test
   fun savePrisonerIepLevel(): Unit = runBlocking {
     val bookingId = 1234567L
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceForNomisDataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceForNomisDataTest.kt
@@ -37,7 +37,7 @@ class IepLevelResourceForNomisDataTest : SqsIntegrationTestBase() {
 
     prisonApiMockServer.stubIEPSummaryForBooking()
     prisonApiMockServer.stubGetPrisonerInfoByBooking(bookingId, prisonerNumber, locationId = 77778L)
-    offenderSearchMockServer.stubGetOffender(prisonId, prisonerNumber, withOpenAcct = false)
+    offenderSearchMockServer.stubGetOffender(prisonId, prisonerNumber, bookingId, withOpenAcct = false)
 
     val lastReviewDate = LocalDate.of(2021, 12, 2)
     val daysSinceReview = Duration.between(lastReviewDate.atStartOfDay(), now().atStartOfDay()).toDays().toInt()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
@@ -133,7 +133,7 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubGetPrisonerInfoByBooking(bookingId = bookingId, prisonerNumber = prisonerNumber, locationId = 77778L)
     prisonApiMockServer.stubGetLocationById(locationId = 77778L, locationDesc = "1-2-003")
     prisonApiMockServer.stubAddIep(bookingId = bookingId)
-    offenderSearchMockServer.stubGetOffender(prisonId, prisonerNumber, withOpenAcct = false)
+    offenderSearchMockServer.stubGetOffender(prisonId, prisonerNumber, bookingId, withOpenAcct = false)
 
     webTestClient.post().uri("/iep/reviews/booking/$bookingId")
       .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_IEP"), scopes = listOf("read", "write")))
@@ -177,12 +177,14 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
     val bookingId = 1294134L
     val prisonerNumber = "A1244AB"
     val prisonId = "MDI"
+    val locationId = 77777L
 
-    prisonApiMockServer.stubGetPrisonerInfoByNoms(bookingId = bookingId, prisonerNumber = prisonerNumber, locationId = 77777L)
-    prisonApiMockServer.stubGetLocationById(locationId = 77777L, locationDesc = "1-2-003")
+    prisonApiMockServer.stubGetPrisonerInfoByNoms(bookingId = bookingId, prisonerNumber = prisonerNumber, locationId = locationId)
+    prisonApiMockServer.stubGetPrisonerInfoByBooking(bookingId = bookingId, prisonerNumber = prisonerNumber, locationId = locationId)
+    prisonApiMockServer.stubGetLocationById(locationId = locationId, locationDesc = "1-2-003")
     prisonApiMockServer.stubAddIep(bookingId = bookingId)
     prisonApiMockServer.stubIepLevels()
-    offenderSearchMockServer.stubGetOffender(prisonId, prisonerNumber, withOpenAcct = false)
+    offenderSearchMockServer.stubGetOffender(prisonId, prisonerNumber, bookingId, withOpenAcct = false)
 
     webTestClient.post().uri("/iep/reviews/prisoner/$prisonerNumber")
       .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_IEP"), scopes = listOf("read", "write")))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
@@ -479,14 +479,18 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
 
     @Test
     fun `POST to sync endpoint when request valid creates the IEP review`() {
+      val locationId = 77778L
+
       // Given the bookingId is valid
       prisonApiMockServer.stubGetPrisonerInfoByBooking(
         bookingId = bookingId,
         prisonerNumber = prisonerNumber,
-        locationId = 77778L,
+        locationId = locationId,
       )
-      prisonApiMockServer.stubGetLocationById(locationId = 77778L, locationDesc = "1-2-003")
+      prisonApiMockServer.stubGetLocationById(locationId = locationId, locationDesc = "1-2-003")
       prisonApiMockServer.stubIepLevels()
+      prisonApiMockServer.stubGetPrisonerInfoByBooking(bookingId, prisonerNumber, locationId)
+      offenderSearchMockServer.stubGetOffender(requestBody.prisonId, prisonerNumber, bookingId)
 
       // API responds 201 Created with the created IEP review record
       val responseBytes = webTestClient.post().uri(syncCreateEndpoint)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
@@ -662,6 +662,11 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
       )
       prisonApiMockServer.stubGetLocationById(locationId = 77778L, locationDesc = "1-2-003")
       prisonApiMockServer.stubIepLevels()
+      offenderSearchMockServer.stubGetOffender(
+        prisonId = existingPrisonerIepLevel!!.prisonId,
+        prisonerNumber,
+        bookingId,
+      )
 
       // API responds 201 Created with the created IEP review record
       webTestClient.delete().uri(syncDeleteEndpoint)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
@@ -260,6 +260,11 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubGetLocationById(locationId = 77778L, locationDesc = "1-2-003")
     prisonApiMockServer.stubAddIep(bookingId = bookingId)
     prisonApiMockServer.stubIepLevels()
+    offenderSearchMockServer.stubGetOffender(
+      prisonId = "MDI",
+      prisonerNumber,
+      bookingId,
+    )
 
     webTestClient.post().uri("/iep/reviews/booking/$bookingId")
       .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_IEP"), scopes = listOf("read", "write")))
@@ -283,6 +288,11 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
     )
     prisonApiMockServer.stubGetLocationById(locationId = 77779L, locationDesc = "1-2-004")
     prisonApiMockServer.stubAddIep(bookingId = bookingId2)
+    offenderSearchMockServer.stubGetOffender(
+      prisonId = "MDI",
+      prisonerNumber2,
+      bookingId2,
+    )
 
     webTestClient.post().uri("/iep/reviews/booking/$bookingId2")
       .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_IEP"), scopes = listOf("read", "write")))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
@@ -559,6 +559,12 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
       val updatedComment = "Updated comment"
       val requestBody = mapOf("comment" to updatedComment)
       prisonApiMockServer.stubIepLevels()
+      prisonApiMockServer.stubGetPrisonerInfoByBooking(bookingId, prisonerNumber, 777L)
+      offenderSearchMockServer.stubGetOffender(
+        prisonId = existingPrisonerIepLevel!!.prisonId,
+        prisonerNumber,
+        bookingId,
+      )
 
       val expectedResponseBody = """
         {
@@ -605,6 +611,12 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
         "current" to updatedCurrent,
       )
       prisonApiMockServer.stubIepLevels()
+      prisonApiMockServer.stubGetPrisonerInfoByBooking(bookingId, prisonerNumber, locationId = 777L)
+      offenderSearchMockServer.stubGetOffender(
+        prisonId = existingPrisonerIepLevel!!.prisonId,
+        prisonerNumber,
+        bookingId,
+      )
 
       val expectedResponseBody = """
         {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResourceTest.kt
@@ -297,5 +297,4 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
         true,
       )
   }
-
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResourceTest.kt
@@ -148,6 +148,7 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubLocation("MDI-1")
     prisonApiMockServer.stubPositiveCaseNoteSummary()
     prisonApiMockServer.stubNegativeCaseNoteSummary()
+    prisonApiMockServer.stubIepLevels()
 
     webTestClient.get()
       .uri("/incentives-reviews/prison/MDI/location/MDI-1")
@@ -225,6 +226,7 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubApi404for("/api/locations/code/MDI-1")
     prisonApiMockServer.stubPositiveCaseNoteSummary()
     prisonApiMockServer.stubNegativeCaseNoteSummary()
+    prisonApiMockServer.stubIepLevels()
 
     webTestClient.get()
       .uri("/incentives-reviews/prison/MDI/location/MDI-1")
@@ -296,29 +298,4 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
       )
   }
 
-  @Test
-  fun `when insufficient data to calculate next review date`(): Unit = runBlocking {
-    offenderSearchMockServer.stubFindOffenders("MDI")
-    prisonApiMockServer.stubLocation("MDI-1")
-    prisonApiMockServer.stubPositiveCaseNoteSummary()
-    prisonApiMockServer.stubNegativeCaseNoteSummary()
-
-    repository.deleteAll()
-
-    webTestClient.get()
-      .uri("/incentives-reviews/prison/MDI/location/MDI-1")
-      .headers(setAuthorisation(roles = listOf("ROLE_INCENTIVES")))
-      .exchange()
-      .expectStatus().isNotFound
-      .expectBody().json(
-        // language=json
-        """
-          {
-            "status": 404,
-            "userMessage": "Not Found: No Data found for ID(s) [1234134, 1234135, 1234136, 1234137, 1234138]",
-            "developerMessage": "No Data found for ID(s) [1234134, 1234135, 1234136, 1234137, 1234138]"
-          }
-          """
-      )
-  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsServiceTest.kt
@@ -19,7 +19,6 @@ import uk.gov.justice.digital.hmpps.incentivesapi.dto.OffenderSearchPrisonerAler
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.OffenderSearchPrisonerList
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.CaseNoteUsage
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.PrisonLocation
-import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
@@ -370,16 +369,5 @@ class IncentiveReviewsServiceTest {
     cellLocation = "2-1-003",
     locationDescription = "Moorland (HMP & YOI)",
     alerts = listOf(),
-  )
-
-  private fun prisonerIepLevel(bookingId: Long, reviewTime: LocalDateTime = LocalDateTime.now(clock)) = PrisonerIepLevel(
-    iepCode = "STD",
-    prisonId = "MDI",
-    locationId = "MDI-1-1-004",
-    bookingId = bookingId,
-    current = true,
-    reviewedBy = "TEST_STAFF1",
-    reviewTime = reviewTime,
-    prisonerNumber = "A1234AB"
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsServiceTest.kt
@@ -4,7 +4,6 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -14,7 +13,6 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.stubbing.OngoingStubbing
-import uk.gov.justice.digital.hmpps.incentivesapi.config.ListOfDataNotFoundException
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IncentiveReview
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.OffenderSearchPrisoner
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.OffenderSearchPrisonerAlert
@@ -22,7 +20,6 @@ import uk.gov.justice.digital.hmpps.incentivesapi.dto.OffenderSearchPrisonerList
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.CaseNoteUsage
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.PrisonLocation
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
-import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonerIepLevelRepository
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
@@ -32,17 +29,23 @@ import java.time.ZoneId
 class IncentiveReviewsServiceTest {
   private val prisonApiService: PrisonApiService = mock()
   private val offenderSearchService: OffenderSearchService = mock()
-  private val prisonerIepLevelRepository: PrisonerIepLevelRepository = mock()
+  private val nextReviewDateGetterService: NextReviewDateGetterService = mock()
   private var clock: Clock = Clock.fixed(Instant.parse("2022-08-01T12:45:00.00Z"), ZoneId.systemDefault())
-  private val incentiveReviewsService = IncentiveReviewsService(offenderSearchService, prisonApiService, prisonerIepLevelRepository, clock)
+  private val incentiveReviewsService = IncentiveReviewsService(offenderSearchService, prisonApiService, nextReviewDateGetterService, clock)
 
   @BeforeEach
   fun setUp(): Unit = runBlocking {
     // Fixes tests which do not explicitly mock retrieveCaseNoteCounts
     whenever(prisonApiService.retrieveCaseNoteCounts(any(), any())).thenReturn(emptyFlow())
 
-    whenever(prisonerIepLevelRepository.findAllByBookingIdInAndCurrentIsTrueOrderByReviewTimeDesc(any()))
-      .thenReturn(flowOf(prisonerIepLevel(110001), prisonerIepLevel(110002)))
+    whenever(
+      nextReviewDateGetterService.getMany(any())
+    ).thenReturn(
+      mapOf(
+        110001L to LocalDate.parse("2022-12-12"),
+        110002L to LocalDate.parse("2022-12-12"),
+      )
+    )
   }
 
   @Test
@@ -65,50 +68,54 @@ class IncentiveReviewsServiceTest {
 
   @Test
   fun `maps responses from offender search`(): Unit = runBlocking {
-    whenever(prisonApiService.getLocation(any())).thenReturnLocation("MDI-2-1")
-    whenever(offenderSearchService.findOffenders(any(), any(), any(), any())).thenReturnOffenders(
-      listOf(
-        OffenderSearchPrisoner(
-          prisonerNumber = "A1409AE",
-          bookingId = 110001,
-          firstName = "JAMES",
-          middleNames = "",
-          lastName = "HALLS",
-          status = "ACTIVE IN",
-          inOutStatus = "IN",
-          dateOfBirth = LocalDate.parse("1971-07-01"),
-          receptionDate = LocalDate.parse("2020-07-01"),
-          prisonId = "MDI",
-          prisonName = "Moorland (HMP & YOI)",
-          cellLocation = "2-1-002",
-          locationDescription = "Moorland (HMP & YOI)",
-          alerts = listOf(
-            OffenderSearchPrisonerAlert(
-              alertType = "H",
-              alertCode = "HA",
-              active = true,
-              expired = false,
-            ),
+    val offenders = listOf(
+      OffenderSearchPrisoner(
+        prisonerNumber = "A1409AE",
+        bookingId = 110001,
+        firstName = "JAMES",
+        middleNames = "",
+        lastName = "HALLS",
+        status = "ACTIVE IN",
+        inOutStatus = "IN",
+        dateOfBirth = LocalDate.parse("1971-07-01"),
+        receptionDate = LocalDate.parse("2020-07-01"),
+        prisonId = "MDI",
+        prisonName = "Moorland (HMP & YOI)",
+        cellLocation = "2-1-002",
+        locationDescription = "Moorland (HMP & YOI)",
+        alerts = listOf(
+          OffenderSearchPrisonerAlert(
+            alertType = "H",
+            alertCode = "HA",
+            active = true,
+            expired = false,
           ),
         ),
-        OffenderSearchPrisoner(
-          prisonerNumber = "G6123VU",
-          bookingId = 110002,
-          firstName = "RHYS",
-          middleNames = "BARRY",
-          lastName = "JONES",
-          status = "ACTIVE IN",
-          inOutStatus = "IN",
-          dateOfBirth = LocalDate.parse("1970-03-01"),
-          receptionDate = LocalDate.parse("2020-07-01"),
-          prisonId = "MDI",
-          prisonName = "Moorland (HMP & YOI)",
-          cellLocation = "2-1-003",
-          locationDescription = "Moorland (HMP & YOI)",
-          alerts = listOf(),
-        ),
-      )
+      ),
+      OffenderSearchPrisoner(
+        prisonerNumber = "G6123VU",
+        bookingId = 110002,
+        firstName = "RHYS",
+        middleNames = "BARRY",
+        lastName = "JONES",
+        status = "ACTIVE IN",
+        inOutStatus = "IN",
+        dateOfBirth = LocalDate.parse("1970-03-01"),
+        receptionDate = LocalDate.parse("2020-07-01"),
+        prisonId = "MDI",
+        prisonName = "Moorland (HMP & YOI)",
+        cellLocation = "2-1-003",
+        locationDescription = "Moorland (HMP & YOI)",
+        alerts = listOf(),
+      ),
     )
+    whenever(prisonApiService.getLocation(any())).thenReturnLocation("MDI-2-1")
+    whenever(offenderSearchService.findOffenders(any(), any(), any(), any())).thenReturnOffenders(offenders)
+    val nextReviewDatesMap = mapOf(
+      110001L to LocalDate.now(clock).plusYears(1),
+      110002L to LocalDate.now(clock).plusYears(1),
+    )
+    whenever(nextReviewDateGetterService.getMany(offenders)).thenReturn(nextReviewDatesMap)
 
     val reviews = incentiveReviewsService.reviews("MDI", "MDI-2-1")
 
@@ -125,7 +132,7 @@ class IncentiveReviewsServiceTest {
           positiveBehaviours = 0,
           negativeBehaviours = 0,
           acctOpenStatus = true,
-          nextReviewDate = LocalDate.now(clock).plusYears(1),
+          nextReviewDate = nextReviewDatesMap[110001L]!!,
         ),
         IncentiveReview(
           prisonerNumber = "G6123VU",
@@ -135,7 +142,7 @@ class IncentiveReviewsServiceTest {
           positiveBehaviours = 0,
           negativeBehaviours = 0,
           acctOpenStatus = false,
-          nextReviewDate = LocalDate.now(clock).plusYears(1),
+          nextReviewDate = nextReviewDatesMap[110002L]!!,
         ),
       )
     )
@@ -146,8 +153,11 @@ class IncentiveReviewsServiceTest {
     // Given
     val prisonerNumber = "G6123VU"
     whenever(prisonApiService.getLocation(any())).thenReturnLocation("MDI-2-1")
+    val offenders = listOf(offenderSearchPrisoner(prisonerNumber))
     whenever(offenderSearchService.findOffenders(any(), any(), any(), any()))
-      .thenReturnOffenders(listOf(offenderSearchPrisoner(prisonerNumber)))
+      .thenReturnOffenders(offenders)
+    val nextReviewDatesMap = mapOf(offenders[0].bookingId to LocalDate.now(clock).plusYears(1))
+    whenever(nextReviewDateGetterService.getMany(offenders)).thenReturn(nextReviewDatesMap)
 
     whenever(prisonApiService.retrieveCaseNoteCounts("POS", listOf(prisonerNumber)))
       .thenReturn(
@@ -188,7 +198,7 @@ class IncentiveReviewsServiceTest {
           positiveBehaviours = 5,
           negativeBehaviours = 7,
           acctOpenStatus = false,
-          nextReviewDate = LocalDate.now(clock).plusYears(1),
+          nextReviewDate = nextReviewDatesMap[110002L]!!,
         ),
       )
     )
@@ -198,12 +208,16 @@ class IncentiveReviewsServiceTest {
   fun `defaults positive and negative behaviours to 0 if no case notes returned`(): Unit = runBlocking {
     // Given
     val prisonerNumber = "G6123VU"
+    val expectedNextReviewDate = LocalDate.now(clock).plusYears(1)
+
     whenever(prisonApiService.getLocation(any())).thenReturnLocation("MDI-2-1")
     whenever(offenderSearchService.findOffenders(any(), any(), any(), any()))
       .thenReturnOffenders(listOf(offenderSearchPrisoner(prisonerNumber)))
 
     whenever(prisonApiService.retrieveCaseNoteCounts("POS", listOf(prisonerNumber))).thenReturn(emptyFlow())
     whenever(prisonApiService.retrieveCaseNoteCounts("NEG", listOf(prisonerNumber))).thenReturn(emptyFlow())
+
+    whenever(nextReviewDateGetterService.getMany(any())).thenReturn(mapOf(110002L to expectedNextReviewDate))
 
     // When
     val reviews = incentiveReviewsService.reviews("MDI", "MDI-2-1")
@@ -219,7 +233,7 @@ class IncentiveReviewsServiceTest {
           positiveBehaviours = 0,
           negativeBehaviours = 0,
           acctOpenStatus = false,
-          nextReviewDate = LocalDate.now(clock).plusYears(1),
+          nextReviewDate = expectedNextReviewDate,
         ),
       )
     )
@@ -229,22 +243,19 @@ class IncentiveReviewsServiceTest {
   fun `oldest date of next review is first`(): Unit = runBlocking {
     // Given
     whenever(prisonApiService.getLocation(any())).thenReturnLocation("MDI-2-1")
+    val offenders = listOf(
+      offenderSearchPrisoner("A1409AE", 110001L),
+      offenderSearchPrisoner("G6123VU", 110002L),
+    )
     whenever(offenderSearchService.findOffenders(any(), any(), any(), any()))
-      .thenReturnOffenders(
-        listOf(
-          offenderSearchPrisoner("A1409AE", 110001),
-          offenderSearchPrisoner("G6123VU", 110002),
-        )
-      )
+      .thenReturnOffenders(offenders)
 
     val oldestReview = LocalDateTime.now(clock).minusDays(5)
-    whenever(prisonerIepLevelRepository.findAllByBookingIdInAndCurrentIsTrueOrderByReviewTimeDesc(any()))
-      .thenReturn(
-        flowOf(
-          prisonerIepLevel(110001, LocalDateTime.now(clock)),
-          prisonerIepLevel(110002, oldestReview)
-        )
-      )
+    val nextReviewDatesMap = mapOf(
+      110001L to LocalDate.now(clock).plusYears(1),
+      110002L to oldestReview.toLocalDate().plusYears(1),
+    )
+    whenever(nextReviewDateGetterService.getMany(offenders)).thenReturn(nextReviewDatesMap)
 
     // When
     val reviews = incentiveReviewsService.reviews("MDI", "MDI-2-1")
@@ -260,7 +271,7 @@ class IncentiveReviewsServiceTest {
           positiveBehaviours = 0,
           negativeBehaviours = 0,
           acctOpenStatus = false,
-          nextReviewDate = oldestReview.toLocalDate().plusYears(1),
+          nextReviewDate = nextReviewDatesMap[110002L]!!,
         ),
         IncentiveReview(
           prisonerNumber = "A1409AE",
@@ -270,79 +281,31 @@ class IncentiveReviewsServiceTest {
           positiveBehaviours = 0,
           negativeBehaviours = 0,
           acctOpenStatus = false,
-          nextReviewDate = LocalDate.now(clock).plusYears(1),
+          nextReviewDate = nextReviewDatesMap[110001L]!!,
         ),
       )
     )
   }
 
   @Test
-  fun `throw exception if cannot calculate next review date for one bookingId`(): Unit = runBlocking {
-    // Given - we only have prisonerIepLevel records for 110001
-    whenever(prisonApiService.getLocation(any())).thenReturnLocation("MDI-2-1")
-    whenever(offenderSearchService.findOffenders(any(), any(), any(), any()))
-      .thenReturnOffenders(
-        listOf(
-          offenderSearchPrisoner("A1409AE", 110001),
-          offenderSearchPrisoner("G6123VU", 110002),
-        )
-      )
-
-    whenever(prisonerIepLevelRepository.findAllByBookingIdInAndCurrentIsTrueOrderByReviewTimeDesc(any()))
-      .thenReturn(flowOf(prisonerIepLevel(110001)))
-
-    // When
-    assertThatThrownBy {
-      runBlocking { incentiveReviewsService.reviews("MDI", "MDI-2-1") }
-    }.isInstanceOf(ListOfDataNotFoundException::class.java)
-      .hasMessage("No Data found for ID(s) [110002]")
-  }
-
-  @Test
-  fun `throw exception if cannot calculate next review date for all bookingIds`(): Unit = runBlocking {
-    // Given - we don't have prisonerIepLevel records for either bookingId
-    whenever(prisonApiService.getLocation(any())).thenReturnLocation("MDI-2-1")
-    whenever(offenderSearchService.findOffenders(any(), any(), any(), any()))
-      .thenReturnOffenders(
-        listOf(
-          offenderSearchPrisoner("A1409AE", 110001),
-          offenderSearchPrisoner("G6123VU", 110002),
-        )
-      )
-
-    whenever(prisonerIepLevelRepository.findAllByBookingIdInAndCurrentIsTrueOrderByReviewTimeDesc(any()))
-      .thenReturn(emptyFlow())
-
-    // When
-    assertThatThrownBy {
-      runBlocking { incentiveReviewsService.reviews("MDI", "MDI-2-1") }
-    }.isInstanceOf(ListOfDataNotFoundException::class.java)
-      .hasMessage("No Data found for ID(s) [110001, 110002]")
-  }
-
-  @Test
   fun `overdue count where 2 next review are in the past`(): Unit = runBlocking {
     // Given
     whenever(prisonApiService.getLocation(any())).thenReturnLocation("MDI-2-1")
+    val offenders = listOf(
+      offenderSearchPrisoner("A1409AE", 110001),
+      offenderSearchPrisoner("G6123VU", 110002),
+      offenderSearchPrisoner("G6123VX", 110003),
+    )
     whenever(offenderSearchService.findOffenders(any(), any(), any(), any()))
-      .thenReturnOffenders(
-        listOf(
-          offenderSearchPrisoner("A1409AE", 110001),
-          offenderSearchPrisoner("G6123VU", 110002),
-          offenderSearchPrisoner("G6123VX", 110003),
-        )
-      )
-
-    whenever(prisonerIepLevelRepository.findAllByBookingIdInAndCurrentIsTrueOrderByReviewTimeDesc(any()))
-      .thenReturn(
-        flowOf(
-          prisonerIepLevel(110001, LocalDateTime.now(clock)),
-          // next review will be 1 day before LocalDateTime.now(clock)
-          prisonerIepLevel(110002, LocalDateTime.now(clock).minusYears(1).minusDays(1)),
-          // next review will be 10 days before LocalDateTime.now(clock)
-          prisonerIepLevel(110003, LocalDateTime.now(clock).minusYears(1).minusDays(10)),
-        )
-      )
+      .thenReturnOffenders(offenders)
+    val nextReviewDatesMap = mapOf(
+      110001L to LocalDate.now(clock),
+      // next review will be 1 day before LocalDateTime.now(clock)
+      110002L to LocalDate.now(clock).minusYears(1).minusDays(1),
+      // next review will be 10 days before LocalDateTime.now(clock)
+      110003L to LocalDate.now(clock).minusYears(1).minusDays(10),
+    )
+    whenever(nextReviewDateGetterService.getMany(offenders)).thenReturn(nextReviewDatesMap)
 
     // When
     val reviews = incentiveReviewsService.reviews("MDI", "MDI-2-1")
@@ -360,14 +323,6 @@ class IncentiveReviewsServiceTest {
         listOf(
           offenderSearchPrisoner("A1409AE", 110001),
           offenderSearchPrisoner("G6123VU", 110002),
-        )
-      )
-
-    whenever(prisonerIepLevelRepository.findAllByBookingIdInAndCurrentIsTrueOrderByReviewTimeDesc(any()))
-      .thenReturn(
-        flowOf(
-          prisonerIepLevel(110001, LocalDateTime.now(clock)),
-          prisonerIepLevel(110002, LocalDateTime.now(clock)),
         )
       )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateGetterServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateGetterServiceTest.kt
@@ -13,7 +13,7 @@ import uk.gov.justice.digital.hmpps.incentivesapi.jpa.NextReviewDate
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.NextReviewDateRepository
 import java.time.LocalDate
 
-internal class NextReviewDateGetterServiceTest {
+class NextReviewDateGetterServiceTest {
   private val nextReviewDateRepository: NextReviewDateRepository = mock()
   private val prisonApiService: PrisonApiService = mock()
   private val offenderSearchService: OffenderSearchService = mock()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateGetterServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateGetterServiceTest.kt
@@ -1,0 +1,79 @@
+package uk.gov.justice.digital.hmpps.incentivesapi.service
+
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.incentivesapi.jpa.NextReviewDate
+import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.NextReviewDateRepository
+import java.time.LocalDate
+
+internal class NextReviewDateGetterServiceTest {
+  private val nextReviewDateRepository: NextReviewDateRepository = mock()
+  private val prisonApiService: PrisonApiService = mock()
+  private val offenderSearchService: OffenderSearchService = mock()
+  private val nextReviewDateUpdaterService: NextReviewDateUpdaterService = mock()
+  private val nextReviewDateGetterService = NextReviewDateGetterService(
+    nextReviewDateRepository,
+    prisonApiService,
+    offenderSearchService,
+    nextReviewDateUpdaterService,
+  )
+
+  @Test
+  fun `getMany() returns the next review dates (updates missing ones)`(): Unit = runBlocking {
+    val offenders = listOf(
+      offenderSearchPrisoner("AB123C", 123L),
+      offenderSearchPrisoner("XY456Z", 456L),
+    )
+    val expectedNextReviewDates = mapOf(
+      123L to LocalDate.parse("2025-01-23"),
+      456L to LocalDate.parse("2025-04-06"),
+    )
+
+    // one offender with a NextReviewDate record
+    whenever(nextReviewDateRepository.findAllById(listOf(123L, 456L)))
+      .thenReturn(flowOf(NextReviewDate(456L, expectedNextReviewDates[456L]!!)))
+
+    // calls update() with offenders without next review date
+    whenever(nextReviewDateUpdaterService.updateMany(listOf(offenders[0])))
+      .thenReturn(mapOf(123L to expectedNextReviewDates[123L]!!))
+
+    val result = nextReviewDateGetterService.getMany(offenders)
+
+    assertThat(result).isEqualTo(expectedNextReviewDates)
+  }
+
+  @Test
+  fun `get() return the next review date (update it if missing)`(): Unit = runBlocking {
+    val bookingId = 1234L
+    val prisonerNumber = "A1244AB"
+    val expectedNextReviewDate = LocalDate.parse("2022-07-30")
+
+    val locationInfo = prisonerAtLocation(bookingId, prisonerNumber)
+    whenever(prisonApiService.getPrisonerInfo(bookingId, useClientCredentials = true))
+      .thenReturn(locationInfo)
+    val offender = offenderSearchPrisoner(prisonerNumber, bookingId)
+    whenever(offenderSearchService.getOffender(locationInfo.offenderNo))
+      .thenReturn(offender)
+
+    // no record found in the database
+    whenever(nextReviewDateRepository.findAllById(listOf(bookingId)))
+      .thenReturn(emptyFlow())
+    whenever(nextReviewDateUpdaterService.updateMany(listOf(offender)))
+      .thenReturn(mapOf(offender.bookingId to expectedNextReviewDate))
+
+    val result = nextReviewDateGetterService.get(bookingId)
+
+    // check next review date was updated for prisoner
+    verify(nextReviewDateUpdaterService, times(1))
+      .updateMany(listOf(offender))
+
+    assertThat(result).isEqualTo(expectedNextReviewDate)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterServiceTest.kt
@@ -85,12 +85,13 @@ class NextReviewDateUpdaterServiceTest {
         .thenReturn(false)
       whenever(nextReviewDateRepository.existsById(offender2.bookingId))
         .thenReturn(false)
-      val expectedRecordsList = listOf(
+      val expectedRecordsFlow = flowOf(
         NextReviewDate(offender1.bookingId, expectedDate1, new = true),
         NextReviewDate(offender2.bookingId, expectedDate2, new = true),
       )
+      val expectedRecordsList = expectedRecordsFlow.toList()
       whenever(nextReviewDateRepository.saveAll(expectedRecordsList))
-        .thenReturn(emptyFlow())
+        .thenReturn(expectedRecordsFlow)
 
       val result = nextReviewDateUpdaterService.updateMany(offenders)
 
@@ -137,12 +138,13 @@ class NextReviewDateUpdaterServiceTest {
         )
       ).calculate()
 
-      val expectedRecordsList = listOf(
+      val expectedRecordsFlow = flowOf(
         NextReviewDate(offender1.bookingId, expectedDate1, new = true),
         NextReviewDate(offender2.bookingId, expectedDate2, new = false),
       )
+      val expectedRecordsList = expectedRecordsFlow.toList()
       whenever(nextReviewDateRepository.saveAll(expectedRecordsList))
-        .thenReturn(emptyFlow())
+        .thenReturn(expectedRecordsFlow)
 
       val result = nextReviewDateUpdaterService.updateMany(offenders)
 
@@ -186,11 +188,12 @@ class NextReviewDateUpdaterServiceTest {
     ).calculate()
 
     whenever(nextReviewDateRepository.existsById(bookingId)).thenReturn(true)
-    val expectedRecordsList = listOf(
+    val expectedRecordsFlow = flowOf(
       NextReviewDate(bookingId, expectedNextReviewDate, new = false),
     )
+    val expectedRecordsList = expectedRecordsFlow.toList()
     whenever(nextReviewDateRepository.saveAll(expectedRecordsList))
-      .thenReturn(emptyFlow())
+      .thenReturn(expectedRecordsFlow)
 
     val result = nextReviewDateUpdaterService.update(bookingId)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterServiceTest.kt
@@ -1,0 +1,183 @@
+package uk.gov.justice.digital.hmpps.incentivesapi.service
+
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.IepLevel
+import uk.gov.justice.digital.hmpps.incentivesapi.jpa.NextReviewDate
+import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.NextReviewDateRepository
+import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonerIepLevelRepository
+
+class NextReviewDateUpdaterServiceTest {
+  private val prisonerIepLevelRepository: PrisonerIepLevelRepository = mock()
+  private val nextReviewDateRepository: NextReviewDateRepository = mock()
+  private val prisonApiService: PrisonApiService = mock()
+  private val offenderSearchService: OffenderSearchService = mock()
+
+  private val nextReviewDateUpdaterService = NextReviewDateUpdaterService(
+    prisonerIepLevelRepository,
+    nextReviewDateRepository,
+    prisonApiService,
+    offenderSearchService,
+  )
+
+  private val iepLevels = mapOf(
+    "BAS" to IepLevel(iepLevel = "BAS", iepDescription = "Basic", sequence = 1),
+    "STD" to IepLevel(iepLevel = "STD", iepDescription = "Standard", sequence = 2),
+    "ENH" to IepLevel(iepLevel = "ENH", iepDescription = "Enhanced", sequence = 3),
+    "EN2" to IepLevel(iepLevel = "EN2", iepDescription = "Enhanced 2", sequence = 4),
+  )
+
+  @BeforeEach
+  fun setUp(): Unit = runBlocking {
+    whenever(prisonApiService.getIncentiveLevels())
+      .thenReturn(iepLevels)
+  }
+
+  @Nested
+  inner class UpdateAllTest {
+    private val offender1 = offenderSearchPrisoner("AB123C", 123L)
+    private val offender2 = offenderSearchPrisoner("XY456Z", 456L)
+
+    private val offenders = listOf(offender1, offender2)
+
+    @BeforeEach
+    fun setUp(): Unit = runBlocking {
+      whenever(prisonApiService.getIncentiveLevels())
+        .thenReturn(iepLevels)
+    }
+
+    @Test
+    fun `updateMany() when no reviews in database`(): Unit = runBlocking {
+      whenever(
+        prisonerIepLevelRepository.findAllByBookingIdInOrderByReviewTimeDesc(
+          listOf(offender1.bookingId, offender2.bookingId)
+        )
+      ).thenReturn(emptyFlow())
+
+      val result = nextReviewDateUpdaterService.updateMany(offenders)
+
+      val expectedDate1 = NextReviewDateService(
+        NextReviewDateInput(
+          dateOfBirth = offender1.dateOfBirth,
+          receptionDate = offender1.receptionDate,
+          hasAcctOpen = offender1.acctOpen,
+          iepDetails = emptyList(),
+        )
+      ).calculate()
+      val expectedDate2 = NextReviewDateService(
+        NextReviewDateInput(
+          dateOfBirth = offender2.dateOfBirth,
+          receptionDate = offender2.receptionDate,
+          hasAcctOpen = offender2.acctOpen,
+          iepDetails = emptyList(),
+        )
+      ).calculate()
+
+      assertThat(result).isEqualTo(
+        mapOf(
+          offender1.bookingId to expectedDate1,
+          offender2.bookingId to expectedDate2,
+        )
+      )
+
+      verify(nextReviewDateRepository, times(1)).saveAll(
+        listOf(
+          NextReviewDate(offender1.bookingId, expectedDate1),
+          NextReviewDate(offender2.bookingId, expectedDate2),
+        )
+      )
+    }
+
+    @Test
+    fun `updateMany() when some reviews in database`(): Unit = runBlocking {
+      val offender2Reviews = flowOf(
+        prisonerIepLevel(offender2.bookingId),
+        prisonerIepLevel(offender2.bookingId),
+      )
+      whenever(
+        prisonerIepLevelRepository.findAllByBookingIdInOrderByReviewTimeDesc(
+          listOf(offender1.bookingId, offender2.bookingId)
+        )
+      ).thenReturn(offender2Reviews)
+
+      val result = nextReviewDateUpdaterService.updateMany(offenders)
+
+      val expectedDate1 = NextReviewDateService(
+        NextReviewDateInput(
+          dateOfBirth = offender1.dateOfBirth,
+          receptionDate = offender1.receptionDate,
+          hasAcctOpen = offender1.acctOpen,
+          iepDetails = emptyList(),
+        )
+      ).calculate()
+      val expectedDate2 = NextReviewDateService(
+        NextReviewDateInput(
+          dateOfBirth = offender2.dateOfBirth,
+          receptionDate = offender2.receptionDate,
+          hasAcctOpen = offender2.acctOpen,
+          iepDetails = offender2Reviews.toList().toIepDetails(iepLevels),
+        )
+      ).calculate()
+
+      assertThat(result).isEqualTo(
+        mapOf(
+          offender1.bookingId to expectedDate1,
+          offender2.bookingId to expectedDate2,
+        )
+      )
+
+      verify(nextReviewDateRepository, times(1)).saveAll(
+        listOf(
+          NextReviewDate(offender1.bookingId, expectedDate1),
+          NextReviewDate(offender2.bookingId, expectedDate2),
+        )
+      )
+    }
+  }
+
+  @Test
+  fun `update() calculate, save and return the next review date`(): Unit = runBlocking {
+    val bookingId = 1234L
+    val prisonerNumber = "A1244AB"
+
+    val locationInfo = prisonerAtLocation(bookingId, prisonerNumber)
+    whenever(prisonApiService.getPrisonerInfo(bookingId, useClientCredentials = true))
+      .thenReturn(locationInfo)
+    val offender = offenderSearchPrisoner(prisonerNumber, bookingId)
+    whenever(offenderSearchService.getOffender(locationInfo.offenderNo))
+      .thenReturn(offender)
+    val reviews = flowOf(
+      prisonerIepLevel(bookingId),
+      prisonerIepLevel(bookingId),
+    )
+    whenever(prisonerIepLevelRepository.findAllByBookingIdInOrderByReviewTimeDesc(listOf(bookingId)))
+      .thenReturn(reviews)
+
+    val expectedNextReviewDate = NextReviewDateService(
+      NextReviewDateInput(
+        dateOfBirth = offender.dateOfBirth,
+        receptionDate = offender.receptionDate,
+        hasAcctOpen = offender.acctOpen,
+        iepDetails = reviews.toList().toIepDetails(iepLevels),
+      )
+    ).calculate()
+
+    val result = nextReviewDateUpdaterService.update(bookingId)
+
+    assertThat(result).isEqualTo(expectedNextReviewDate)
+
+    verify(nextReviewDateRepository, times(1)).saveAll(
+      listOf(NextReviewDate(bookingId, expectedNextReviewDate)),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
@@ -53,6 +53,7 @@ class PrisonerIepLevelReviewServiceTest {
   private val auditService: AuditService = mock()
   private val featureFlagsService: FeatureFlagsService = mock()
   private val nextReviewDateGetterService: NextReviewDateGetterService = mock()
+  private val nextReviewDateUpdaterService: NextReviewDateUpdaterService = mock()
   private val offenderSearchService: OffenderSearchService = mock()
 
   private val prisonerIepLevelReviewService = PrisonerIepLevelReviewService(
@@ -65,6 +66,7 @@ class PrisonerIepLevelReviewServiceTest {
     clock,
     featureFlagsService,
     nextReviewDateGetterService,
+    nextReviewDateUpdaterService,
     offenderSearchService,
   )
 
@@ -720,6 +722,9 @@ class PrisonerIepLevelReviewServiceTest {
           prisonerNumber = prisonerAtLocation().offenderNo
         )
       )
+
+      // Triggers the update of next review date when a new review is created
+      verify(nextReviewDateUpdaterService, times(1)).update(bookingId)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
@@ -32,7 +32,6 @@ import uk.gov.justice.digital.hmpps.incentivesapi.dto.SyncPostRequest
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.IepLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.IepReviewInNomis
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.Location
-import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.PrisonerAtLocation
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonerIepLevelRepository
 import java.time.Clock
@@ -1219,11 +1218,6 @@ class PrisonerIepLevelReviewServiceTest {
     occurredAt = Instant.now(),
     description = "A prisoner has been merged from A8765SS to A1244AB"
   )
-
-  private fun prisonerAtLocation(bookingId: Long = 1234567, offenderNo: String = "A1234AA", agencyId: String = "MDI") =
-    PrisonerAtLocation(
-      bookingId, 1, "John", "Smith", offenderNo, agencyId, 1
-    )
 
   private val location = Location(
     agencyId = "MDI", locationId = 77777L, description = "Houseblock 1"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
@@ -818,6 +818,16 @@ class PrisonerIepLevelReviewServiceTest {
     }
 
     @Test
+    fun `updates the next review date of the affected prisoner`(): Unit = runBlocking {
+      // When
+      prisonerIepLevelReviewService.handleSyncDeleteIepReviewRequest(bookingId, iepReview.id)
+
+      // Then check it's saved
+      verify(nextReviewDateUpdaterService, times(1))
+        .update(bookingId)
+    }
+
+    @Test
     fun `sends IepReview event and audit message`(): Unit = runBlocking {
       // When sync DELETE request is handled
       prisonerIepLevelReviewService.handleSyncDeleteIepReviewRequest(bookingId, iepReview.id)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
@@ -941,6 +941,16 @@ class PrisonerIepLevelReviewServiceTest {
     }
 
     @Test
+    fun `updates the next review date for the prisoner`(): Unit = runBlocking {
+      // When
+      prisonerIepLevelReviewService.handleSyncPatchIepReviewRequest(bookingId, iepReview.id, syncPatchRequest)
+
+      // Then check the next review date was updated for the affected prisoner
+      verify(nextReviewDateUpdaterService, times(1))
+        .update(bookingId)
+    }
+
+    @Test
     fun `sends IepReview event and audit message`(): Unit = runBlocking {
       // When sync POST request is handled
       prisonerIepLevelReviewService.handleSyncPatchIepReviewRequest(bookingId, iepReview.id, syncPatchRequest)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/testData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/testData.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.incentivesapi.service
+
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.OffenderSearchPrisoner
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.PrisonerAtLocation
+import java.time.LocalDate
+
+fun offenderSearchPrisoner(
+  prisonerNumber: String = "A1244AB",
+  bookingId: Long = 1234567L,
+) = OffenderSearchPrisoner(
+  prisonerNumber = prisonerNumber,
+  bookingId = bookingId,
+  firstName = "JAMES",
+  middleNames = "",
+  lastName = "HALLS",
+  status = "ACTIVE IN",
+  inOutStatus = "IN",
+  dateOfBirth = LocalDate.parse("1971-07-01"),
+  receptionDate = LocalDate.parse("2020-07-01"),
+  prisonId = "MDI",
+  prisonName = "Moorland",
+  cellLocation = "2-1-002",
+  locationDescription = "Cell 2",
+  alerts = emptyList(),
+)
+
+fun prisonerAtLocation(bookingId: Long = 1234567, offenderNo: String = "A1234AA", agencyId: String = "MDI") =
+  PrisonerAtLocation(
+    bookingId, 1, "John", "Smith", offenderNo, agencyId, 1
+  )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/testData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/testData.kt
@@ -2,7 +2,9 @@ package uk.gov.justice.digital.hmpps.incentivesapi.service
 
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.OffenderSearchPrisoner
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.PrisonerAtLocation
+import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 fun offenderSearchPrisoner(
   prisonerNumber: String = "A1244AB",
@@ -28,3 +30,14 @@ fun prisonerAtLocation(bookingId: Long = 1234567, offenderNo: String = "A1234AA"
   PrisonerAtLocation(
     bookingId, 1, "John", "Smith", offenderNo, agencyId, 1
   )
+
+fun prisonerIepLevel(bookingId: Long, reviewTime: LocalDateTime = LocalDateTime.now()) = PrisonerIepLevel(
+  iepCode = "STD",
+  prisonId = "MDI",
+  locationId = "MDI-1-1-004",
+  bookingId = bookingId,
+  current = true,
+  reviewedBy = "TEST_STAFF1",
+  reviewTime = reviewTime,
+  prisonerNumber = "A1234AB"
+)


### PR DESCRIPTION
- creates `next_review_date` database table with `booking_id`/`next_review_date` columns
- mechanism to update next review date for one/multiple prisoners
- mechanism to get next review date for one/multiple prisoners
  - this tries to get them from the database first
  - update these in the database if missing
  - return the next review dates
- create a new review triggers the update of the next review date in the database
  - this includes admissions, transfers, merges, etc...