### PR TITLE
INC-958: Use new `alerts-updated` domain events to recalculate the next review date

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/prisonapi/prisonapidto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/prisonapi/prisonapidto.kt
@@ -23,7 +23,11 @@ data class PrisonerAlert(
   val active: Boolean,
   val expired: Boolean,
 ) {
-  val isOpenAcct = alertCode == "HA" && active && !expired
+  companion object {
+    const val ACCT_ALERT_CODE = "HA"
+  }
+
+  val isOpenAcct = alertCode == ACCT_ALERT_CODE && active && !expired
 }
 
 data class PrisonerExtraInfo(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonOffenderEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonOffenderEventListener.kt
@@ -25,7 +25,7 @@ class PrisonOffenderEventListener(
     val hmppsDomainEvent = mapper.readValue(message, HMPPSDomainEvent::class.java)
     when (eventType) {
       "prisoner-offender-search.prisoner.received", "prison-offender-events.prisoner.merged" -> prisonerIepLevelReviewService.processOffenderEvent(hmppsDomainEvent)
-      "prisoner-offender-search.prisoner.updated" -> prisonerIepLevelReviewService.processPrisonerUpdatedEvent(hmppsDomainEvent)
+      "prisoner-offender-search.prisoner.alerts-updated" -> prisonerIepLevelReviewService.processPrisonerAlertsUpdatedEvent(hmppsDomainEvent)
       else -> {
         log.debug("Ignoring message with type $eventType")
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/SnsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/SnsService.kt
@@ -52,8 +52,10 @@ data class AdditionalInformation(
   val nomsNumber: String? = null,
   val reason: String? = null,
   val removedNomsNumber: String? = null,
-  val categoriesChanged: List<String>? = null,
   val nextReviewDate: LocalDate? = null,
+  val bookingId: Long? = null,
+  val alertsAdded: List<String>? = null,
+  val alertsRemoved: List<String>? = null,
 )
 
 data class HMPPSDomainEvent(

--- a/src/main/resources/application-localstack.yml
+++ b/src/main/resources/application-localstack.yml
@@ -8,7 +8,7 @@ hmpps.sqs:
       queueName: incentives-event-queue
       dlqName: incentives-event-dlq
       subscribeTopicId: domainevents
-      subscribeFilter: '{"eventType":[ "prison-offender-events.prisoner.merged", "prisoner-offender-search.prisoner.received", "prisoner-offender-search.prisoner.updated" ] }'
+      subscribeFilter: '{"eventType":[ "prison-offender-events.prisoner.merged", "prisoner-offender-search.prisoner.received", "prisoner-offender-search.prisoner.alerts-updated" ] }'
   topics:
     domainevents:
       arn: arn:aws:sns:eu-west-2:000000000000:11111111-2222-3333-4444-555555555555

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonOffenderEventListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonOffenderEventListenerTest.kt
@@ -69,13 +69,13 @@ class PrisonOffenderEventListenerTest {
   }
 
   @Test
-  fun `process prisoner updated message`(): Unit = runBlocking {
+  fun `process prisoner alerts updated message`(): Unit = runBlocking {
     coroutineScope {
       // When
-      listener.onPrisonOffenderEvent("/messages/prisonerUpdated.json".readResourceAsText())
+      listener.onPrisonOffenderEvent("/messages/prisonerAlertsUpdated.json".readResourceAsText())
 
       // Then
-      verify(prisonerIepLevelReviewService, times(1)).processPrisonerUpdatedEvent(any())
+      verify(prisonerIepLevelReviewService, times(1)).processPrisonerAlertsUpdatedEvent(any())
     }
   }
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -44,7 +44,7 @@ hmpps.sqs:
       queueName: incentives-event-queue
       dlqName: incentives-event-dlq
       subscribeTopicId: domainevents
-      subscribeFilter: '{"eventType":[ "prison-offender-events.prisoner.merged", "prisoner-offender-search.prisoner.received", "prisoner-offender-search.prisoner.updated" ] }'
+      subscribeFilter: '{"eventType":[ "prison-offender-events.prisoner.merged", "prisoner-offender-search.prisoner.received", "prisoner-offender-search.prisoner.alerts-updated" ] }'
   topics:
     domainevents:
       arn: arn:aws:sns:eu-west-2:000000000000:11111111-2222-3333-4444-555555555555

--- a/src/test/resources/messages/prisonerAlertsUpdated.json
+++ b/src/test/resources/messages/prisonerAlertsUpdated.json
@@ -2,7 +2,7 @@
   "Type": "Notification",
   "MessageId": "ee46cb90-a2de-57bf-86ba-9d2eba64645a",
   "TopicArn": "arn:aws:sns:eu-west-2:754256621582:cloud-platform-Digital-Prison-Services-f221e27fcfcf78f6ab4f4c3cc165eee7",
-  "Message":"{\"version\":\"1.0\", \"occurredAt\":\"2020-02-12T15:14:24.125533+00:00\", \"publishedAt\":\"2020-02-12T15:15:09.902048716+00:00\", \"description\":\"A prisoner record has been updated\", \"additionalInformation\":{\"nomsNumber\":\"A1244AB\", \"categoriesChanged\": [\"ALERTS\"]}}",
+  "Message":"{\"version\":\"1.0\", \"occurredAt\":\"2020-02-12T15:14:24.125533+00:00\", \"publishedAt\":\"2020-02-12T15:15:09.902048716+00:00\", \"description\":\"A prisoner had their alerts updated, added: 1, removed: 0\", \"additionalInformation\":{\"nomsNumber\":\"A1244AB\", \"bookingId\":\"1234567\", \"alertsAdded\": [\"HA\"], \"alertsRemoved\": []}}",
   "Timestamp": "2020-02-12T15:15:06.239Z",
   "SignatureVersion": "1",
   "Signature": "E0oesISQOBGaDjgOg3wEFfCFcIMNN4GyOdCtLRuhXB8QOzFt5XhzhfhcypPyXvIN+G5+Ky79BK0SlXDWxv9vSw2tOSojNwH1vvbXApInAiqyAgIBNYgUk3l1MzKmkqoH5lWmgmo5U4szk5jKbL0LVVc4BYRY6pIq2ZWt4pPoX47Z5oibjfXZZhKsR6k5VCTnUD7lqa2hkWWqaqZIsoeCG5g83Xb5d7s+LlN5iV74gwP/lgZT0E/uSnRCk8Nx0UUPEvpk/04V5yaW6W9YP/hwKMNep873tYzTcFGilyKoU5ucy4vVMulwT+EL3iOmumQEoFcCd/BQotjU2+wQ4wL3/Q==",
@@ -11,7 +11,7 @@
   "MessageAttributes": {
     "eventType": {
       "Type": "String",
-      "Value": "prisoner-offender-search.prisoner.updated"
+      "Value": "prisoner-offender-search.prisoner.alerts-updated"
     },
     "id": {
       "Type": "String",


### PR DESCRIPTION
Before this we were listening to the `prisoner.updated` domain event and updating the next review date any time any alerts changed. This is not ideal as we receive a lot of events we don't care about and also we potentially re-calculate the next review date when non-ACCT alerts changed.

Since then Andy has added a more specific domain event published when alerts changes (`prisoner-offender-search.prisoner.alerts-updated`), this domain event should be less frequent and it also includes the alert codes of the alerts added/removed meaning we can update the next review date only when an ACCT alert was added/removed.

**NOTE**: The old domain events are no longer processed so this can only be merged once the wiring to subscribe to the new events is working. The CP terraform changes were merged but I haven't seen these new messages in `dev` yet. Once these new messages are processed we can unsubscribe from old messages