### PR TITLE
Bump generic-service to double-check latest version hasn't broken anything

### DIFF
--- a/helm_deploy/hmpps-incentives-api/Chart.yaml
+++ b/helm_deploy/hmpps-incentives-api/Chart.yaml
@@ -5,7 +5,7 @@ name: hmpps-incentives-api
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 2.3.0
+    version: 2.4.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.2.4


### PR DESCRIPTION
I made changes with https://github.com/ministryofjustice/hmpps-helm-charts/pull/86

Tested locally by following the steps here https://github.com/ministryofjustice/hmpps-helm-charts#testing-changes-locally also want to check it deploys to dev without issues