### PR TITLE
INC-1146: Authorise incentive level modification requests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResource.kt
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
@@ -68,6 +69,7 @@ class IncentiveLevelResource(
   }
 
   @PostMapping("levels")
+  @PreAuthorize("hasRole('MAINTAIN_INCENTIVE_LEVELS') and hasAuthority('SCOPE_write')")
   @ResponseStatus(HttpStatus.CREATED)
   @Operation(
     summary = "Creates a new incentive level",
@@ -104,6 +106,7 @@ class IncentiveLevelResource(
   }
 
   @PatchMapping("level-order")
+  @PreAuthorize("hasRole('MAINTAIN_INCENTIVE_LEVELS') and hasAuthority('SCOPE_write')")
   @Operation(
     summary = "Sets the order of incentive levels",
     description = "All existing incentive level codes must be provided",
@@ -178,6 +181,7 @@ class IncentiveLevelResource(
   }
 
   @PutMapping("levels/{code}")
+  @PreAuthorize("hasRole('MAINTAIN_INCENTIVE_LEVELS') and hasAuthority('SCOPE_write')")
   @Operation(
     summary = "Updates an incentive level",
     description = "Payload must include all required fields",
@@ -223,6 +227,7 @@ class IncentiveLevelResource(
   }
 
   @PatchMapping("levels/{code}")
+  @PreAuthorize("hasRole('MAINTAIN_INCENTIVE_LEVELS') and hasAuthority('SCOPE_write')")
   @Operation(
     summary = "Updates an incentive level",
     description = "Partial updates are allowed",
@@ -269,6 +274,7 @@ class IncentiveLevelResource(
   }
 
   @DeleteMapping("levels/{code}")
+  @PreAuthorize("hasRole('MAINTAIN_INCENTIVE_LEVELS') and hasAuthority('SCOPE_write')")
   @Operation(
     summary = "Deactivates an incentive level",
     // TODO: decide and explain what happens to associated per-prison data
@@ -369,6 +375,7 @@ class IncentiveLevelResource(
   }
 
   @PutMapping("prison-levels/{prisonId}/level/{levelCode}")
+  @PreAuthorize("hasRole('MAINTAIN_PRISON_IEP_LEVELS') and hasAuthority('SCOPE_write')")
   @Operation(
     summary = "Updates prison incentive level information",
     description = "Payload must include all required fields",
@@ -419,6 +426,7 @@ class IncentiveLevelResource(
   }
 
   @PatchMapping("prison-levels/{prisonId}/level/{levelCode}")
+  @PreAuthorize("hasRole('MAINTAIN_PRISON_IEP_LEVELS') and hasAuthority('SCOPE_write')")
   @Operation(
     summary = "Updates prison incentive level information",
     description = "Partial updates are allowed",
@@ -492,6 +500,7 @@ class IncentiveLevelResource(
   }
 
   @DeleteMapping("prison-levels/{prisonId}/level/{levelCode}")
+  @PreAuthorize("hasRole('MAINTAIN_PRISON_IEP_LEVELS') and hasAuthority('SCOPE_write')")
   @Operation(
     summary = "Deactivate an incentive level for a prison",
     // TODO: decide and explain what happens to prisoners if level is deactivated

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/helper/ErrorResponseHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/helper/ErrorResponseHelper.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.incentivesapi.helper
+
+import org.assertj.core.api.Assertions.assertThat
+import org.springframework.http.HttpStatus
+import org.springframework.test.web.reactive.server.WebTestClient
+
+fun <T : WebTestClient.ResponseSpec> T.expectErrorResponse(status: HttpStatus, vararg messages: String): T {
+  expectStatus().isEqualTo(status)
+
+  with(expectBody()) {
+    jsonPath("$.status").isEqualTo(status.value())
+
+    val userMessage = jsonPath("$.userMessage")
+    for (message in messages) {
+      userMessage.value<String> { assertThat(it).contains(message) }
+    }
+  }
+
+  return this
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResourceTest.kt
@@ -1,16 +1,17 @@
 package uk.gov.justice.digital.hmpps.incentivesapi.resource
 
 import kotlinx.coroutines.runBlocking
-import org.assertj.core.api.Assertions.assertThat
 import org.json.JSONObject
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepReview
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.SyncPostRequest
+import uk.gov.justice.digital.hmpps.incentivesapi.helper.expectErrorResponse
 import uk.gov.justice.digital.hmpps.incentivesapi.integration.SqsIntegrationTestBase
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonerIepLevelRepository
@@ -764,11 +765,7 @@ class IepLevelResourceTest : SqsIntegrationTestBase() {
           }"""
         )
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody()
-        .jsonPath("userMessage").value<String> {
-          assertThat(it).contains("Invalid parameters: `iepLevel` must have length of at most 6")
-        }
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Invalid parameters: `iepLevel` must have length of at most 6")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResourceTest.kt
@@ -17,6 +17,7 @@ import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Primary
 import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.incentivesapi.helper.expectErrorResponse
 import uk.gov.justice.digital.hmpps.incentivesapi.integration.SqsIntegrationTestBase
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.IncentiveLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonIncentiveLevel
@@ -181,10 +182,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         .uri("/incentive/levels/bas")
         .headers(setAuthorisation())
         .exchange()
-        .expectStatus().isNotFound
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("No incentive level found for code `bas`")
-        }
+        .expectErrorResponse(HttpStatus.NOT_FOUND, "No incentive level found for code `bas`")
     }
   }
 
@@ -241,10 +239,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
         )
         .exchange()
-        .expectStatus().isForbidden
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("Forbidden")
-        }
+        .expectErrorResponse(HttpStatus.FORBIDDEN, "Forbidden")
 
       runBlocking {
         assertThat(incentiveLevelRepository.count()).isEqualTo(6)
@@ -266,11 +261,11 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """.trimIndent()
         )
         .exchange()
-        .expectStatus().isEqualTo(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("Unsupported media type")
-          assertThat(it).contains("accepted types: application/json")
-        }
+        .expectErrorResponse(
+          HttpStatus.UNSUPPORTED_MEDIA_TYPE,
+          "Unsupported media type",
+          "accepted types: application/json",
+        )
 
       runBlocking {
         assertThat(incentiveLevelRepository.count()).isEqualTo(6)
@@ -295,10 +290,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
         )
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("Incentive level with code STD already exists")
-        }
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Incentive level with code STD already exists")
 
       runBlocking {
         assertThat(incentiveLevelRepository.count()).isEqualTo(6)
@@ -331,10 +323,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         .header("Content-Type", "application/json")
         .bodyValue(body)
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("Parameter conversion failure")
-        }
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Parameter conversion failure")
 
       runBlocking {
         assertThat(incentiveLevelRepository.count()).isEqualTo(6)
@@ -365,10 +354,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         .header("Content-Type", "application/json")
         .bodyValue(body)
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("Invalid parameters")
-        }
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Invalid parameters")
 
       runBlocking {
         assertThat(incentiveLevelRepository.count()).isEqualTo(6)
@@ -427,10 +413,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
         )
         .exchange()
-        .expectStatus().isForbidden
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("Forbidden")
-        }
+        .expectErrorResponse(HttpStatus.FORBIDDEN, "Forbidden")
 
       runBlocking {
         val incentiveLevelCodes = incentiveLevelRepository.findAllByOrderBySequence().map { it.code }.toList()
@@ -451,10 +434,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
         )
         .exchange()
-        .expectStatus().isNotFound
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("No incentive level found for code `EN4`")
-        }
+        .expectErrorResponse(HttpStatus.NOT_FOUND, "No incentive level found for code `EN4`")
 
       runBlocking {
         val incentiveLevels = incentiveLevelRepository.findAllByOrderBySequence().toList()
@@ -479,10 +459,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
         )
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("must have size of at least 2")
-        }
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "must have size of at least 2")
 
       runBlocking {
         val incentiveLevels = incentiveLevelRepository.findAllByOrderBySequence().toList()
@@ -504,10 +481,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
         )
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("All incentive levels required when setting order. Missing: `ENT`")
-        }
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "All incentive levels required when setting order. Missing: `ENT`")
     }
 
     @Test
