### PR TITLE
Tweak Renovate to pin JDK version in Docker

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
   "packageRules": [
     {
       "matchDatasources": ["docker"],
-      "allowedVersions": "19-jre-jammy"
+      "allowedVersions": "eclipse-temurin:19-jre-jammy"
     },
     {
       "groupName": "spring doc",


### PR DESCRIPTION
To avoid PRs being raised https://github.com/ministryofjustice/hmpps-incentives-api/pull/262