### PR TITLE
INC-962: Fix for sync race condition/duplicated NOMIS reviews

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -162,7 +162,9 @@ class PrisonerIepLevelReviewService(
 
     nextReviewDateUpdaterService.update(bookingId)
 
-    publishReviewDomainEvent(iepDetail, IncentivesDomainEventType.IEP_REVIEW_INSERTED)
+    // NOTE: This reason is to allow service that syncs back to NOMIS to ignore these domain events (as these reviews
+    // are already coming from NOMIS, they don't need to be synced again)
+    publishReviewDomainEvent(iepDetail, IncentivesDomainEventType.IEP_REVIEW_INSERTED, IepReviewReason.USER_CREATED_NOMIS)
     publishAuditEvent(iepDetail, AuditType.IEP_REVIEW_ADDED)
 
     return iepDetail
@@ -457,6 +459,7 @@ class PrisonerIepLevelReviewService(
   private suspend fun publishReviewDomainEvent(
     iepDetail: IepDetail,
     eventType: IncentivesDomainEventType,
+    reason: IepReviewReason? = null,
   ) {
     iepDetail.id?.let {
       val description: String = when (eventType) {
@@ -475,6 +478,7 @@ class PrisonerIepLevelReviewService(
         AdditionalInformation(
           id = iepDetail.id,
           nomsNumber = iepDetail.prisonerNumber ?: "N/A",
+          reason = reason?.toString(),
         ),
       )
     } ?: run {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/SnsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/SnsService.kt
@@ -84,5 +84,9 @@ enum class IncentivesDomainEventType(val value: String) {
   PRISONER_NEXT_REVIEW_DATE_CHANGED("incentives.prisoner.next-review-date-changed"),
 }
 
+enum class IepReviewReason {
+  USER_CREATED_NOMIS, // NOTE: Used by Syscon sync service to discriminate reviews already synced
+}
+
 fun Instant.toOffsetDateFormat(): String =
   atZone(ZoneId.of("Europe/London")).toOffsetDateTime().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
@@ -1195,6 +1195,7 @@ class PrisonerIepLevelReviewServiceTest {
         additionalInformation = AdditionalInformation(
           id = iepReviewId,
           nomsNumber = prisonerAtLocation().offenderNo,
+          reason = "USER_CREATED_NOMIS",
         )
       )
 


### PR DESCRIPTION
Because of the timing between when the sync service tells us about new reviews (via `POST /iep/sync/booking/:bookingId` endpoint) and when we respond/this is stored in the sync mapping service, another domain event is published causing duplicated reviews in NOMIS.

The sync service should really ignore domain events published by this sync POST endpoint because these reviews are already in NOMIS.

We're now adding a `"reason": "USER_CREATED_NOMIS"` (in the usual `additionalInformation`) so that sync service can ignore these domain events and avoid duplicates.