@@ -552,10 +526,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
         )
         .exchange()
-        .expectStatus().isForbidden
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("Forbidden")
-        }
+        .expectErrorResponse(HttpStatus.FORBIDDEN, "Forbidden")
 
       runBlocking {
         val incentiveLevel = incentiveLevelRepository.findById("STD")
@@ -576,10 +547,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
         )
         .exchange()
-        .expectStatus().isNotFound
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("No incentive level found for code `std`")
-        }
+        .expectErrorResponse(HttpStatus.NOT_FOUND, "No incentive level found for code `std`")
 
       runBlocking {
         var incentiveLevel = incentiveLevelRepository.findById("std")
@@ -603,10 +571,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
         )
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("Incentive level codes must match in URL and payload")
-        }
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Incentive level codes must match in URL and payload")
 
       runBlocking {
         var incentiveLevel = incentiveLevelRepository.findById("STD")
@@ -642,10 +607,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         .header("Content-Type", "application/json")
         .bodyValue(body)
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("Parameter conversion failure")
-        }
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Parameter conversion failure")
 
       runBlocking {
         val incentiveLevel = incentiveLevelRepository.findById("STD")
@@ -667,10 +629,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """,
         )
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("Invalid parameters")
-        }
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Invalid parameters")
 
       runBlocking {
         var incentiveLevel = incentiveLevelRepository.findById("STD")
@@ -723,10 +682,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
         )
         .exchange()
-        .expectStatus().isForbidden
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("Forbidden")
-        }
+        .expectErrorResponse(HttpStatus.FORBIDDEN, "Forbidden")
 
       runBlocking {
         val incentiveLevel = incentiveLevelRepository.findById("STD")
@@ -747,10 +703,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
         )
         .exchange()
-        .expectStatus().isNotFound
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("No incentive level found for code `std`")
-        }
+        .expectErrorResponse(HttpStatus.NOT_FOUND, "No incentive level found for code `std`")
 
       runBlocking {
         var incentiveLevel = incentiveLevelRepository.findById("std")
@@ -808,10 +761,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """,
         )
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("Invalid parameters")
-        }
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Invalid parameters")
 
       runBlocking {
         val incentiveLevel = incentiveLevelRepository.findById("STD")
@@ -870,10 +820,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         .uri("/incentive/levels/STD")
         .headers(setAuthorisation())
         .exchange()
-        .expectStatus().isForbidden
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("Forbidden")
-        }
+        .expectErrorResponse(HttpStatus.FORBIDDEN, "Forbidden")
 
       runBlocking {
         val incentiveLevel = incentiveLevelRepository.findById("STD")
@@ -887,10 +834,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         .uri("/incentive/levels/std")
         .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCENTIVE_LEVELS"), scopes = listOf("read", "write")))
         .exchange()
-        .expectStatus().isNotFound
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("No incentive level found for code `std`")
-        }
+        .expectErrorResponse(HttpStatus.NOT_FOUND, "No incentive level found for code `std`")
 
       runBlocking {
         var incentiveLevel = incentiveLevelRepository.findById("std")
@@ -989,10 +933,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         .uri("/incentive/prison-levels/MDI/level/ENT")
         .headers(setAuthorisation())
         .exchange()
-        .expectStatus().isNotFound
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("No active prison incentive level found for code `ENT`")
-        }
+        .expectErrorResponse(HttpStatus.NOT_FOUND, "No active prison incentive level found for code `ENT`")
     }
 
     @Test
