### PR TITLE
INC-936: manually set whenUpdated in NextReviewDate records

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/NextReviewDate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/NextReviewDate.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.incentivesapi.jpa
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.Id
-import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.annotation.ReadOnlyProperty
 import org.springframework.data.annotation.Transient
 import org.springframework.data.domain.Persistable
@@ -20,8 +19,6 @@ data class NextReviewDate(
   @ReadOnlyProperty
   val whenCreated: LocalDateTime? = null,
 
-  @LastModifiedDate
-  @ReadOnlyProperty
   val whenUpdated: LocalDateTime? = null,
 
   @Transient

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterService.kt
@@ -8,13 +8,16 @@ import uk.gov.justice.digital.hmpps.incentivesapi.jpa.NextReviewDate
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.NextReviewDateRepository
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonerIepLevelRepository
+import java.time.Clock
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 /**
  * Recalculates and persists next review dates
  */
 @Service
 class NextReviewDateUpdaterService(
+  private val clock: Clock,
   private val prisonerIepLevelRepository: PrisonerIepLevelRepository,
   private val nextReviewDateRepository: NextReviewDateRepository,
   private val prisonApiService: PrisonApiService,
@@ -77,6 +80,7 @@ class NextReviewDateUpdaterService(
         bookingId = bookingId,
         nextReviewDate = nextReviewDate,
         new = !nextReviewDateRepository.existsById(bookingId),
+        whenUpdated = LocalDateTime.now(clock),
       )
     }
 


### PR DESCRIPTION
`@LastModifiedDate` annotation doesn't work. It's probably because we're not using spring-data-jpa and instead we use `spring-data-r2dbc`.

Only place which updates `NextReviewDate` records is the `NextReviewDateUpdaterService` so we can explicitly set the `whenUpdated` field to now when this happens.

Tests had to be updated in order for some mocks to work as expected but overall this is simple enough and it works.