### PR TITLE
INC-1074: Remove deprecated `reviewCount`/`overdueCount` in Reviews endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IncentiveReview.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IncentiveReview.kt
@@ -53,14 +53,6 @@ data class IncentiveReviewResponse(
   @Schema(description = "Prisoner incentive reviews")
   val reviews: List<IncentiveReview>,
 
-  // TODO: Remove once UI stops using it
-  @Schema(description = "Total number of reviews at given location", example = "102", deprecated = true)
-  val reviewCount: Int,
-
-  // TODO: Remove once UI stops using it
-  @Schema(description = "Total number of overdue prisoner reviews at given location", example = "102", deprecated = true)
-  val overdueCount: Int,
-
   @Schema(description = "Description of given location", example = "Houseblock 1")
   val locationDescription: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsService.kt
@@ -130,17 +130,11 @@ class IncentiveReviewsService(
       )
     }
 
-    // Existing count fields
-    val reviewsCount = reviewsAtLevel.size
-    val overdueCount = overdueCounts.values.sum()
-
     val reviewsPage = reviewsAtLevel paginateWith PageRequest.of(page, size)
     val locationDescription = deferredLocationDescription.await()
     IncentiveReviewResponse(
       locationDescription = locationDescription,
       levels = levels,
-      overdueCount = overdueCount,
-      reviewCount = reviewsCount,
       reviews = reviewsPage,
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResourceTest.kt
@@ -222,8 +222,6 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
         // language=json
         """
           {
-            "reviewCount": 3,
-            "overdueCount": 1,
             "levels": [
               {
                 "levelCode": "BAS",
@@ -304,8 +302,6 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
         // language=json
         """
           {
-            "reviewCount": 3,
-            "overdueCount": 1,
             "levels": [
               {
                 "levelCode": "BAS",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsServiceTest.kt
@@ -121,7 +121,8 @@ class IncentiveReviewsServiceTest {
 
     verify(offenderSearchService, times(1)).findOffenders(any(), eq("MDI-2-1"))
     assertThat(reviews.locationDescription).isEqualTo("A houseblock")
-    assertThat(reviews.reviewCount).isEqualTo(2)
+    val reviewCount = reviews.levels.find { level -> level.levelCode == "STD" }?.reviewCount
+    assertThat(reviewCount).isEqualTo(2)
     assertThat(reviews.reviews).isEqualTo(
       listOf(
         IncentiveReview(
@@ -271,7 +272,8 @@ class IncentiveReviewsServiceTest {
 
     val reviews = incentiveReviewsService.reviews("MDI", "MDI-2-1", "STD")
 
-    assertThat(reviews.reviewCount).isEqualTo(2)
+    val reviewCount = reviews.levels.find { level -> level.levelCode == "STD" }?.reviewCount
+    assertThat(reviewCount).isEqualTo(2)
     assertThat(reviews.reviews).isEqualTo(
       listOf(
         IncentiveReview(
@@ -467,7 +469,8 @@ class IncentiveReviewsServiceTest {
     val reviews = incentiveReviewsService.reviews("MDI", "MDI-2-1", "STD")
 
     // Then
-    assertThat(reviews.overdueCount).isEqualTo(2)
+    val overdueCount = reviews.levels.sumOf { level -> level.overdueCount }
+    assertThat(overdueCount).isEqualTo(2)
     assertThat(reviews.reviews).hasSize(3)
   }
 
@@ -502,7 +505,8 @@ class IncentiveReviewsServiceTest {
     val reviews = incentiveReviewsService.reviews("MDI", "MDI-2-1", "STD")
 
     // Then
-    assertThat(reviews.overdueCount).isEqualTo(3)
+    val overdueCount = reviews.levels.sumOf { level -> level.overdueCount }
+    assertThat(overdueCount).isEqualTo(3)
     assertThat(reviews.reviews).hasSize(1)
   }
 
@@ -537,7 +541,8 @@ class IncentiveReviewsServiceTest {
     val reviews = incentiveReviewsService.reviews("MDI", "MDI-2-1", "STD", page = 0, size = 1)
 
     // Then
-    assertThat(reviews.overdueCount).isEqualTo(3)
+    val overdueCount = reviews.levels.sumOf { level -> level.overdueCount }
+    assertThat(overdueCount).isEqualTo(3)
     assertThat(reviews.reviews).hasSize(1)
   }
 
@@ -556,7 +561,8 @@ class IncentiveReviewsServiceTest {
     val reviews = incentiveReviewsService.reviews("MDI", "MDI-2-1", "STD")
 
     // Then
-    assertThat(reviews.overdueCount).isEqualTo(0)
+    val overdueCount = reviews.levels.sumOf { level -> level.overdueCount }
+    assertThat(overdueCount).isEqualTo(0)
     assertThat(reviews.reviews).hasSize(2)
   }
 


### PR DESCRIPTION
⚠️ **DO NOT** merge/deploy this PR until the UI change is promoted to `preprod`/`prod`.

These two fields will soon no longer be used by the UI once this PR is promoted to `preprod`/`prod`:

https://github.com/ministryofjustice/hmpps-incentives-ui/pull/392

This is an "internal" API only used by the `incentives-api`, [see Azure `dependencies` query](https://portal.azure.com#@747381f4-e81f-4a43-bf68-ced6a1e14edf/blade/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2Fa5ddf257-3b21-4ba9-a28c-ab30f751b383%2FresourceGroups%2Fnomisapi-prod-rg%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2Fnomisapi-prod/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAA2WOsQ7CIBiE9z4FYS88QUfj5mDcmwYu7V9bIPxAFx%252FeotE0Ot1w%252Bb47iwBn4QyBm4fYJkSINMQRSXSdkOQMXKICbodAalpDYMWIhQzUnDnVHH1R%252BS6%252FvBtWCN4tiTdKU29YyPPpJvTBFlEIG%252BsQib3TstFafHiz%252BGz7q19wqab64zXcHvhMdc%252FS%252FsCZ9IO8ZSH6GX%252FdE4lCCQ7yAAAA/timespan/P7D).