@@ -1001,10 +942,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         .uri("/incentive/prison-levels/BAI/level/EN4")
         .headers(setAuthorisation())
         .exchange()
-        .expectStatus().isNotFound
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("No active prison incentive level found for code `EN4`")
-        }
+        .expectErrorResponse(HttpStatus.NOT_FOUND, "No active prison incentive level found for code `EN4`")
     }
   }
 
@@ -1147,10 +1085,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
         )
         .exchange()
-        .expectStatus().isForbidden
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("Forbidden")
-        }
+        .expectErrorResponse(HttpStatus.FORBIDDEN, "Forbidden")
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("MDI", "STD")
@@ -1177,10 +1112,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
         )
         .exchange()
-        .expectStatus().isNotFound
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("No incentive level found for code `std`")
-        }
+        .expectErrorResponse(HttpStatus.NOT_FOUND, "No incentive level found for code `std`")
 
       runBlocking {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
@@ -1204,10 +1136,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
         )
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("Incentive level codes must match in URL and payload")
-        }
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Incentive level codes must match in URL and payload")
 
       runBlocking {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
@@ -1231,10 +1160,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
         )
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("Prison ids must match in URL and payload")
-        }
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Prison ids must match in URL and payload")
 
       runBlocking {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
@@ -1256,10 +1182,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
         )
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("Parameter conversion failure")
-        }
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Parameter conversion failure")
 
       runBlocking {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
@@ -1283,10 +1206,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
         )
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("Invalid parameters")
-        }
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Invalid parameters")
 
       runBlocking {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
@@ -1310,10 +1230,10 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
         )
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("A level cannot be made inactive and still be the default for admission")
-        }
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "A level cannot be made inactive and still be the default for admission",
+        )
 
       runBlocking {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
@@ -1339,10 +1259,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
         )
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("There must be an active default level for admission in a prison")
-        }
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "There must be an active default level for admission in a prison")
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("BAI", "STD")
@@ -1375,10 +1292,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
         )
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("There must be an active default level for admission in a prison")
-        }
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "There must be an active default level for admission in a prison")
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("BAI", "BAS")
@@ -1501,10 +1415,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
         )
         .exchange()
