### PR TITLE
INC-966: Increase `prisoner_iep_level.location_id` column length

### DIFF
--- a/src/main/resources/db/migration/V1_22__prisoner_iep_level_increase_location_id_length.sql
+++ b/src/main/resources/db/migration/V1_22__prisoner_iep_level_increase_location_id_length.sql
@@ -1,0 +1,2 @@
+-- Increased 'location_id' length to be able to fit locations descriptions. These can be 240 chars
+ALTER TABLE prisoner_iep_level ALTER COLUMN location_id TYPE VARCHAR(240);


### PR DESCRIPTION
Some of the SQL INSERT rarely fails because of the fact a location description is longer (up to 240 characters) than the `location_id` column where they're stored (which is currently 30 characters max).

Given we're storing the location description, and as also suggested by Syscon, I'm increasing the length of this column to 240 characters so that it's in line with the maximum possible value.