### PR TITLE
INC-813: Made sync endpoints transactional

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -157,6 +157,7 @@ class PrisonerIepLevelReviewService(
     return review.toIepDetail(prisonApiService.getIncentiveLevels())
   }
 
+  @Transactional
   suspend fun handleSyncPostIepReviewRequest(bookingId: Long, syncPostRequest: SyncPostRequest): IepDetail {
     val iepDetail = persistSyncPostRequest(bookingId, syncPostRequest, true)
 
@@ -166,6 +167,7 @@ class PrisonerIepLevelReviewService(
     return iepDetail
   }
 
+  @Transactional
   suspend fun handleSyncPatchIepReviewRequest(
     bookingId: Long,
     id: Long,
@@ -206,6 +208,7 @@ class PrisonerIepLevelReviewService(
     return iepDetail
   }
 
+  @Transactional
   suspend fun handleSyncDeleteIepReviewRequest(bookingId: Long, id: Long) {
     val prisonerIepLevel: PrisonerIepLevel? = prisonerIepLevelRepository.findById(id)
     if (prisonerIepLevel == null) {


### PR DESCRIPTION
Some of these endpoints requests may trigger the update of several records in the DB so it makes sense for these operation to be atomic/transactional.

NOTE: This is part of ongoing support for syncronisation testing