### PR TITLE
INC-1074: Add counts by level to reviews endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IncentiveReview.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IncentiveReview.kt
@@ -41,6 +41,12 @@ data class IncentiveReviewResponse(
   @Schema(description = "Total number of overdue prisoner reviews at given location", example = "102")
   val overdueCount: Int,
 
+  @Schema(description = "Total number of prisoners by incentive level", example = "{\"BAS\": 10, \"STD\": 72, \"ENH\": 20}")
+  val prisonersCounts: Map<String, Int>,
+
+  @Schema(description = "Total number of overdue prisoner reviews by incentive level", example = "{\"BAS\": 1, \"STD\": 10, \"ENH\": 0}")
+  val overdueCounts: Map<String, Int>,
+
   @Schema(description = "Description of given location", example = "Houseblock 1")
   val locationDescription: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IncentiveReview.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IncentiveReview.kt
@@ -30,22 +30,36 @@ data class IncentiveReview(
   var nextReviewDate: LocalDate,
 )
 
+@Schema(description = "An Incentive level available at the given location, with the total and overdue number of prisoners at this level")
+data class IncentiveReviewLevel(
+  @Schema(description = "Level code", example = "STD")
+  val levelCode: String,
+
+  @Schema(description = "Level name", example = "Standard")
+  val levelName: String,
+
+  @Schema(description = "Number of prisoners at this level", example = "72")
+  val reviewCount: Int,
+
+  @Schema(description = "Number of overdue prisoners at this level", example = "10")
+  val overdueCount: Int,
+)
+
 @Schema(description = "Incentive reviews list for prisoners at a given location")
 data class IncentiveReviewResponse(
+  @Schema(description = "List of levels available at the given location, with the total and overdue number of prisoners at each level")
+  val levels: List<IncentiveReviewLevel>,
+
   @Schema(description = "Prisoner incentive reviews")
   val reviews: List<IncentiveReview>,
 
-  @Schema(description = "Total number of reviews at given location", example = "102")
+  // TODO: Remove once UI stops using it
+  @Schema(description = "Total number of reviews at given location", example = "102", deprecated = true)
   val reviewCount: Int,
 
-  @Schema(description = "Total number of overdue prisoner reviews at given location", example = "102")
+  // TODO: Remove once UI stops using it
+  @Schema(description = "Total number of overdue prisoner reviews at given location", example = "102", deprecated = true)
   val overdueCount: Int,
-
-  @Schema(description = "Total number of prisoners by incentive level", example = "{\"BAS\": 10, \"STD\": 72, \"ENH\": 20}")
-  val prisonersCounts: Map<String, Int>,
-
-  @Schema(description = "Total number of overdue prisoner reviews by incentive level", example = "{\"BAS\": 1, \"STD\": 10, \"ENH\": 0}")
-  val overdueCounts: Map<String, Int>,
 
   @Schema(description = "Description of given location", example = "Houseblock 1")
   val locationDescription: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsService.kt
@@ -79,12 +79,7 @@ class IncentiveReviewsService(
     val negativeCaseNotesInLast3Months = deferredNegativeCaseNotesInLast3Months.await()
 
     val nextReviewDates = deferredNextReviewDates.await()
-    val overdueCount = nextReviewDates.values.count { it.isBefore(LocalDate.now(clock)) }
-    val locationDescription = deferredLocationDescription.await()
-
-    val comparator = IncentiveReviewSort.orDefault(sort) comparingIn order
-
-    val reviews = offenders
+    val allReviews = offenders
       .map {
         IncentiveReview(
           prisonerNumber = it.prisonerNumber,
@@ -98,17 +93,44 @@ class IncentiveReviewsService(
           nextReviewDate = nextReviewDates[it.bookingId]!!,
         )
       }
+
+    val comparator = IncentiveReviewSort.orDefault(sort) comparingIn order
+    val reviewsAtLevel = allReviews
       .filter { it.levelCode == levelCode }
       .sortedWith(comparator)
 
-    val reviewsCount = reviews.size
-    val reviewsPage = reviews paginateWith PageRequest.of(page, size)
+    // Count overdue reviews and total reviews by Incentive levels
+    val prisonersCounts: MutableMap<String, Int> = mutableMapOf()
+    val overdueCounts: MutableMap<String, Int> = mutableMapOf()
+    allReviews.forEach() { review ->
+      val levelCode = review.levelCode
 
+      if (!prisonersCounts.containsKey(levelCode)) {
+        prisonersCounts[levelCode] = 0
+      }
+      if (!overdueCounts.containsKey(levelCode)) {
+        overdueCounts[levelCode] = 0
+      }
+
+      prisonersCounts[levelCode] = prisonersCounts[levelCode]!! + 1
+      if (nextReviewDates[review.bookingId]!!.isBefore(LocalDate.now(clock))) {
+        overdueCounts[levelCode] = overdueCounts[levelCode]!! + 1
+      }
+    }
+
+    // Existing count fields
+    val reviewsCount = reviewsAtLevel.size
+    val overdueCount = overdueCounts.values.sum()
+
+    val reviewsPage = reviewsAtLevel paginateWith PageRequest.of(page, size)
+    val locationDescription = deferredLocationDescription.await()
     IncentiveReviewResponse(
       locationDescription = locationDescription,
       overdueCount = overdueCount,
       reviewCount = reviewsCount,
       reviews = reviewsPage,
+      prisonersCounts = prisonersCounts,
+      overdueCounts = overdueCounts,
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResourceTest.kt
@@ -211,6 +211,7 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubPositiveCaseNoteSummary()
     prisonApiMockServer.stubNegativeCaseNoteSummary()
     prisonApiMockServer.stubIepLevels()
+    prisonApiMockServer.stubAgenciesIepLevels("MDI")
 
     webTestClient.get()
       .uri("/incentives-reviews/prison/MDI/location/MDI-1/level/STD")
@@ -223,16 +224,26 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
           {
             "reviewCount": 3,
             "overdueCount": 1,
-            "prisonersCounts": {
-              "BAS": 1,
-              "STD": 3,
-              "ENH": 1
-            },
-            "overdueCounts": {
-              "BAS": 0,
-              "STD": 0,
-              "ENH": 1
-            },
+            "levels": [
+              {
+                "levelCode": "BAS",
+                "levelName": "Basic",
+                "reviewCount": 1,
+                "overdueCount": 0
+              },
+              {
+                "levelCode": "STD",
+                "levelName": "Standard",
+                "reviewCount": 3,
+                "overdueCount": 0
+              },
+              {
+                "levelCode": "ENH",
+                "levelName": "Enhanced",
+                "reviewCount": 1,
+                "overdueCount": 1
+              }
+            ],
             "reviews": [
               {
                 "prisonerNumber": "A1234AA",
@@ -282,6 +293,7 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubPositiveCaseNoteSummary()
     prisonApiMockServer.stubNegativeCaseNoteSummary()
     prisonApiMockServer.stubIepLevels()
+    prisonApiMockServer.stubAgenciesIepLevels("MDI")
 
     webTestClient.get()
       .uri("/incentives-reviews/prison/MDI/location/MDI-1/level/STD")
@@ -294,16 +306,26 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
           {
             "reviewCount": 3,
             "overdueCount": 1,
-            "prisonersCounts": {
-              "BAS": 1,
-              "STD": 3,
-              "ENH": 1
-            },
-            "overdueCounts": {
-              "BAS": 0,
-              "STD": 0,
-              "ENH": 1
-            },
+            "levels": [
+              {
+                "levelCode": "BAS",
+                "levelName": "Basic",
+                "reviewCount": 1,
+                "overdueCount": 0
+              },
+              {
+                "levelCode": "STD",
+                "levelName": "Standard",
+                "reviewCount": 3,
+                "overdueCount": 0
+              },
+              {
+                "levelCode": "ENH",
+                "levelName": "Enhanced",
+                "reviewCount": 1,
+                "overdueCount": 1
+              }
+            ],
             "reviews": [
               {
                 "prisonerNumber": "A1234AA",
@@ -354,6 +376,7 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
     prisonApiMockServer.stubPositiveCaseNoteSummary()
     prisonApiMockServer.stubNegativeCaseNoteSummary()
     prisonApiMockServer.stubIepLevels()
+    prisonApiMockServer.stubAgenciesIepLevels("MDI")
 
     // pre-cache different next review dates as `persistPrisonerIepLevel` defaults lead to all being today + 1 year
     nextReviewDateRepository.saveAll(
@@ -393,6 +416,7 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
       prisonApiMockServer.stubPositiveCaseNoteSummary()
       prisonApiMockServer.stubNegativeCaseNoteSummary()
       prisonApiMockServer.stubIepLevels()
+      prisonApiMockServer.stubAgenciesIepLevels("MDI")
     }
 
     private fun loadPage(page: Int) = webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsServiceTest.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.incentivesapi.config.ListOfDataNotFoundExcep
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IncentiveReview
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.OffenderSearchPrisoner
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.CaseNoteUsage
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.IepLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.PrisonLocation
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.PrisonerAlert
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonerIepLevelRepository
@@ -31,11 +32,12 @@ import java.time.ZoneId
 
 class IncentiveReviewsServiceTest {
   private val prisonApiService: PrisonApiService = mock()
+  private val iepLevelService: IepLevelService = mock()
   private val offenderSearchService: OffenderSearchService = mock()
   private val prisonerIepLevelRepository: PrisonerIepLevelRepository = mock()
   private val nextReviewDateGetterService: NextReviewDateGetterService = mock()
   private var clock: Clock = Clock.fixed(Instant.parse("2022-08-01T12:45:00.00Z"), ZoneId.systemDefault())
-  private val incentiveReviewsService = IncentiveReviewsService(offenderSearchService, prisonApiService, prisonerIepLevelRepository, nextReviewDateGetterService, clock)
+  private val incentiveReviewsService = IncentiveReviewsService(offenderSearchService, prisonApiService, iepLevelService, prisonerIepLevelRepository, nextReviewDateGetterService, clock)
 
   @BeforeEach
   fun setUp(): Unit = runBlocking {
@@ -52,6 +54,27 @@ class IncentiveReviewsServiceTest {
         110002L to LocalDate.parse("2022-12-12"),
       )
     )
+
+    whenever(iepLevelService.getIepLevelsForPrison("MDI", useClientCredentials = true))
+      .thenReturn(
+        listOf(
+          IepLevel(
+            iepLevel = "BAS",
+            iepDescription = "Basic",
+            sequence = 1,
+          ),
+          IepLevel(
+            iepLevel = "STD",
+            iepDescription = "Standard",
+            sequence = 2,
+          ),
+          IepLevel(
+            iepLevel = "ENH",
+            iepDescription = "Enhanced",
+            sequence = 3,
+          ),
+        )
+      )
   }
 
   @Test


### PR DESCRIPTION
In order for the UI/'Reviews' table to show:
- Number of prisoners overdue at each level ("dashboard" to be shown above the Reviews table)
- Number of prisoners at each level (to be shown in parenthesis in the tabs)

This is an example of the field added to the response:

```JSON
{
  "levels": [
    {
      "levelCode": "BAS",
      "levelName": "Basic",
      "reviewCount": 1,
      "overdueCount": 0
    },
    {
      "levelCode": "STD",
      "levelName": "Standard",
      "reviewCount": 3,
      "overdueCount": 0
    },
    {
      "levelCode": "ENH",
      "levelName": "Enhanced",
      "reviewCount": 1,
      "overdueCount": 1
    }
  ],
  // [...]
}
```

The response now contains the list of Incentive levels for the given prison.
This means the UI doesn't need to make this additional HTTP request.

We're also deprecating these 2 fields:
- `overdueCount`, that's the total number of overdue prisoners in the given residential location. New design doesn't show the total number of overdue anymore and this value can be derived by the level-by-level `overdueCount`s anyway (summing them up)
-  `reviewCount`, that's the number of all prisoners (unpaginated) at the given level in the given residential location. This information is also in the `levels` field now.