### PR TITLE
INC-961: Fix default value for sync mechanism after rename

### DIFF
--- a/helm_deploy/hmpps-incentives-api/values.yaml
+++ b/helm_deploy/hmpps-incentives-api/values.yaml
@@ -33,7 +33,7 @@ generic-service:
     SPRING_PROFILES_ACTIVE: "logstash"
     APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY)"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
-    FEATURE_REVIEWADDEDSYNCMECHANISM: "PRISON_API"
+    FEATURE_REVIEW_ADDED_SYNC_MECHANISM: "PRISON_API"
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:


### PR DESCRIPTION
The environment variable was renamed in most places but not in the default values leading to the pod having both environment variables set but with different values. I don't know which one would win and it's best to avoid confusion anyway.

See Pod variables in `dev`:

```YAML
    - name: FEATURE_REVIEWADDEDSYNCMECHANISM
      value: PRISON_API
    - name: FEATURE_REVIEW_ADDED_SYNC_MECHANISM
      value: DOMAIN_EVENT
```

(which one will Spring Boot use?)