### PR TITLE
INC-1119: use new HMPPS Domain Events queue from the Incentives namespace - PreProd

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -37,11 +37,11 @@ generic-service:
       HMPPS_SQS_QUEUES_AUDIT_QUEUE_ACCESS_KEY_ID: "access_key_id"
       HMPPS_SQS_QUEUES_AUDIT_QUEUE_SECRET_ACCESS_KEY: "secret_access_key"
       HMPPS_SQS_QUEUES_AUDIT_QUEUE_NAME: "sqs_queue_name"
-    sqs-incentives-secret:
+    sqs-prisoner-event-queue-secret:
       HMPPS_SQS_QUEUES_INCENTIVES_QUEUE_ACCESS_KEY_ID: "access_key_id"
       HMPPS_SQS_QUEUES_INCENTIVES_QUEUE_SECRET_ACCESS_KEY: "secret_access_key"
       HMPPS_SQS_QUEUES_INCENTIVES_QUEUE_NAME: "sqs_queue_name"
-    sqs-incentives-dlq-secret:
+    sqs-prisoner-event-queue-dlq-secret:
       HMPPS_SQS_QUEUES_INCENTIVES_DLQ_ACCESS_KEY_ID: "access_key_id"
       HMPPS_SQS_QUEUES_INCENTIVES_DLQ_SECRET_ACCESS_KEY: "secret_access_key"
       HMPPS_SQS_QUEUES_INCENTIVES_DLQ_NAME: "sqs_queue_name"
@@ -53,5 +53,5 @@ generic-prometheus-alerts:
   rdsAlertsDatabases:
     cloud-platform-6b3b723b359a69e2: "incentives api"
   sqsAlertsQueueNames:
-    - "Digital-Prison-Services-preprod-hmpps_incentives_queue"
-    - "Digital-Prison-Services-preprod-hmpps_incentives_dlq"
+    - "hmpps-incentives-preprod-prisoner-event-queue"
+    - "hmpps-incentives-preprod-prisoner-event-dlq"


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/INC-1119

Same as https://github.com/ministryofjustice/hmpps-incentives-api/pull/366 & https://github.com/ministryofjustice/hmpps-incentives-api/pull/369