### PR TITLE
Revert "Tweak Renovate to pin JDK version in Docker (#310)"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
   "packageRules": [
     {
       "matchDatasources": ["docker"],
-      "allowedVersions": "eclipse-temurin:19-jre-jammy"
+      "allowedVersions": "19-jre-jammy"
     },
     {
       "groupName": "spring doc",


### PR DESCRIPTION
This reverts commit 5801f64f314b2c9347e6a8023ea3149385579f87.

Should resolve https://github.com/ministryofjustice/hmpps-incentives-api/issues/312