### PR TITLE
INC-940: Increase health-check timeout for external apis to 3s

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,7 +71,7 @@ spring:
       sslRootCert: /home/appuser/.postgresql/root.crt
 
 api:
-  health-timeout-ms: 1000
+  health-timeout-ms: 3000
 
 server:
   port: 8080


### PR DESCRIPTION
…because 1s is short enough for some tests to be flakey. Additionally, 1s might be a bit too short for external apis for the deployed app too: a dependency experiencing high load would reply slower and cause our app’s health check to be flappy.

Sample flakey health-check response from `Health page reports ok` test:

```json
{
  "status": "DOWN",
  "components": {
    "audit-health": {
      "status": "UP",
      "details": {
        "queueName": "45c4180c-facf-4b06-b77c-f4c1dfefe98d",
        "messagesOnQueue": "0",
        "messagesInFlight": "0"
      }
    },
    "authHealthCheck": {
      "status": "DOWN",
      "details": {
        "error": "java.lang.IllegalStateException: Timeout on blocking read for 1000000000 NANOSECONDS"
      }
    },
    "diskSpace": {
      "status": "UP",
      "details": {
        "total": 250790436864,
        "free": 29556772864,
        "threshold": 10485760,
        "exists": true
      }
    },
    "domainevents-health": {
      "status": "UP",
      "details": {
        "topicArn": "arn:aws:sns:eu-west-2:000000000000:11111111-2222-3333-4444-555555555555",
        "subscriptionsConfirmed": "0",
        "subscriptionsPending": "0"
      }
    },
    "healthInfo": {
      "status": "UP",
      "details": {
        "version": "2022-11-28"
      }
    },
    "incentives-health": {
      "status": "UP",
      "details": {
        "queueName": "incentives-event-queue",
        "messagesOnQueue": "0",
        "messagesInFlight": "0",
        "dlqStatus": "UP",
        "dlqName": "incentives-event-dlq",
        "messagesOnDlq": "0"
      }
    },
    "livenessState": {
      "status": "UP"
    },
    "offenderSearchApiHealthCheck": {
      "status": "DOWN",
      "details": {
        "error": "java.lang.IllegalStateException: Timeout on blocking read for 1000000000 NANOSECONDS"
      }
    },
    "ping": {
      "status": "UP"
    },
    "prisonApiHealthCheck": {
      "status": "DOWN",
      "details": {
        "error": "java.lang.IllegalStateException: Timeout on blocking read for 1000000000 NANOSECONDS"
      }
    },
    "r2dbc": {
      "status": "UP",
      "details": {
        "database": "PostgreSQL",
        "validationQuery": "validate(REMOTE)"
      }
    },
    "readinessState": {
      "status": "UP"
    }
  },
  "groups": [
    "liveness",
    "readiness"
  ]
}
```