### PR TITLE
Fix type error in health checks

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/health/HealthCheck.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/health/HealthCheck.kt
@@ -12,7 +12,7 @@ abstract class HealthCheck(private val webClient: WebClient, private val timeout
       .uri("/health/ping")
       .retrieve()
       .toEntity(String::class.java)
-      .block(timeout)
+      .block(timeout) ?: throw Exception("/health/ping did not return a response")
     Health.up().withDetail("HttpStatus", responseEntity.statusCode).build()
   } catch (e: WebClientResponseException) {
     Health.down(e).withDetail("body", e.responseBodyAsString).build()


### PR DESCRIPTION
…because the HTTP response is nullable so retrieving `.statusCode` is fallible: better to handle the exception explicitly:

> > Task :compileKotlin
> w: hmpps-incentives-api/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/health/HealthCheck.kt: (16, 42): Unsafe use of a nullable receiver of type ResponseEntity<String!>?

i.e. `responseEntity.statusCode` will throw a null pointer exception which is less clear