### PR TITLE
INC-965: Increase `reviewed_by` length to avoid errors

### DIFF
--- a/src/main/resources/db/migration/V1_21__prisoner_iep_level_increase_reviewed_by_length.sql
+++ b/src/main/resources/db/migration/V1_21__prisoner_iep_level_increase_reviewed_by_length.sql
@@ -1,0 +1,2 @@
+-- Increased 'reviewed_by' length to be able to fit all users
+ALTER TABLE prisoner_iep_level ALTER COLUMN reviewed_by TYPE VARCHAR(32);


### PR DESCRIPTION
We saw some errors in `prod` caused by some of the values being longer than 30 characters:

```
API error in POST /iep/reviews/booking/1175396 500 Internal Server Error
{"status":500,"userMessage":"Unexpected error: executeMany;
bad SQL grammar [INSERT INTO prisoner_iep_level (booking_id, prisoner_number, prison_id, location_id, review_time, reviewed_by, iep_code, comment_text, current, review_type)
VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)];
nested exception is io.r2dbc.postgresql.ExceptionFactory$PostgresqlBadGrammarException:
[22001] value too long for type character varying(30)" [...]
```

I had a look at Prison API's/NOMIS migration that added `staff_members` and `user_id` there has a max length of 32 characters, so this should be the problem. I'm updating our `reviewed_by` column to have the same length

https://github.com/ministryofjustice/prison-api/blob/main/src/main/resources/db/migration/nomis/ddl/V1_43__STAFF_MEMBERS.sql#L7