### PR TITLE
Remove unnecessary/broken `@CreatedDate` annotation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/NextReviewDate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/NextReviewDate.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.incentivesapi.jpa
 
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.Id
 import org.springframework.data.annotation.ReadOnlyProperty
 import org.springframework.data.annotation.Transient
@@ -15,7 +14,6 @@ data class NextReviewDate(
 
   val nextReviewDate: LocalDate,
 
-  @CreatedDate
   @ReadOnlyProperty
   val whenCreated: LocalDateTime? = null,
 


### PR DESCRIPTION
We noticed that `@CreatedDate`/`@LastModifiedDate` annotations don't work because we're using `spring-data-r2dbc` (and not `spring-data-jpa`).

The `when_created` column is populated correctly because of the DB default, but it makes sense to remove this annotation to avoid confusion.