### PR TITLE
INC-813: Add index on reviews' `booking_id`

### DIFF
--- a/src/main/resources/db/migration/V1_20__prisoner_iep_level_add_index_on_booking_id.sql
+++ b/src/main/resources/db/migration/V1_20__prisoner_iep_level_add_index_on_booking_id.sql
@@ -1,0 +1,1 @@
+create index prisoner_iep_level_booking_id_idx on prisoner_iep_level (booking_id);


### PR DESCRIPTION
Some of the queries getting the reviews for a prisoner are slow, add an index on `booking_id` should help avoid a full table scan for these.

(to the `prisoner_iep_level` DB table)