### PR TITLE
INC-930: Fix sync DELETE endpoint always assuming review was current

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -225,7 +225,7 @@ class PrisonerIepLevelReviewService(
     nextReviewDateUpdaterService.update(bookingId)
 
     // If the deleted record had `current=true`, the latest IEP review becomes current
-    prisonerIepLevel.current.let {
+    if (prisonerIepLevel.current) {
       // The deleted record was current, set new current to the latest IEP review
       prisonerIepLevelRepository.findFirstByBookingIdOrderByReviewTimeDesc(bookingId)?.run {
         prisonerIepLevelRepository.save(this.copy(current = true))


### PR DESCRIPTION
The use of `.let {}` instead of a simple `if ()` caused the the sync DELETE endpoint to always try to set another review as current even when unnecessary.

This can lead to a violation of the DB constrain that prevents more than one current reviews for the same `bookindId`.

See: https://mojdt.slack.com/archives/C03BCRW4B5G/p1668786899831079