### PR TITLE
INC-1069: Improve next review date logic for readmissions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateService.kt
@@ -18,7 +18,7 @@ class NextReviewDateService(private val input: NextReviewDateInput) {
 
   fun calculate(): LocalDate {
     if (isReadmission()) {
-      val readmissionDate = input.iepDetails.first().iepDate
+      val readmissionDate = reviews(includeReadmissions = true).first().iepDate
       return ruleForNewPrisoners(readmissionDate)
     }
 
@@ -94,11 +94,14 @@ class NextReviewDateService(private val input: NextReviewDateInput) {
   }
 
   private fun isReadmission(): Boolean {
-    // NOTE: Readmission/recalls "reviews" are not real incentive reviews, that's why the "raw" iepDetails list is checked here
-    return input.iepDetails.firstOrNull()?.reviewType == ReviewType.READMISSION
+    // NOTE: Readmission/recalls "reviews" are not real incentive reviews, that's why they need to be explicitly included here
+    return reviews(includeReadmissions = true).firstOrNull()?.reviewType == ReviewType.READMISSION
   }
 
-  private fun reviews(): List<IepDetail> {
-    return input.iepDetails.filter(IepDetail::isRealReview)
+  private fun reviews(includeReadmissions: Boolean = false): List<IepDetail> {
+    return input.iepDetails.filter { iepDetail ->
+      iepDetail.isRealReview() ||
+        (includeReadmissions && iepDetail.reviewType == ReviewType.READMISSION)
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateServiceTest.kt
@@ -356,6 +356,50 @@ class NextReviewDateServiceTest {
 
       assertThat(nextReviewDate).isEqualTo(expectedNextReviewDate)
     }
+
+    @Test
+    fun `when prisoner is readmitted (age 18+) then transferred, it still returns +3 months`() {
+      val input = NextReviewDateInput(
+        iepDetails = listOf(
+          review("2018-07-02", "MDI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.TRANSFER),
+          // When readmitted, was 18th birthday, not a "young person" anymore
+          review("2018-07-01", "ACI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.READMISSION),
+          review("2016-08-01", "MDI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.REVIEW),
+          review("2016-07-01", "MDI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.INITIAL),
+        ),
+        hasAcctOpen = true,
+        dateOfBirth = LocalDate.parse("2000-07-01"),
+        receptionDate = LocalDate.parse("2016-07-01"),
+      )
+      val readmissionDate = LocalDate.parse("2018-07-01")
+      val expectedNextReviewDate = readmissionDate.plusMonths(3)
+
+      val nextReviewDate = NextReviewDateService(input).calculate()
+
+      assertThat(nextReviewDate).isEqualTo(expectedNextReviewDate)
+    }
+
+    @Test
+    fun `when prisoner is readmitted and 'young person' (under age of 18), then transferred it still returns +1 months`() {
+      val input = NextReviewDateInput(
+        iepDetails = listOf(
+          review("2018-07-02", "MDI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.TRANSFER),
+          // When readmitted, was almost 18yo, so still a "young person"
+          review("2018-06-30", "ACI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.READMISSION),
+          review("2016-08-01", "MDI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.REVIEW),
+          review("2016-07-01", "MDI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.INITIAL),
+        ),
+        hasAcctOpen = true,
+        dateOfBirth = LocalDate.parse("2000-07-01"),
+        receptionDate = LocalDate.parse("2016-07-01"),
+      )
+      val readmissionDate = LocalDate.parse("2018-06-30")
+      val expectedNextReviewDate = readmissionDate.plusMonths(1)
+
+      val nextReviewDate = NextReviewDateService(input).calculate()
+
+      assertThat(nextReviewDate).isEqualTo(expectedNextReviewDate)
+    }
   }
 }
 


### PR DESCRIPTION
Previous logic was very simple and only checked the last incentive record of a prisoner to determine if it was a readmission.

This doesn't work if the prisoner is transferred before they got reviewed.

The new logic is similar but it allows for newer non-review entries present after the readmission one.

Example:
- `TRANSFER`
- `TRANSFER`
- `READMISSION`
- [...]

The two entries of type `TRANSFER` here are "ignored" (as they're not real reviews). Readmissions are also not real reviews but they're considered when determining whether the prisoner has been readmitted but hasn't been reviewed yet.

The date of the readmission entry is used as a starting date for the calculation of the next review date as expected (+3 months in general but +1 month for young people).