-        .expectStatus().isForbidden
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("Forbidden")
-        }
+        .expectErrorResponse(HttpStatus.FORBIDDEN, "Forbidden")
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("BAI", "BAS")
@@ -1528,10 +1439,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
         )
         .exchange()
-        .expectStatus().isNotFound
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("No incentive level found for code `std`")
-        }
+        .expectErrorResponse(HttpStatus.NOT_FOUND, "No incentive level found for code `std`")
 
       runBlocking {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
@@ -1555,10 +1463,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
         )
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("Invalid parameters")
-        }
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Invalid parameters")
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("WRI", "ENH")
@@ -1585,10 +1490,10 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
         )
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("A level cannot be made inactive and still be the default for admission")
-        }
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "A level cannot be made inactive and still be the default for admission",
+        )
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("MDI", "ENT")
@@ -1615,10 +1520,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
         )
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("A level cannot be made inactive and still be the default for admission")
-        }
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "A level cannot be made inactive and still be the default for admission")
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("MDI", "STD")
@@ -1645,10 +1547,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
         )
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("There must be an active default level for admission in a prison")
-        }
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "There must be an active default level for admission in a prison")
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("BAI", "STD")
@@ -1679,10 +1578,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
         )
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("There must be an active default level for admission in a prison")
-        }
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "There must be an active default level for admission in a prison")
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("BAI", "BAS")
@@ -1740,10 +1636,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         .headers(setAuthorisation())
         .header("Content-Type", "application/json")
         .exchange()
-        .expectStatus().isForbidden
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("Forbidden")
-        }
+        .expectErrorResponse(HttpStatus.FORBIDDEN, "Forbidden")
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("WRI", "ENH")
@@ -1758,10 +1651,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_PRISON_IEP_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .exchange()
-        .expectStatus().isNotFound
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("No incentive level found for code `bas`")
-        }
+        .expectErrorResponse(HttpStatus.NOT_FOUND, "No incentive level found for code `bas`")
 
       runBlocking {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
@@ -1777,10 +1667,10 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_PRISON_IEP_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody().jsonPath("$.userMessage").value<String> {
-          assertThat(it).contains("A level cannot be made inactive and still be the default for admission")
-        }
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "A level cannot be made inactive and still be the default for admission",
+        )
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("MDI", "STD")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResourceTest.kt
@@ -198,7 +198,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
 
       webTestClient.post()
         .uri("/incentive/levels")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCENTIVE_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -228,14 +228,34 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
       }
     }
 
