### PR TITLE
INC-949: Migration endpoint don't update next review date

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -153,14 +153,14 @@ class PrisonerIepLevelReviewService(
       )
     )
 
-    nextReviewDateUpdaterService.update(review.bookingId)
-
     return review.toIepDetail(prisonApiService.getIncentiveLevels())
   }
 
   @Transactional
   suspend fun handleSyncPostIepReviewRequest(bookingId: Long, syncPostRequest: SyncPostRequest): IepDetail {
     val iepDetail = persistSyncPostRequest(bookingId, syncPostRequest, true)
+
+    nextReviewDateUpdaterService.update(bookingId)
 
     publishReviewDomainEvent(iepDetail, IncentivesDomainEventType.IEP_REVIEW_INSERTED)
     publishAuditEvent(iepDetail, AuditType.IEP_REVIEW_ADDED)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
@@ -773,7 +773,7 @@ class PrisonerIepLevelReviewServiceTest {
       )
 
       // Triggers the update of next review date when a new review is created
-      verify(nextReviewDateUpdaterService, times(1)).update(bookingId)
+      verify(nextReviewDateUpdaterService, times(0)).update(bookingId)
     }
 
     @Test
@@ -1156,6 +1156,16 @@ class PrisonerIepLevelReviewServiceTest {
 
       // Then check it's returned
       assertThat(result).isEqualTo(iepDetail)
+    }
+
+    @Test
+    fun `updates next review date`(): Unit = runBlocking {
+      // When
+      prisonerIepLevelReviewService.handleSyncPostIepReviewRequest(bookingId, syncPostRequest)
+
+      // Then check it's returned
+      verify(nextReviewDateUpdaterService, times(1))
+        .update(bookingId)
     }
 
     @Test


### PR DESCRIPTION
During the migration a lot of intermediate reviews are created. It doesn't make much sense to update the next review date every time a potentially old review is created.

This has also 2 performance benefits:
- we avoid making more requests when handling migration requests which makes the migration faster
- when we'll publish domain events on next review date change these will trigger a reindex of the prisoner in ES/Offender Search API: we don't want to trigger a reindex for each of the intermediate/old reviews being migrated from NOMIS