### PR TITLE
Use Incentives database as source of truth

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -11,7 +11,7 @@ generic-service:
     API_BASE_URL_PRISON: https://api.prison.service.justice.gov.uk
     API_BASE_URL_OFFENDER_SEARCH: https://prisoner-offender-search.prison.service.justice.gov.uk
     FEATURE_REVIEW_ADDED_SYNC_MECHANISM: "DOMAIN_EVENT"
-    FEATURE_INCENTIVES_DATA_SOURCE_OF_TRUTH: false
+    FEATURE_INCENTIVES_DATA_SOURCE_OF_TRUTH: true
 
 # CloudPlatform AlertManager receiver to route Prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts


### PR DESCRIPTION
When getting the history of reviews for a prisoner use the Incentives DB instead of getting it from NOMIS (via Prison API)

NOTE: We can now do this because we migrated all the data and 2-way syncing is enabled.