-    // TODO: add once roles have been determined
-    // fun `requires correct role to create a level`() {}
+    @Test
+    fun `requires correct role to create a level`() {
+      webTestClient.post()
+        .uri("/incentive/levels")
+        .headers(setAuthorisation())
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          // language=json
+          """
+          {"code": "EN4", "description": "Enhanced 4", "active": false}
+          """
+        )
+        .exchange()
+        .expectStatus().isForbidden
+        .expectBody().jsonPath("$.userMessage").value<String> {
+          assertThat(it).contains("Forbidden")
+        }
+
+      runBlocking {
+        assertThat(incentiveLevelRepository.count()).isEqualTo(6)
+      }
+    }
 
     @Test
     fun `fails to create a level when media type is not supported`() {
       webTestClient.post()
         .uri("/incentive/levels")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCENTIVE_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/yaml")
         .bodyValue(
           // language=yaml
@@ -266,7 +286,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
     fun `fails to create a level when code already exists`() {
       webTestClient.post()
         .uri("/incentive/levels")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCENTIVE_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -307,7 +327,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
     fun `fails to create a level with missing fields`(body: String) {
       webTestClient.post()
         .uri("/incentive/levels")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCENTIVE_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(body)
         .exchange()
@@ -341,7 +361,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
     fun `fails to create a level with invalid fields`(body: String) {
       webTestClient.post()
         .uri("/incentive/levels")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCENTIVE_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(body)
         .exchange()
@@ -359,7 +379,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
     fun `reorders complete set of incentive levels`() {
       webTestClient.patch()
         .uri("/incentive/level-order")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCENTIVE_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -394,14 +414,35 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
       }
     }
 
-    // TODO: add once roles have been determined
-    // fun `requires correct role to reorder levels`() {}
+    @Test
+    fun `requires correct role to reorder levels`() {
+      webTestClient.patch()
+        .uri("/incentive/level-order")
+        .headers(setAuthorisation())
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          // language=json
+          """
+          ["EN3", "EN2", "ENT", "ENH", "STD", "BAS"]
+          """
+        )
+        .exchange()
+        .expectStatus().isForbidden
+        .expectBody().jsonPath("$.userMessage").value<String> {
+          assertThat(it).contains("Forbidden")
+        }
+
+      runBlocking {
+        val incentiveLevelCodes = incentiveLevelRepository.findAllByOrderBySequence().map { it.code }.toList()
+        assertThat(incentiveLevelCodes).isEqualTo(listOf("BAS", "STD", "ENH", "EN2", "EN3", "ENT"))
+      }
+    }
 
     @Test
     fun `fails to reorder incentive levels when some are missing`() {
       webTestClient.patch()
         .uri("/incentive/level-order")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCENTIVE_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -429,7 +470,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
     fun `fails to reorder incentive levels when not enough provided`() {
       webTestClient.patch()
         .uri("/incentive/level-order")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCENTIVE_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -454,7 +495,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
     fun `fails to reorder incomplete set of incentive levels`() {
       webTestClient.patch()
         .uri("/incentive/level-order")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCENTIVE_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -473,7 +514,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
     fun `updates a level`() {
       webTestClient.put()
         .uri("/incentive/levels/STD")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCENTIVE_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -498,14 +539,35 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
       }
     }
 
-    // TODO: add once roles have been determined
-    // fun `requires correct role to update a level`() {}
+    @Test
+    fun `requires correct role to update a level`() {
+      webTestClient.put()
+        .uri("/incentive/levels/STD")
+        .headers(setAuthorisation())
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          // language=json
+          """
+          {"code": "STD", "description": "Silver", "active": true}
+          """
+        )
+        .exchange()
+        .expectStatus().isForbidden
+        .expectBody().jsonPath("$.userMessage").value<String> {
+          assertThat(it).contains("Forbidden")
+        }
+
+      runBlocking {
+        val incentiveLevel = incentiveLevelRepository.findById("STD")
+        assertThat(incentiveLevel?.description).isNotEqualTo("Silver")
+      }
+    }
 
     @Test
     fun `fails to update a missing level`() {
       webTestClient.put()
         .uri("/incentive/levels/std")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCENTIVE_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -532,7 +594,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
     fun `fails to update a level with mismatched codes`() {
       webTestClient.put()
         .uri("/incentive/levels/ENH")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCENTIVE_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -576,7 +638,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
     fun `fails to update a level with missing fields`(body: String) {
       webTestClient.put()
         .uri("/incentive/levels/STD")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCENTIVE_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(body)
         .exchange()
@@ -596,7 +658,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
     fun `fails to update a level with invalid fields`() {
       webTestClient.put()
         .uri("/incentive/levels/STD")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCENTIVE_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -623,7 +685,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
     fun `partially updates a level`() {
       webTestClient.patch()
         .uri("/incentive/levels/STD")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCENTIVE_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -648,14 +710,35 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
       }
     }
 
-    // TODO: add once roles have been determined
-    // fun `requires correct role to partially update a level`() {}
+    @Test
+    fun `requires correct role to partially update a level`() {
+      webTestClient.patch()
+        .uri("/incentive/levels/STD")
+        .headers(setAuthorisation())
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          // language=json
+          """
+          {"description": "Silver"}
+          """
+        )
+        .exchange()
+        .expectStatus().isForbidden
+        .expectBody().jsonPath("$.userMessage").value<String> {
+          assertThat(it).contains("Forbidden")
+        }
+
+      runBlocking {
+        val incentiveLevel = incentiveLevelRepository.findById("STD")
+        assertThat(incentiveLevel?.description).isNotEqualTo("Silver")
+      }
+    }
 
     @Test
     fun `fails to partially update a missing level`() {
       webTestClient.patch()
         .uri("/incentive/levels/std")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCENTIVE_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -682,7 +765,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
     fun `partially updates a level but does not change the code`() {
       webTestClient.patch()
         .uri("/incentive/levels/ENH")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCENTIVE_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -716,7 +799,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
     fun `fails to partially update a level with invalid fields`() {
       webTestClient.patch()
         .uri("/incentive/levels/STD")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCENTIVE_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -741,7 +824,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
     fun `deactivates a level`() {
       webTestClient.delete()
         .uri("/incentive/levels/STD")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCENTIVE_LEVELS"), scopes = listOf("read", "write")))
         .exchange()
         .expectStatus().isOk
         .expectBody().json(
@@ -763,7 +846,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
     fun `deactivates an inactive level`() {
       webTestClient.delete()
         .uri("/incentive/levels/ENT")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCENTIVE_LEVELS"), scopes = listOf("read", "write")))
         .exchange()
         .expectStatus().isOk
         .expectBody().json(
@@ -781,14 +864,28 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
       }
     }
 
-    // TODO: add once roles have been determined
-    // fun `requires correct role to deactivate a level`() {}
+    @Test
+    fun `requires correct role to deactivate a level`() {
+      webTestClient.delete()
+        .uri("/incentive/levels/STD")
+        .headers(setAuthorisation())
+        .exchange()
+        .expectStatus().isForbidden
+        .expectBody().jsonPath("$.userMessage").value<String> {
+          assertThat(it).contains("Forbidden")
+        }
+
+      runBlocking {
+        val incentiveLevel = incentiveLevelRepository.findById("STD")
+        assertThat(incentiveLevel?.active).isTrue
+      }
+    }
 
     @Test
     fun `fails to deactivate a missing level`() {
       webTestClient.delete()
         .uri("/incentive/levels/std")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCENTIVE_LEVELS"), scopes = listOf("read", "write")))
         .exchange()
         .expectStatus().isNotFound
         .expectBody().jsonPath("$.userMessage").value<String> {
@@ -945,7 +1042,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
     fun `updates a prison incentive level when per-prison information does not exist`() {
       webTestClient.put()
         .uri("/incentive/prison-levels/MDI/level/STD")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_PRISON_IEP_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -985,7 +1082,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
 
       webTestClient.put()
         .uri("/incentive/prison-levels/WRI/level/ENH")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_PRISON_IEP_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -1031,14 +1128,43 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
       }
     }
 
-    // TODO: add once roles have been determined
-    // fun `requires correct role to update a prison incentive level`() {}
+    @Test
+    fun `requires correct role to update a prison incentive level`() {
+      saveLevel("MDI", "STD")
+
+      webTestClient.put()
+        .uri("/incentive/prison-levels/MDI/level/STD")
+        .headers(setAuthorisation())
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          // language=json
+          """
+          {
+            "levelCode": "STD", "prisonId": "MDI", "defaultOnAdmission": true,
+            "remandTransferLimitInPence": 5600, "remandSpendLimitInPence": 56000, "convictedTransferLimitInPence": 1900, "convictedSpendLimitInPence": 19000,
+            "visitOrders": 3, "privilegedVisitOrders": 2
+          }
+          """
+        )
+        .exchange()
+        .expectStatus().isForbidden
+        .expectBody().jsonPath("$.userMessage").value<String> {
+          assertThat(it).contains("Forbidden")
+        }
+
+      runBlocking {
+        val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("MDI", "STD")
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(5500)
+        assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(2)
+        assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
+      }
+    }
 
     @Test
     fun `fails to update a prison incentive level when incentive level does not exist`() {
       webTestClient.put()
         .uri("/incentive/prison-levels/MDI/level/std")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_PRISON_IEP_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -1065,7 +1191,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
     fun `fails to update a prison incentive level with mismatched codes`() {
       webTestClient.put()
         .uri("/incentive/prison-levels/MDI/level/STD")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_PRISON_IEP_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -1092,7 +1218,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
     fun `fails to update a prison incentive level with mismatched prison id`() {
       webTestClient.put()
         .uri("/incentive/prison-levels/MDI/level/STD")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_PRISON_IEP_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -1119,7 +1245,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
     fun `fails to update a prison incentive level with missing fields`() {
       webTestClient.put()
         .uri("/incentive/prison-levels/WRI/level/STD")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_PRISON_IEP_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -1144,7 +1270,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
     fun `fails to update a prison incentive level with invalid fields`() {
       webTestClient.put()
         .uri("/incentive/prison-levels/WRI/level/ENH")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_PRISON_IEP_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -1171,7 +1297,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
     fun `fails to update a prison incentive level when making inactive level the default`() {
       webTestClient.put()
         .uri("/incentive/prison-levels/BAI/level/BAS")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_PRISON_IEP_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -1200,7 +1326,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
 
       webTestClient.put()
         .uri("/incentive/prison-levels/BAI/level/STD")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_PRISON_IEP_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -1236,7 +1362,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
 
       webTestClient.put()
         .uri("/incentive/prison-levels/BAI/level/BAS")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_PRISON_IEP_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -1274,7 +1400,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
     fun `partially updates a prison incentive level when per-prison information does not exist`() {
       webTestClient.patch()
         .uri("/incentive/prison-levels/BAI/level/BAS")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_PRISON_IEP_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -1314,7 +1440,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
 
       webTestClient.patch()
         .uri("/incentive/prison-levels/WRI/level/ENH")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_PRISON_IEP_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -1358,14 +1484,40 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
       }
     }
 
-    // TODO: add once roles have been determined
-    // fun `requires correct role to partially update a prison incentive level`() {}
+    @Test
+    fun `requires correct role to partially update a prison incentive level`() {
+      saveLevel("BAI", "BAS")
+
+      webTestClient.patch()
+        .uri("/incentive/prison-levels/BAI/level/BAS")
+        .headers(setAuthorisation())
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          // language=json
+          """
+          {
+            "remandTransferLimitInPence": 5600, "remandSpendLimitInPence": 56000
+          }
+          """
+        )
+        .exchange()
+        .expectStatus().isForbidden
+        .expectBody().jsonPath("$.userMessage").value<String> {
+          assertThat(it).contains("Forbidden")
+        }
+
+      runBlocking {
+        val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("BAI", "BAS")
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(5500)
+        assertThat(prisonIncentiveLevel?.remandSpendLimitInPence).isEqualTo(55000)
+      }
+    }
 
     @Test
     fun `fails to partially update a prison incentive level when incentive level does not exist`() {
       webTestClient.patch()
         .uri("/incentive/prison-levels/MDI/level/std")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_PRISON_IEP_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -1392,7 +1544,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
 
       webTestClient.patch()
         .uri("/incentive/prison-levels/WRI/level/ENH")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_PRISON_IEP_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -1422,7 +1574,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
 
       webTestClient.patch()
         .uri("/incentive/prison-levels/MDI/level/ENT")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_PRISON_IEP_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -1452,7 +1604,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
 
       webTestClient.patch()
         .uri("/incentive/prison-levels/MDI/level/STD")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_PRISON_IEP_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -1482,7 +1634,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
 
       webTestClient.patch()
         .uri("/incentive/prison-levels/MDI/level/STD")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_PRISON_IEP_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -1516,7 +1668,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
 
       webTestClient.patch()
         .uri("/incentive/prison-levels/BAI/level/BAS")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_PRISON_IEP_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           // language=json
@@ -1553,7 +1705,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
 
       webTestClient.delete()
         .uri("/incentive/prison-levels/WRI/level/EN2")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_PRISON_IEP_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .exchange()
         .expectStatus().isOk
@@ -1579,14 +1731,31 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
       }
     }
 
-    // TODO: add once roles have been determined
-    // fun `requires correct role to deactivate a prison incentive level`() {}
+    @Test
+    fun `requires correct role to deactivate a prison incentive level`() {
+      saveLevel("WRI", "ENH")
+
+      webTestClient.delete()
+        .uri("/incentive/prison-levels/WRI/level/ENH")
+        .headers(setAuthorisation())
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isForbidden
+        .expectBody().jsonPath("$.userMessage").value<String> {
+          assertThat(it).contains("Forbidden")
+        }
+
+      runBlocking {
+        val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("WRI", "ENH")
+        assertThat(prisonIncentiveLevel?.active).isTrue
+      }
+    }
 
     @Test
     fun `fails to deactivate a prison incentive level when incentive level does not exist`() {
       webTestClient.delete()
         .uri("/incentive/prison-levels/WRI/level/bas")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_PRISON_IEP_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .exchange()
         .expectStatus().isNotFound
@@ -1605,7 +1774,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
 
       webTestClient.delete()
         .uri("/incentive/prison-levels/MDI/level/STD")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_PRISON_IEP_LEVELS"), scopes = listOf("read", "write")))
         .header("Content-Type", "application/json")
         .exchange()
         .expectStatus().isBadRequest

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResourceTest.kt
@@ -10,7 +10,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
+import uk.gov.justice.digital.hmpps.incentivesapi.helper.expectErrorResponse
 import uk.gov.justice.digital.hmpps.incentivesapi.integration.SqsIntegrationTestBase
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.NextReviewDateRepository
@@ -106,17 +108,7 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
         .uri("/incentives-reviews/prison/Moorland/location/MDI-1/level/STD")
         .headers(setAuthorisation(roles = listOf("ROLE_INCENTIVES")))
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody().json(
-          // language=json
-          """
-          {
-            "status": 400,
-            "userMessage": "Invalid parameters: `prisonId` must have length of at most 5",
-            "developerMessage": "Invalid parameters: `prisonId` must have length of at most 5"
-          }
-          """
-        )
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Invalid parameters: `prisonId` must have length of at most 5")
     }
 
     @Test
@@ -128,17 +120,7 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
         .uri("/incentives-reviews/prison/MDI/location/MDI-1/level/s")
         .headers(setAuthorisation(roles = listOf("ROLE_INCENTIVES")))
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody().json(
-          // language=json
-          """
-          {
-            "status": 400,
-            "userMessage": "Invalid parameters: `levelCode` must have length of at least 2",
-            "developerMessage": "Invalid parameters: `levelCode` must have length of at least 2"
-          }
-          """
-        )
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Invalid parameters: `levelCode` must have length of at least 2")
     }
 
     @Test
@@ -150,12 +132,7 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
         .uri("/incentives-reviews/prison/MDI/location/MDI-1/level/STD?sort=PRISON")
         .headers(setAuthorisation(roles = listOf("ROLE_INCENTIVES")))
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody()
-        .jsonPath("status").isEqualTo(400)
-        .jsonPath("userMessage").value<String> {
-          assertThat(it).contains("No enum constant")
-        }
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "No enum constant")
     }
 
     @Test
@@ -167,17 +144,7 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
         .uri("/incentives-reviews/prison/MDI/location/MDI-1/level/STD?page=-1")
         .headers(setAuthorisation(roles = listOf("ROLE_INCENTIVES")))
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody().json(
-          // language=json
-          """
-          {
-            "status": 400,
-            "userMessage": "Invalid parameters: `page` must be at least 0",
-            "developerMessage": "Invalid parameters: `page` must be at least 0"
-          }
-          """
-        )
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Invalid parameters: `page` must be at least 0")
     }
 
     @Test
@@ -189,16 +156,9 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
         .uri("/incentives-reviews/prison/MDI/location/MDI-1/level/STD?page=-1&pageSize=0")
         .headers(setAuthorisation(roles = listOf("ROLE_INCENTIVES")))
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody().json(
-          // language=json
-          """
-          {
-            "status": 400,
-            "userMessage": "Invalid parameters: `page` must be at least 0, `pageSize` must be at least 1",
-            "developerMessage": "Invalid parameters: `page` must be at least 0, `pageSize` must be at least 1"
-          }
-          """
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "Invalid parameters: `page` must be at least 0, `pageSize` must be at least 1",
         )
     }
   }
@@ -454,17 +414,7 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
         .uri("/incentives-reviews/prison/MDI/location/MDI-1/level/STD?sort=PRISONER_NUMBER&order=DESC&page=$page&pageSize=2")
         .headers(setAuthorisation(roles = listOf("ROLE_INCENTIVES")))
         .exchange()
-        .expectStatus().isBadRequest
-        .expectBody().json(
-          // language=json
-          """
-          {
-            "status": 400,
-            "userMessage": "Validation failure: Page number is out of range",
-            "developerMessage": "Page number is out of range"
-          }
-          """
-        )
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Page number is out of range")
     }
   }
 
@@ -481,16 +431,9 @@ class IncentiveReviewsResourceTest : SqsIntegrationTestBase() {
       .uri("/incentives-reviews/prison/MDI/location/MDI-1/level/STD")
       .headers(setAuthorisation(roles = listOf("ROLE_INCENTIVES")))
       .exchange()
-      .expectStatus().isNotFound
-      .expectBody().json(
-        // language=json
-        """
-          {
-            "status": 404,
-            "userMessage": "No incentive levels found for ID(s) [1234134, 1234135, 1234136, 1234137, 1234138]",
-            "developerMessage": "No incentive levels found for ID(s) [1234134, 1234135, 1234136, 1234137, 1234138]"
-          }
-          """
+      .expectErrorResponse(
+        HttpStatus.NOT_FOUND,
+        "No incentive levels found for ID(s) [1234134, 1234135, 1234136, 1234137, 1234138]",
       )
   }
 }


### PR DESCRIPTION
Requests must have `write` scope with these roles:
• Changing (globally available) incentive levels requires `MAINTAIN_INCENTIVE_LEVELS`
• Changing per-prison incentive level configuration requires `MAINTAIN_PRISON_IEP_LEVELS`