### PR TITLE
INC-931: Paginate responses of incentives reviews

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResource.kt
@@ -75,9 +75,9 @@ class IncentiveReviewsResource(private val incentiveReviewsService: IncentiveRev
     @RequestParam(required = false)
     order: Sort.Direction? = null,
 
-    @Schema(description = "Page (starts at 1)", defaultValue = "1", minimum = "1", example = "2", type = "integer", required = false, format = "int32")
-    @RequestParam(required = false, defaultValue = "1")
-    page: Int = 1,
+    @Schema(description = "Page (starts at 0)", defaultValue = "0", minimum = "0", example = "2", type = "integer", required = false, format = "int32")
+    @RequestParam(required = false, defaultValue = "0")
+    page: Int = 0,
 
     @Schema(description = "Page size", defaultValue = "$DEFAULT_PAGE_SIZE", minimum = "1", maximum = "100", example = "20", type = "integer", required = false, format = "int32")
     @RequestParam(required = false, defaultValue = "$DEFAULT_PAGE_SIZE")
@@ -87,7 +87,7 @@ class IncentiveReviewsResource(private val incentiveReviewsService: IncentiveRev
       ("prisonId" to prisonId).hasLengthAtLeast(3).hasLengthAtMost(5)
       ("cellLocationPrefix" to cellLocationPrefix).hasLengthAtLeast(5)
       ("levelCode" to levelCode).hasLengthAtLeast(2)
-      ("page" to page).isAtLeast(1)
+      ("page" to page).isAtLeast(0)
       ("pageSize" to pageSize).isAtLeast(1).isAtMost(100)
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsService.kt
@@ -33,7 +33,7 @@ class IncentiveReviewsService(
 
   /**
    * Returns incentive review information for a given location within a prison and on a given level
-   * NB: page is 1-based
+   * NB: page is 0-based
    */
   suspend fun reviews(
     prisonId: String,
@@ -41,7 +41,7 @@ class IncentiveReviewsService(
     levelCode: String,
     sort: IncentiveReviewSort? = null,
     order: Sort.Direction? = null,
-    page: Int = 1,
+    page: Int = 0,
     size: Int = DEFAULT_PAGE_SIZE,
   ): IncentiveReviewResponse = coroutineScope {
     val deferredOffenders = async {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsService.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.toList
 import org.apache.commons.text.WordUtils
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClientResponseException.NotFound
@@ -15,6 +16,7 @@ import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.CaseNoteUsage
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonerIepLevelRepository
 import uk.gov.justice.digital.hmpps.incentivesapi.util.flow.toMap
+import uk.gov.justice.digital.hmpps.incentivesapi.util.paginateWith
 import java.time.Clock
 import java.time.LocalDate
 import java.util.Comparator
@@ -99,11 +101,14 @@ class IncentiveReviewsService(
       .filter { it.levelCode == levelCode }
       .sortedWith(comparator)
 
+    val reviewsCount = reviews.size
+    val reviewsPage = reviews paginateWith PageRequest.of(page, size)
+
     IncentiveReviewResponse(
       locationDescription = locationDescription,
       overdueCount = overdueCount,
-      reviewCount = reviews.size,
-      reviews = reviews,
+      reviewCount = reviewsCount,
+      reviews = reviewsPage,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsService.kt
@@ -67,9 +67,7 @@ class IncentiveReviewsService(
     val deferredNegativeCaseNotesInLast3Months = async { getCaseNoteUsage("NEG", "IEP_WARN", prisonerNumbers) }
 
     val deferredIncentiveLevels = async { getIncentiveLevelsForOffenders(bookingIds) }
-
-    val nextReviewDates = nextReviewDateGetterService.getMany(offenders.content)
-    val overdueCount = nextReviewDates.values.count { it.isBefore(LocalDate.now(clock)) }
+    val deferredNextReviewDates = async { nextReviewDateGetterService.getMany(offenders.content) }
 
     val incentiveLevels = deferredIncentiveLevels.await()
     val bookingIdsMissingIncentiveLevel = bookingIds subtract incentiveLevels.keys
@@ -80,6 +78,8 @@ class IncentiveReviewsService(
     val positiveCaseNotesInLast3Months = deferredPositiveCaseNotesInLast3Months.await()
     val negativeCaseNotesInLast3Months = deferredNegativeCaseNotesInLast3Months.await()
 
+    val nextReviewDates = deferredNextReviewDates.await()
+    val overdueCount = nextReviewDates.values.count { it.isBefore(LocalDate.now(clock)) }
     val locationDescription = deferredLocationDescription.await()
 
     val comparator = IncentiveReviewSort.orDefault(sort) comparingIn order

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/util/pagination.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/util/pagination.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.incentivesapi.util
+
+import org.springframework.data.domain.PageRequest
+import javax.validation.ValidationException
+import kotlin.math.min
+
+infix fun <T> List<T>.paginateWith(pageRequest: PageRequest): List<T> {
+  if (pageRequest.pageNumber == 0 && isEmpty()) {
+    return emptyList()
+  }
+
+  val offset = pageRequest.offset.toInt()
+  if (offset > size) {
+    throw ValidationException("Page number is out of range")
+  }
+  val limit = min(offset + pageRequest.pageSize, size)
+  return this.subList(offset, limit)
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResourceTest.kt
@@ -40,7 +40,8 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
   }
 
   private val iepTime: LocalDateTime = LocalDateTime.now()
-  suspend fun persistPrisonerIepLevel(
+
+  private suspend fun persistPrisonerIepLevel(
     bookingId: Long,
     prisonerNumber: String,
   ) = prisonerIepLevelRepository.save(
@@ -86,6 +87,13 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
 
   @Nested
   inner class `validates request parameters` {
+    @BeforeEach
+    fun setUp() {
+      prisonApiMockServer.stubPositiveCaseNoteSummary()
+      prisonApiMockServer.stubNegativeCaseNoteSummary()
+      prisonApiMockServer.stubIepLevels()
+    }
+
     @Test
     fun `when prisonId is incorrect`() {
       offenderSearchMockServer.stubFindOffenders("Moorland")
@@ -153,7 +161,7 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
       prisonApiMockServer.stubLocation("MDI-1")
 
       webTestClient.get()
-        .uri("/incentives-reviews/prison/MDI/location/MDI-1/level/STD?page=0")
+        .uri("/incentives-reviews/prison/MDI/location/MDI-1/level/STD?page=-1")
         .headers(setAuthorisation(roles = listOf("ROLE_INCENTIVES")))
         .exchange()
         .expectStatus().isBadRequest
@@ -162,8 +170,8 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
           """
           {
             "status": 400,
-            "userMessage": "Invalid parameters: `page` must be at least 1",
-            "developerMessage": "Invalid parameters: `page` must be at least 1"
+            "userMessage": "Invalid parameters: `page` must be at least 0",
+            "developerMessage": "Invalid parameters: `page` must be at least 0"
           }
           """
         )
@@ -175,7 +183,7 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
       prisonApiMockServer.stubLocation("MDI-1")
 
       webTestClient.get()
-        .uri("/incentives-reviews/prison/MDI/location/MDI-1/level/STD?page=0&pageSize=0")
+        .uri("/incentives-reviews/prison/MDI/location/MDI-1/level/STD?page=-1&pageSize=0")
         .headers(setAuthorisation(roles = listOf("ROLE_INCENTIVES")))
         .exchange()
         .expectStatus().isBadRequest
@@ -184,8 +192,8 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
           """
           {
             "status": 400,
-            "userMessage": "Invalid parameters: `page` must be at least 1, `pageSize` must be at least 1",
-            "developerMessage": "Invalid parameters: `page` must be at least 1, `pageSize` must be at least 1"
+            "userMessage": "Invalid parameters: `page` must be at least 0, `pageSize` must be at least 1",
+            "developerMessage": "Invalid parameters: `page` must be at least 0, `pageSize` must be at least 1"
           }
           """
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/util/PaginationTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/util/PaginationTests.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.incentivesapi.util
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.springframework.data.domain.PageRequest
+import javax.validation.ValidationException
+
+class PaginationTests {
+  @Test
+  fun `slices a list into pages`() {
+    val list = listOf("a", "b", "c", "d", "e")
+    var page = list paginateWith PageRequest.of(0, 2)
+    assertThat(page).isEqualTo(listOf("a", "b"))
+    page = list paginateWith PageRequest.of(1, 2)
+    assertThat(page).isEqualTo(listOf("c", "d"))
+    page = list paginateWith PageRequest.of(2, 2)
+    assertThat(page).isEqualTo(listOf("e"))
+  }
+
+  @Test
+  fun `throws an error for pages starting beyond end of list`() {
+    val empty = emptyList<Int>()
+    assertThatThrownBy {
+      empty paginateWith PageRequest.of(1, 10)
+    }.isInstanceOf(ValidationException::class.java)
+      .hasMessage("Page number is out of range")
+
+    val nonEmpty = listOf(1, 2, 3)
+    assertThatThrownBy {
+      nonEmpty paginateWith PageRequest.of(1, 10)
+    }.isInstanceOf(ValidationException::class.java)
+      .hasMessage("Page number is out of range")
+  }
+
+  @Test
+  fun `returns an empty page 0 for an empty list`() {
+    val empty = emptyList<Int>()
+    val page = empty paginateWith PageRequest.of(0, 10)
+    assertThat(page).isEmpty()
+  }
+}


### PR DESCRIPTION
Notable change: the reviews resource now counts pages starting from 0 (not 1 as before) to match Spring Data’s conventions; other HMPPS apis do this too.