### PR TITLE
INC-901: Update next review date on alerts changes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonOffenderEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonOffenderEventListener.kt
@@ -22,11 +22,10 @@ class PrisonOffenderEventListener(
     val eventType = messageAttributes.eventType.Value
     log.info("Received message $message, type $eventType")
 
+    val hmppsDomainEvent = mapper.readValue(message, HMPPSDomainEvent::class.java)
     when (eventType) {
-      "prisoner-offender-search.prisoner.received", "prison-offender-events.prisoner.merged" -> {
-        val hmppsDomainEvent = mapper.readValue(message, HMPPSDomainEvent::class.java)
-        prisonerIepLevelReviewService.processOffenderEvent(hmppsDomainEvent)
-      }
+      "prisoner-offender-search.prisoner.received", "prison-offender-events.prisoner.merged" -> prisonerIepLevelReviewService.processOffenderEvent(hmppsDomainEvent)
+      "prisoner-offender-search.prisoner.updated" -> prisonerIepLevelReviewService.processPrisonerUpdatedEvent(hmppsDomainEvent)
       else -> {
         log.debug("Ignoring message with type $eventType")
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -276,7 +276,7 @@ class PrisonerIepLevelReviewService(
     if (alertsChanged) {
       updateNextReviewDate(prisonOffenderEvent)
     } else {
-      log.debug("Ignoring 'prisoner-offender-search.prisoner.updated' event, alerts didn't change: categoriesChanged = ${prisonOffenderEvent.additionalInformation.categoriesChanged}")
+      log.debug("Ignoring 'prisoner-offender-search.prisoner.updated' event, alerts didn't change: prisonerNumber = ${prisonOffenderEvent.additionalInformation.nomsNumber}, categoriesChanged = ${prisonOffenderEvent.additionalInformation.categoriesChanged}")
     }
   }
 
@@ -293,7 +293,7 @@ class PrisonerIepLevelReviewService(
         description = "A prisoner next review date was updated",
       )
     } ?: run {
-      log.warn("prisonerNumber null for prisonOffenderEvent: $prisonOffenderEvent ")
+      log.warn("Could not update next review date: prisonerNumber null for prisonOffenderEvent: $prisonOffenderEvent ")
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -161,7 +161,7 @@ class PrisonerIepLevelReviewService(
   suspend fun handleSyncPostIepReviewRequest(bookingId: Long, syncPostRequest: SyncPostRequest): IepDetail {
     val iepDetail = persistSyncPostRequest(bookingId, syncPostRequest, true)
 
-    publishDomainEvent(iepDetail, IncentivesDomainEventType.IEP_REVIEW_INSERTED)
+    publishReviewDomainEvent(iepDetail, IncentivesDomainEventType.IEP_REVIEW_INSERTED)
     publishAuditEvent(iepDetail, AuditType.IEP_REVIEW_ADDED)
 
     return iepDetail
@@ -202,7 +202,7 @@ class PrisonerIepLevelReviewService(
     nextReviewDateUpdaterService.update(updatedReview.bookingId)
 
     val iepDetail = updatedReview.toIepDetail(prisonApiService.getIncentiveLevels())
-    publishDomainEvent(iepDetail, IncentivesDomainEventType.IEP_REVIEW_UPDATED)
+    publishReviewDomainEvent(iepDetail, IncentivesDomainEventType.IEP_REVIEW_UPDATED)
     publishAuditEvent(iepDetail, AuditType.IEP_REVIEW_UPDATED)
 
     return iepDetail
@@ -233,7 +233,7 @@ class PrisonerIepLevelReviewService(
     }
 
     val iepDetail = prisonerIepLevel.toIepDetail(prisonApiService.getIncentiveLevels())
-    publishDomainEvent(iepDetail, IncentivesDomainEventType.IEP_REVIEW_DELETED)
+    publishReviewDomainEvent(iepDetail, IncentivesDomainEventType.IEP_REVIEW_DELETED)
     publishAuditEvent(iepDetail, AuditType.IEP_REVIEW_DELETED)
   }
 
@@ -310,7 +310,7 @@ class PrisonerIepLevelReviewService(
       )
 
       val iepDetail = prisonerIepLevel.toIepDetail(prisonApiService.getIncentiveLevels())
-      publishDomainEvent(
+      publishReviewDomainEvent(
         iepDetail,
         IncentivesDomainEventType.IEP_REVIEW_INSERTED,
       )
@@ -399,7 +399,7 @@ class PrisonerIepLevelReviewService(
 
     // Propagate new IEP review to other services
     if (featureFlagsService.reviewAddedSyncMechanism() == ReviewAddedSyncMechanism.DOMAIN_EVENT) {
-      publishDomainEvent(newIepReview, IncentivesDomainEventType.IEP_REVIEW_INSERTED)
+      publishReviewDomainEvent(newIepReview, IncentivesDomainEventType.IEP_REVIEW_INSERTED)
     } else {
       prisonApiService.addIepReview(
         prisonerInfo.bookingId,
@@ -446,12 +446,21 @@ class PrisonerIepLevelReviewService(
     return review
   }
 
-  private suspend fun publishDomainEvent(
+  private suspend fun publishReviewDomainEvent(
     iepDetail: IepDetail,
     eventType: IncentivesDomainEventType,
   ) {
     iepDetail.id?.let {
-      snsService.sendIepReviewEvent(iepDetail.id, iepDetail.prisonerNumber ?: "N/A", iepDetail.iepTime, eventType)
+      val description: String = when (eventType) {
+        IncentivesDomainEventType.IEP_REVIEW_INSERTED -> "An IEP review has been added"
+        IncentivesDomainEventType.IEP_REVIEW_UPDATED -> "An IEP review has been updated"
+        IncentivesDomainEventType.IEP_REVIEW_DELETED -> "An IEP review has been deleted"
+        else -> {
+          throw IllegalArgumentException("Tried to publish a review event with a non-review event type: $eventType")
+        }
+      }
+
+      snsService.publishDomainEvent(iepDetail.id, iepDetail.prisonerNumber ?: "N/A", iepDetail.iepTime, eventType, description)
     } ?: run {
       log.warn("IepDetail has `null` id, domain event not published: $iepDetail")
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -152,7 +152,7 @@ class PrisonerIepLevelReviewService(
       )
     )
 
-    nextReviewDateUpdaterService.update(review.bookingId)
+    updateNextReviewDate(review.bookingId, prisonerInfo.offenderNo)
 
     return review.toIepDetail(prisonApiService.getIncentiveLevels())
   }
@@ -199,7 +199,7 @@ class PrisonerIepLevelReviewService(
     )
 
     val updatedReview = prisonerIepLevelRepository.save(prisonerIepLevel)
-    nextReviewDateUpdaterService.update(updatedReview.bookingId)
+    updateNextReviewDate(updatedReview.bookingId, updatedReview.prisonerNumber)
 
     val iepDetail = updatedReview.toIepDetail(prisonApiService.getIncentiveLevels())
     publishReviewDomainEvent(iepDetail, IncentivesDomainEventType.IEP_REVIEW_UPDATED)
@@ -222,7 +222,7 @@ class PrisonerIepLevelReviewService(
     }
 
     prisonerIepLevelRepository.delete(prisonerIepLevel)
-    nextReviewDateUpdaterService.update(bookingId)
+    updateNextReviewDate(bookingId, prisonerIepLevel.prisonerNumber)
 
     // If the deleted record had `current=true`, the latest IEP review becomes current
     if (prisonerIepLevel.current) {
@@ -284,6 +284,14 @@ class PrisonerIepLevelReviewService(
     prisonOffenderEvent.additionalInformation.nomsNumber?.let { prisonerNumber ->
       val offender = offenderSearchService.getOffender(prisonerNumber)
       nextReviewDateUpdaterService.updateMany(listOf(offender))
+
+      snsService.publishDomainEvent(
+        id = offender.bookingId,
+        nomsNumber = offender.prisonerNumber,
+        occurredAt = LocalDateTime.now(clock),
+        eventType = IncentivesDomainEventType.PRISONER_NEXT_REVIEW_DATE_UPDATED,
+        description = "A prisoner next review date was updated",
+      )
     } ?: run {
       log.warn("prisonerNumber null for prisonOffenderEvent: $prisonOffenderEvent ")
     }
@@ -417,6 +425,18 @@ class PrisonerIepLevelReviewService(
     return newIepReview
   }
 
+  suspend fun updateNextReviewDate(bookingId: Long, prisonerNumber: String) {
+    nextReviewDateUpdaterService.update(bookingId)
+
+    snsService.publishDomainEvent(
+      id = bookingId,
+      nomsNumber = prisonerNumber,
+      occurredAt = LocalDateTime.now(clock),
+      eventType = IncentivesDomainEventType.PRISONER_NEXT_REVIEW_DATE_UPDATED,
+      description = "A prisoner next review date was updated",
+    )
+  }
+
   suspend fun persistIepLevel(
     prisonerInfo: PrisonerAtLocation,
     iepReview: IepReview,
@@ -441,7 +461,7 @@ class PrisonerIepLevelReviewService(
       )
     )
 
-    nextReviewDateUpdaterService.update(prisonerInfo.bookingId)
+    updateNextReviewDate(prisonerInfo.bookingId, prisonerInfo.offenderNo)
 
     return review
   }
@@ -508,7 +528,7 @@ class PrisonerIepLevelReviewService(
     reviewsToUpdate.collect {
       prisonerIepLevelRepository.save(it)
     }
-    nextReviewDateUpdaterService.update(remainingBookingId)
+    updateNextReviewDate(remainingBookingId, remainingPrisonerNumber)
 
     val numberUpdated = reviewsToUpdate.count()
     if (numberUpdated > 0) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/SnsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/SnsService.kt
@@ -21,13 +21,13 @@ class SnsService(hmppsQueueService: HmppsQueueService, private val objectMapper:
   private val domaineventsTopic by lazy { hmppsQueueService.findByTopicId("domainevents") ?: throw RuntimeException("Topic with name domainevents doesn't exist") }
   private val domaineventsTopicClient by lazy { domaineventsTopic.snsClient }
 
-  fun sendIepReviewEvent(reviewId: Long, nomsNumber: String, occurredAt: LocalDateTime, eventType: IncentivesDomainEventType) {
+  fun publishDomainEvent(id: Long, nomsNumber: String, occurredAt: LocalDateTime, eventType: IncentivesDomainEventType, description: String) {
     publishToDomainEventsTopic(
       HMPPSDomainEvent(
         eventType.value,
-        AdditionalInformation(reviewId, nomsNumber, eventType.value),
+        AdditionalInformation(id, nomsNumber, eventType.value),
         occurredAt.atZone(ZoneId.systemDefault()).toInstant(),
-        "An IEP review has been added"
+        description,
       )
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/SnsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/SnsService.kt
@@ -51,6 +51,7 @@ data class AdditionalInformation(
   val nomsNumber: String? = null,
   val reason: String? = null,
   val removedNomsNumber: String? = null,
+  val categoriesChanged: List<String>? = null,
 )
 
 data class HMPPSDomainEvent(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/SnsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/SnsService.kt
@@ -79,6 +79,7 @@ enum class IncentivesDomainEventType(val value: String) {
   IEP_REVIEW_INSERTED("incentives.iep-review.inserted"),
   IEP_REVIEW_UPDATED("incentives.iep-review.updated"),
   IEP_REVIEW_DELETED("incentives.iep-review.deleted"),
+  PRISONER_NEXT_REVIEW_DATE_UPDATED("incentives.prisoner.next-review-date-updated"),
 }
 
 fun Instant.toOffsetDateFormat(): String =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/SnsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/SnsService.kt
@@ -79,7 +79,6 @@ enum class IncentivesDomainEventType(val value: String) {
   IEP_REVIEW_INSERTED("incentives.iep-review.inserted"),
   IEP_REVIEW_UPDATED("incentives.iep-review.updated"),
   IEP_REVIEW_DELETED("incentives.iep-review.deleted"),
-  PRISONER_NEXT_REVIEW_DATE_UPDATED("incentives.prisoner.next-review-date-updated"),
 }
 
 fun Instant.toOffsetDateFormat(): String =

--- a/src/main/resources/application-localstack.yml
+++ b/src/main/resources/application-localstack.yml
@@ -8,7 +8,7 @@ hmpps.sqs:
       queueName: incentives-event-queue
       dlqName: incentives-event-dlq
       subscribeTopicId: domainevents
-      subscribeFilter: '{"eventType":[ "prison-offender-events.prisoner.merged", "prisoner-offender-search.prisoner.received" ] }'
+      subscribeFilter: '{"eventType":[ "prison-offender-events.prisoner.merged", "prisoner-offender-search.prisoner.received", "prisoner-offender-search.prisoner.updated" ] }'
   topics:
     domainevents:
       arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonOffenderEventListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonOffenderEventListenerTest.kt
@@ -68,6 +68,17 @@ class PrisonOffenderEventListenerTest {
     }
   }
 
+  @Test
+  fun `process prisoner updated message`(): Unit = runBlocking {
+    coroutineScope {
+      // When
+      listener.onPrisonOffenderEvent("/messages/prisonerUpdated.json".readResourceAsText())
+
+      // Then
+      verify(prisonerIepLevelReviewService, times(1)).processPrisonerUpdatedEvent(any())
+    }
+  }
+
   private fun String.readResourceAsText(): String {
     return PrisonOffenderEventListenerTest::class.java.getResource(this)?.readText() ?: throw AssertionError("can not find file")
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
@@ -177,25 +177,8 @@ class PrisonerIepLevelReviewServiceTest {
         )
 
         // Domain event not published
-        verify(snsService, times(0)).publishDomainEvent(
-          42,
-          prisonerNumber,
-          reviewTime,
-          IncentivesDomainEventType.IEP_REVIEW_INSERTED,
-          "An IEP review has been added",
-        )
+        verify(snsService, times(0)).publishDomainEvent(any(), any(), any(), any(), any())
       }
-
-      // Next review date is updated/event is published
-      verify(nextReviewDateUpdaterService, times(1))
-        .update(bookingId)
-      verify(snsService, times(1)).publishDomainEvent(
-        bookingId,
-        prisonerNumber,
-        LocalDateTime.now(clock),
-        IncentivesDomainEventType.PRISONER_NEXT_REVIEW_DATE_UPDATED,
-        "A prisoner next review date was updated",
-      )
 
       // An audit event is published
       verify(auditService, times(1)).sendMessage(
@@ -641,15 +624,6 @@ class PrisonerIepLevelReviewServiceTest {
 
       verify(nextReviewDateUpdaterService, times(1))
         .updateMany(listOf(offender))
-
-      verify(snsService, times(1))
-        .publishDomainEvent(
-          id = bookingId,
-          nomsNumber = prisonerNumber,
-          occurredAt = LocalDateTime.now(clock),
-          eventType = IncentivesDomainEventType.PRISONER_NEXT_REVIEW_DATE_UPDATED,
-          description = "A prisoner next review date was updated",
-        )
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
@@ -177,8 +177,25 @@ class PrisonerIepLevelReviewServiceTest {
         )
 
         // Domain event not published
-        verify(snsService, times(0)).publishDomainEvent(any(), any(), any(), any(), any())
+        verify(snsService, times(0)).publishDomainEvent(
+          42,
+          prisonerNumber,
+          reviewTime,
+          IncentivesDomainEventType.IEP_REVIEW_INSERTED,
+          "An IEP review has been added",
+        )
       }
+
+      // Next review date is updated/event is published
+      verify(nextReviewDateUpdaterService, times(1))
+        .update(bookingId)
+      verify(snsService, times(1)).publishDomainEvent(
+        bookingId,
+        prisonerNumber,
+        LocalDateTime.now(clock),
+        IncentivesDomainEventType.PRISONER_NEXT_REVIEW_DATE_UPDATED,
+        "A prisoner next review date was updated",
+      )
 
       // An audit event is published
       verify(auditService, times(1)).sendMessage(
@@ -624,6 +641,15 @@ class PrisonerIepLevelReviewServiceTest {
 
       verify(nextReviewDateUpdaterService, times(1))
         .updateMany(listOf(offender))
+
+      verify(snsService, times(1))
+        .publishDomainEvent(
+          id = bookingId,
+          nomsNumber = prisonerNumber,
+          occurredAt = LocalDateTime.now(clock),
+          eventType = IncentivesDomainEventType.PRISONER_NEXT_REVIEW_DATE_UPDATED,
+          description = "A prisoner next review date was updated",
+        )
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
@@ -154,11 +154,12 @@ class PrisonerIepLevelReviewServiceTest {
 
       if (reviewAddedSyncMechanism == ReviewAddedSyncMechanism.DOMAIN_EVENT) {
         // A domain even is published
-        verify(snsService, times(1)).sendIepReviewEvent(
+        verify(snsService, times(1)).publishDomainEvent(
           42,
           prisonerNumber,
           reviewTime,
           IncentivesDomainEventType.IEP_REVIEW_INSERTED,
+          "An IEP review has been added",
         )
 
         // Prison API request not made
@@ -176,7 +177,7 @@ class PrisonerIepLevelReviewServiceTest {
         )
 
         // Domain event not published
-        verify(snsService, times(0)).sendIepReviewEvent(any(), any(), any(), any())
+        verify(snsService, times(0)).publishDomainEvent(any(), any(), any(), any(), any())
       }
 
       // An audit event is published
@@ -389,11 +390,12 @@ class PrisonerIepLevelReviewServiceTest {
       )
 
       verify(prisonerIepLevelRepository, times(1)).save(expectedPrisonerIepLevel)
-      verify(snsService, times(1)).sendIepReviewEvent(
+      verify(snsService, times(1)).publishDomainEvent(
         0,
         prisonerAtLocation().offenderNo,
         expectedPrisonerIepLevel.reviewTime,
-        IncentivesDomainEventType.IEP_REVIEW_INSERTED
+        IncentivesDomainEventType.IEP_REVIEW_INSERTED,
+        "An IEP review has been added",
       )
       verify(auditService, times(1))
         .sendMessage(
@@ -456,11 +458,12 @@ class PrisonerIepLevelReviewServiceTest {
       )
 
       verify(prisonerIepLevelRepository, times(1)).save(expectedPrisonerIepLevel)
-      verify(snsService, times(1)).sendIepReviewEvent(
+      verify(snsService, times(1)).publishDomainEvent(
         0,
         prisonerNumber,
         expectedPrisonerIepLevel.reviewTime,
-        IncentivesDomainEventType.IEP_REVIEW_INSERTED
+        IncentivesDomainEventType.IEP_REVIEW_INSERTED,
+        "An IEP review has been added",
       )
       verify(auditService, times(1))
         .sendMessage(
@@ -524,11 +527,12 @@ class PrisonerIepLevelReviewServiceTest {
       )
 
       verify(prisonerIepLevelRepository, times(1)).save(expectedPrisonerIepLevel)
-      verify(snsService, times(1)).sendIepReviewEvent(
+      verify(snsService, times(1)).publishDomainEvent(
         0,
         prisonerNumber,
         expectedPrisonerIepLevel.reviewTime,
-        IncentivesDomainEventType.IEP_REVIEW_INSERTED
+        IncentivesDomainEventType.IEP_REVIEW_INSERTED,
+        "An IEP review has been added",
       )
       verify(auditService, times(1))
         .sendMessage(
@@ -586,11 +590,12 @@ class PrisonerIepLevelReviewServiceTest {
       )
 
       verify(prisonerIepLevelRepository, times(1)).save(expectedPrisonerIepLevel)
-      verify(snsService, times(1)).sendIepReviewEvent(
+      verify(snsService, times(1)).publishDomainEvent(
         0,
         prisonerNumber,
         expectedPrisonerIepLevel.reviewTime,
-        IncentivesDomainEventType.IEP_REVIEW_INSERTED
+        IncentivesDomainEventType.IEP_REVIEW_INSERTED,
+        "An IEP review has been added",
       )
       verify(auditService, times(1))
         .sendMessage(
@@ -876,11 +881,12 @@ class PrisonerIepLevelReviewServiceTest {
       prisonerIepLevelReviewService.handleSyncDeleteIepReviewRequest(bookingId, iepReview.id)
 
       // SNS event is sent
-      verify(snsService, times(1)).sendIepReviewEvent(
+      verify(snsService, times(1)).publishDomainEvent(
         id,
         prisonerAtLocation().offenderNo,
         iepReview.reviewTime,
-        IncentivesDomainEventType.IEP_REVIEW_DELETED
+        IncentivesDomainEventType.IEP_REVIEW_DELETED,
+        "An IEP review has been deleted",
       )
 
       // audit message is sent
@@ -1035,11 +1041,12 @@ class PrisonerIepLevelReviewServiceTest {
       prisonerIepLevelReviewService.handleSyncPatchIepReviewRequest(bookingId, iepReview.id, syncPatchRequest)
 
       // SNS event is sent
-      verify(snsService, times(1)).sendIepReviewEvent(
+      verify(snsService, times(1)).publishDomainEvent(
         id,
         prisonerAtLocation().offenderNo,
         iepReview.reviewTime,
-        IncentivesDomainEventType.IEP_REVIEW_UPDATED
+        IncentivesDomainEventType.IEP_REVIEW_UPDATED,
+        "An IEP review has been updated",
       )
 
       // audit message is sent
@@ -1156,11 +1163,12 @@ class PrisonerIepLevelReviewServiceTest {
       prisonerIepLevelReviewService.handleSyncPostIepReviewRequest(bookingId, syncPostRequest)
 
       // SNS event is sent
-      verify(snsService, times(1)).sendIepReviewEvent(
+      verify(snsService, times(1)).publishDomainEvent(
         iepReviewId,
         prisonerAtLocation().offenderNo,
         syncPostRequest.iepTime,
-        IncentivesDomainEventType.IEP_REVIEW_INSERTED
+        IncentivesDomainEventType.IEP_REVIEW_INSERTED,
+        "An IEP review has been added",
       )
 
       // audit message is sent

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -44,7 +44,7 @@ hmpps.sqs:
       queueName: incentives-event-queue
       dlqName: incentives-event-dlq
       subscribeTopicId: domainevents
-      subscribeFilter: '{"eventType":[ "prison-offender-events.prisoner.merged", "prisoner-offender-search.prisoner.received" ] }'
+      subscribeFilter: '{"eventType":[ "prison-offender-events.prisoner.merged", "prisoner-offender-search.prisoner.received", "prisoner-offender-search.prisoner.updated" ] }'
   topics:
     domainevents:
       arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}

--- a/src/test/resources/messages/prisonerUpdated.json
+++ b/src/test/resources/messages/prisonerUpdated.json
@@ -1,0 +1,29 @@
+{
+  "Type": "Notification",
+  "MessageId": "ee46cb90-a2de-57bf-86ba-9d2eba64645a",
+  "TopicArn": "arn:aws:sns:eu-west-2:754256621582:cloud-platform-Digital-Prison-Services-f221e27fcfcf78f6ab4f4c3cc165eee7",
+  "Message":"{\"version\":\"1.0\", \"occurredAt\":\"2020-02-12T15:14:24.125533+00:00\", \"publishedAt\":\"2020-02-12T15:15:09.902048716+00:00\", \"description\":\"A prisoner record has been updated\", \"additionalInformation\":{\"nomsNumber\":\"A1244AB\", \"categoriesChanged\": [\"ALERTS\"]}}",
+  "Timestamp": "2020-02-12T15:15:06.239Z",
+  "SignatureVersion": "1",
+  "Signature": "E0oesISQOBGaDjgOg3wEFfCFcIMNN4GyOdCtLRuhXB8QOzFt5XhzhfhcypPyXvIN+G5+Ky79BK0SlXDWxv9vSw2tOSojNwH1vvbXApInAiqyAgIBNYgUk3l1MzKmkqoH5lWmgmo5U4szk5jKbL0LVVc4BYRY6pIq2ZWt4pPoX47Z5oibjfXZZhKsR6k5VCTnUD7lqa2hkWWqaqZIsoeCG5g83Xb5d7s+LlN5iV74gwP/lgZT0E/uSnRCk8Nx0UUPEvpk/04V5yaW6W9YP/hwKMNep873tYzTcFGilyKoU5ucy4vVMulwT+EL3iOmumQEoFcCd/BQotjU2+wQ4wL3/Q==",
+  "SigningCertURL": "https://sns.eu-west-2.amazonaws.com/SimpleNotificationService-a86cb10b4e1f29c941702d737128f7b6.pem",
+  "UnsubscribeURL": "https://sns.eu-west-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-2:754256621582:cloud-platform-Digital-Prison-Services-f221e27fcfcf78f6ab4f4c3cc165eee7:92545cfe-de5d-43e1-8339-c366bf0172aa",
+  "MessageAttributes": {
+    "eventType": {
+      "Type": "String",
+      "Value": "prisoner-offender-search.prisoner.updated"
+    },
+    "id": {
+      "Type": "String",
+      "Value": "11c19083-520d-5d7e-c91f-938a7b214ef2"
+    },
+    "contentType": {
+      "Type": "String",
+      "Value": "text/plain;charset=UTF-8"
+    },
+    "timestamp": {
+      "Type": "Number.java.lang.Long",
+      "Value": "1581520506234"
+    }
+  }
+}


### PR DESCRIPTION
- When a prisoner is updated and if the alerts changed update the next review date (see below)
- Fix incentives' reviews domain events description always being "An IEP review has been added", even tho maybe a review was actually patched or deleted (although admittedly these should happen less frequently)
- Better names for methods

**NOTE**: This is the processing side of the ticket, we need to [update the CP terraform resource](https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-domain-events-dev/resources/hmpps-incentives.tf#L118) to also get `prisoner-offender-search.prisoner.updated` domain events.

###  Notes on domain event used

Currently based on `prisoner-offender-search.prisoner.updated` event (`Domain` topic).
This event is published every time a prisoner is updated, this means we need to check if the `categoriesChanged` field lists `ALERTS` as changed. Furthermore we should really re-calculate the next review date when ACCT alerts change (`alertCode == "HA"`).

We're planning to add a `prisoner-offender-search.prisoner.alerts-updated` domain event which would be published only when the alerts changes. This would also include the `alertCode` in the `additionalInformation`, which means we should receive less messages and update the next review date only when ACCT status changed.