### PR TITLE
INC-988: Cache global list of all incentive levels

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IepLevelService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IepLevelService.kt
@@ -37,7 +37,7 @@ class IepLevelService(
     val levelCodesAvailableInPrison = prisonLevels.filter(IepLevel::active).map(IepLevel::iepLevel).toSet()
 
     data class KnownLevel(val code: String, val available: Boolean)
-    val allKnownLevels = prisonApiService.getIepLevels().toList()
+    val allKnownLevels = prisonApiService.getIepLevels()
       .sortedBy { it.sequence }
       .map {
         KnownLevel(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonApiService.kt
@@ -35,10 +35,10 @@ class PrisonApiService(
   }
 
   suspend fun getIncentiveLevels(): Map<String, IepLevel> {
-    return getIepLevels().toList().associateBy { iep -> iep.iepLevel }
+    return getIepLevels().associateBy { iep -> iep.iepLevel }
   }
 
-  fun getIepLevels(): Flow<IepLevel> {
+  suspend fun getIepLevels(): List<IepLevel> {
     return getClient(true)
       .get()
       .uri("/api/reference-domains/domains/IEP_LEVEL/codes")
@@ -51,6 +51,7 @@ class PrisonApiService(
           active = it.activeFlag == "Y"
         )
       }
+      .toList()
   }
 
   fun retrieveCaseNoteCounts(type: String, offenderNos: List<String>): Flow<CaseNoteUsage> =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonApiService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.incentivesapi.service
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.awaitBody
@@ -16,12 +17,21 @@ import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.PrisonLocation
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.PrisonerAtLocation
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.PrisonerExtraInfo
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.ProvenAdjudication
+import uk.gov.justice.digital.hmpps.incentivesapi.util.CachedValue
+import java.time.Clock
 
 @Service
 class PrisonApiService(
   private val prisonWebClient: WebClient,
   private val prisonWebClientClientCredentials: WebClient,
+  clock: Clock,
 ) {
+
+  val allIncentiveLevelsCache = CachedValue<List<IepLevel>>(validForHours = 24, clock)
+
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
 
   private fun getClient(useClientCredentials: Boolean = false): WebClient {
     return if (useClientCredentials) prisonWebClientClientCredentials else prisonWebClient
@@ -39,19 +49,30 @@ class PrisonApiService(
   }
 
   suspend fun getIepLevels(): List<IepLevel> {
-    return getClient(true)
-      .get()
-      .uri("/api/reference-domains/domains/IEP_LEVEL/codes")
-      .retrieve().bodyToFlow<IncentiveLevel>()
-      .map {
-        IepLevel(
-          iepLevel = it.code,
-          iepDescription = it.description,
-          sequence = it.listSeq,
-          active = it.activeFlag == "Y"
-        )
-      }
-      .toList()
+    val cachedValue = allIncentiveLevelsCache.get()
+    return if (cachedValue != null) {
+      cachedValue
+    } else {
+      log.debug("Getting all incentive levels using GET /api/reference-domains/domains/IEP_LEVEL/codes...")
+      val newValue = getClient(true)
+        .get()
+        .uri("/api/reference-domains/domains/IEP_LEVEL/codes")
+        .retrieve()
+        .bodyToFlow<IncentiveLevel>()
+        .map {
+          IepLevel(
+            iepLevel = it.code,
+            iepDescription = it.description,
+            sequence = it.listSeq,
+            active = it.activeFlag == "Y"
+          )
+        }
+        .toList()
+
+      allIncentiveLevelsCache.update(newValue)
+
+      return newValue
+    }
   }
 
   fun retrieveCaseNoteCounts(type: String, offenderNos: List<String>): Flow<CaseNoteUsage> =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/util/CachedValue.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/util/CachedValue.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.incentivesapi.util
+
+import java.time.Clock
+import java.time.LocalDateTime
+
+class CachedValue<T>(private val validForHours: Long = 24, var clock: Clock) {
+  private var value: T? = null
+  private var updatedAt: LocalDateTime? = null
+
+  fun get(): T? {
+    return if (isInvalid()) {
+      null
+    } else {
+      value
+    }
+  }
+
+  fun update(newValue: T) {
+    value = newValue
+    updatedAt = LocalDateTime.now(clock)
+  }
+
+  private fun isInvalid(): Boolean {
+    val noValue = value == null || updatedAt == null
+    val cacheExpired: Boolean = updatedAt != null && updatedAt!!.plusHours(validForHours) < LocalDateTime.now(clock)
+    return noValue || cacheExpired
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IepLevelServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IepLevelServiceTest.kt
@@ -77,7 +77,7 @@ class IepLevelServiceTest {
     @BeforeEach
     fun setup(): Unit = runBlocking {
       whenever(prisonApiService.getIepLevels()).thenReturn(
-        flowOf(
+        listOf(
           IepLevel(iepLevel = "BAS", iepDescription = "Basic", sequence = 1),
           IepLevel(iepLevel = "ENT", iepDescription = "Entry", sequence = 2, active = false),
           IepLevel(iepLevel = "STD", iepDescription = "Standard", sequence = 3, default = true),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/util/CachedValueTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/util/CachedValueTest.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.incentivesapi.util
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+
+class CachedValueTest {
+
+  private var clockBefore: Clock = Clock.fixed(Instant.parse("2022-08-01T12:45:00.00Z"), ZoneId.systemDefault())
+  private var clockAfter: Clock = Clock.offset(clockBefore, Duration.ofHours(2))
+  private val cachedValue = CachedValue<String>(validForHours = 1, clockBefore)
+
+  @Test
+  fun `get() returns the value when is not expired`() {
+    cachedValue.update("value in cache")
+    assertThat(cachedValue.get()).isEqualTo("value in cache")
+  }
+
+  @Test
+  fun `get() returns null when cache is empty`() {
+    assertThat(cachedValue.get()).isNull()
+  }
+
+  @Test
+  fun `get() returns null when cache is expired`() {
+    cachedValue.update("will expire")
+    assertThat(cachedValue.get()).isEqualTo("will expire")
+
+    cachedValue.clock = clockAfter
+
+    assertThat(cachedValue.get()).isNull()
+  }
+
+  @Test
+  fun `update() updates cached value`() {
+    assertThat(cachedValue.get()).isNull()
+
+    cachedValue.update("new value")
+    assertThat(cachedValue.get()).isEqualTo("new value")
+  }
+}


### PR DESCRIPTION
### Problem
We discovered that quite often getting the global list of all the incentive levels can take several seconds (often taking 30-60 seconds, [see AppInsights query](https://portal.azure.com#@747381f4-e81f-4a43-bf68-ced6a1e14edf/blade/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2Fa5ddf257-3b21-4ba9-a28c-ab30f751b383%2FresourceGroups%2Fnomisapi-prod-rg%2Fproviders%2FMicrosoft.Insights%2Fcomponents%2Fnomisapi-prod/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAA0VOuwqDMBTd%252FYqLu8Slo91CKUgpUrpKmhwxoDchV1sK%252Ffimg3Y6cN4OEezA1kOKD71GJJBbk1l8YDrSoa7rnbdTWF3fhQkXM4OahspxjlEqzxa8%252BCekMtGXe4A320nfSGVJJQxZyPbKhdl4FrXhWV%252F7Vt91q2xwkLJQirYeWa2FyK9qMJMgD0hICz3e%252F685Y79cWyJgzgAAAA%253D%253D/timespan/PT4H))

It's not clear why this endpoint can be so slow (it should be fairly simple and quick) but the list of all incentive levels is used in quite a lot of places for a variety of reasons.

### Caching
This list doesn't change very often so it makes sense to cache it for some time.

I've added a simple caching class to keep the value in memory for a day. It should be simple enough for this use case and much faster than making an HTTP request all the times.

**NOTE**: I tried to use Spring Boot's caching mechanism but for some reason I
couldn't get it to work - maybe is the combination of libraries we use.