### PR TITLE
INC-970: Fix for 'OUT has no available incentive levels'

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/prisonapi/prisonapidto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/prisonapi/prisonapidto.kt
@@ -7,6 +7,8 @@ import uk.gov.justice.digital.hmpps.incentivesapi.service.PrisonerInfoForNextRev
 import java.time.LocalDate
 import java.time.LocalDateTime
 
+const val AGENCY_ID_OUTSIDE = "OUT"
+
 data class PrisonerAtLocation(
   val bookingId: Long,
   val facialImageId: Long,


### PR DESCRIPTION
We're seeing a lot of these exceptions in `dev` (probably caused by the same domain event) but it's very noisy and makes it hard to see other more important problems.

We haven't seen this in production yet but it's feasable for this to happen there as well if, for whatever reason, at the time we process a domain even for a prisoner this is no longer in prison (their current agencyId would be `OUT` which stands for "Outside").

Try to determine the default Incentive level for OUT (which is not a valid prison) would cause an exception so it seems reason to just ignore these domain events (and log a warning message).