### PR TITLE
INC-1010 Issue with Invalid type in Prisoners in Incentives Review screen (old version)

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -6,7 +6,7 @@ services:
       - hmpps
     container_name: localstack
     ports:
-      - "4566-4597:4566-4597"
+      - "4566:4566"
       - "8999:8080"
     environment:
       - DEBUG=${DEBUG- }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
       - hmpps
     container_name: localstack-incentives-api
     ports:
-      - "4566-4597:4566-4597"
+      - "4566:4566"
       - "8999:8080"
     environment:
       - DEBUG=${DEBUG- }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveSummaryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveSummaryService.kt
@@ -142,8 +142,8 @@ class IncentiveSummaryService(
         val latestReview = review.firstOrNull(PrisonerIepLevel::isRealReview)
         IepResult(
           bookingId = it.key,
-          iepLevel = latestReview?.let { incentiveLevels[latestReview.iepCode]?.iepDescription ?: "Unmapped" }
-            ?: "Not Entered",
+          iepLevel = latestReview?.let { incentiveLevels[latestReview.iepCode]?.iepDescription ?: invalidLevel().iepLevel }
+            ?: missingLevel().iepLevel,
           daysSinceReview = latestReview?.let {
             Duration.between(
               latestReview.reviewTime.toLocalDate().atStartOfDay(),
@@ -156,7 +156,7 @@ class IncentiveSummaryService(
               .map { iep ->
                 IepDetail(
                   iepCode = iep.iepCode,
-                  iepLevel = incentiveLevels[iep.iepCode]?.iepDescription ?: "Unmapped",
+                  iepLevel = incentiveLevels[iep.iepCode]?.iepDescription ?: invalidLevel().iepDescription,
                   reviewType = iep.reviewType,
                   bookingId = iep.bookingId,
                   agencyId = iep.prisonId,
@@ -190,7 +190,7 @@ class IncentiveSummaryService(
 }
 
 fun invalidLevel() = IepLevel(iepLevel = "INV", iepDescription = "Invalid", sequence = 98)
-fun missingLevel() = IepLevel(iepLevel = "MIS", iepDescription = "Missing", sequence = 99)
+fun missingLevel() = IepLevel(iepLevel = "MIS", iepDescription = "No Review", sequence = 99)
 
 class NoPrisonersAtLocationException(prisonId: String, locationId: String) :
   Exception("No prisoners found at prison $prisonId, location $locationId")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveSummaryMasteredResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveSummaryMasteredResourceTest.kt
@@ -57,11 +57,11 @@ class IncentiveSummaryMasteredResourceTest : SqsIntegrationTestBase() {
       prisonId = "MDI"
     )
 
-    // Prisoner A1234AB has 1 incentive entry current STD,
+    // Prisoner A1234AB has 1 incentive entry current STD from entering prison
     prisonerIepLevel(
       bookingId = 1234135,
       prisonerNumber = "A1234AB",
-      reviewType = ReviewType.MIGRATED,
+      reviewType = ReviewType.INITIAL,
       reviewTime = LocalDateTime.of(2022, 1, 2, 9, 9, 24, 42),
       current = true
     )
@@ -230,22 +230,9 @@ class IncentiveSummaryMasteredResourceTest : SqsIntegrationTestBase() {
                        "negativeBehaviours":5,
                        "incentiveWarnings":0,
                        "provenAdjudications":0
-                    },
-                    {
-                       "prisonerNumber":"A1234AB",
-                       "bookingId":1234135,
-                       "firstName":"David",
-                       "lastName":"White",
-                       "daysOnLevel":5,
-                       "daysSinceLastReview":5,
-                       "positiveBehaviours":3,
-                       "incentiveEncouragements":0,
-                       "negativeBehaviours":3,
-                       "incentiveWarnings":0,
-                       "provenAdjudications":1
                     }
                  ],
-                 "numberAtThisLevel":2
+                 "numberAtThisLevel":1
               },
               {
                  "level":"ENH",
@@ -289,8 +276,21 @@ class IncentiveSummaryMasteredResourceTest : SqsIntegrationTestBase() {
               },
               {
                  "level":"MIS",
-                 "levelDescription":"Missing",
+                 "levelDescription":"No Review",
                  "prisonerBehaviours":[
+                     {
+                       "prisonerNumber":"A1234AB",
+                       "bookingId":1234135,
+                       "firstName":"David",
+                       "lastName":"White",
+                       "daysOnLevel":5,
+                       "daysSinceLastReview":0,
+                       "positiveBehaviours":3,
+                       "incentiveEncouragements":0,
+                       "negativeBehaviours":3,
+                       "incentiveWarnings":0,
+                       "provenAdjudications":1
+                    },
                     {
                        "prisonerNumber":"A1834AA",
                        "bookingId":2234134,
@@ -305,7 +305,7 @@ class IncentiveSummaryMasteredResourceTest : SqsIntegrationTestBase() {
                        "provenAdjudications":0
                     }
                  ],
-                 "numberAtThisLevel":1
+                 "numberAtThisLevel":2
               }
            ],
            "averageDaysSinceLastReview":30,


### PR DESCRIPTION
Where a prisoner has just entered prison (since migrating to new service 5 December) - if no REAL review has taken place the prisoner is show in a “Invalid” tab on the review screen.

Change this to put them in a “**No review**” tab, so its clear that no “real review” has yet taken place.