### PR TITLE
INC-821: Next review date calculation takes readmissions in consideration

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/ReviewType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/ReviewType.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.incentivesapi.dto
 
 enum class ReviewType {
-  INITIAL, REVIEW, TRANSFER, MIGRATED
+  INITIAL, REVIEW, TRANSFER, MIGRATED, READMISSION
 }
 
 interface IsRealReview {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -259,7 +259,9 @@ class PrisonerIepLevelReviewService(
   @Transactional
   suspend fun processOffenderEvent(prisonOffenderEvent: HMPPSDomainEvent) =
     when (prisonOffenderEvent.additionalInformation.reason) {
-      "NEW_ADMISSION", "READMISSION" -> createIepForReceivedPrisoner(prisonOffenderEvent, ReviewType.INITIAL)
+      "NEW_ADMISSION" -> createIepForReceivedPrisoner(prisonOffenderEvent, ReviewType.INITIAL)
+      // NOTE: This may NOT be a recall. Someone could be readmitted back to prison for a number of other reasons (e.g. remands)
+      "READMISSION" -> createIepForReceivedPrisoner(prisonOffenderEvent, ReviewType.READMISSION)
       "TRANSFERRED" -> createIepForReceivedPrisoner(prisonOffenderEvent, ReviewType.TRANSFER)
       "MERGE" -> mergedPrisonerDetails(prisonOffenderEvent)
       else -> {
@@ -327,7 +329,7 @@ class PrisonerIepLevelReviewService(
     val defaultLevelCode = iepLevelService.chooseDefaultLevel(prisonerInfo.agencyId, iepLevelsForPrison)
 
     return when (reviewType) {
-      ReviewType.INITIAL -> {
+      ReviewType.INITIAL, ReviewType.READMISSION -> {
         defaultLevelCode // admission should always be the default
       }
       ReviewType.TRANSFER -> {

--- a/src/main/resources/db/migration/V1_22__prisoner_iep_level_alter_review_type_length.sql
+++ b/src/main/resources/db/migration/V1_22__prisoner_iep_level_alter_review_type_length.sql
@@ -1,0 +1,2 @@
+-- Increased 'review_type' length to be able to fit 'READMISSION'
+ALTER TABLE prisoner_iep_level ALTER COLUMN review_type TYPE VARCHAR(16);


### PR DESCRIPTION
When someone is re-admitted into prison with the same booking (e.g. because of a recall, remand or potentially other similar cases) a "review" is created with time "READMISSION".

The next review date service checks if the last "review" is a readmission and in that case uses the same rules used for new prisoners to calculate the next review date (so within 3 months from readmission date for adults, within 1 month for young people).

**NOTE**: The Incentives policy only mention recalls but we don't have any reliable way to discriminate between recalls and other kind of readmissions. We think it's OK to treat all readmissions as new prisoners (for the purpose of calculating the next review date) but I'll also check with Steve.