### PR TITLE
INC-1143: Use sensible spend limit defaults from PSI

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/PrisonIncentiveLevel.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/PrisonIncentiveLevel.kt
@@ -36,10 +36,10 @@ data class PrisonIncentiveLevel(
   @JsonProperty(required = true)
   val convictedSpendLimitInPence: Int,
 
-  @Schema(description = "The number of weekday visits for a convicted prisoner", example = "2", minimum = "0", type = "integer", format = "int32")
+  @Schema(description = "The number of weekday visits for a convicted prisoner per fortnight", example = "2", minimum = "0", type = "integer", format = "int32")
   @JsonProperty(required = true)
   val visitOrders: Int,
-  @Schema(description = "The number of privileged/weekend visits for a convicted prisoner", example = "1", minimum = "0", type = "integer", format = "int32")
+  @Schema(description = "The number of privileged/weekend visits for a convicted prisoner per 4 weeks", example = "1", minimum = "0", type = "integer", format = "int32")
   @JsonProperty(required = true)
   val privilegedVisitOrders: Int,
 ) {
@@ -73,8 +73,8 @@ data class PrisonIncentiveLevelUpdate(
   @Schema(description = "The maximum amount allowed in the spends account for a convicted prisoner", example = "18000", minimum = "0", type = "integer", format = "int32", required = false)
   val convictedSpendLimitInPence: Int? = null,
 
-  @Schema(description = "The number of weekday visits for a convicted prisoner", example = "2", minimum = "0", type = "integer", format = "int32", required = false)
+  @Schema(description = "The number of weekday visits for a convicted prisoner per fortnight", example = "2", minimum = "0", type = "integer", format = "int32", required = false)
   val visitOrders: Int? = null,
-  @Schema(description = "The number of privileged/weekend visits for a convicted prisoner", example = "1", minimum = "0", type = "integer", format = "int32", required = false)
+  @Schema(description = "The number of privileged/weekend visits for a convicted prisoner per 4 weeks", example = "1", minimum = "0", type = "integer", format = "int32", required = false)
   val privilegedVisitOrders: Int? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonIncentiveLevelService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonIncentiveLevelService.kt
@@ -137,26 +137,45 @@ class PrisonIncentiveLevelService(
   private fun PrisonIncentiveLevelUpdateDTO.toNewEntity(
     prisonId: String,
     levelCode: String,
-  ): PrisonIncentiveLevel = PrisonIncentiveLevel(
-    levelCode = levelCode,
-    prisonId = prisonId,
-    active = active ?: true,
-    defaultOnAdmission = defaultOnAdmission ?: false,
+  ): PrisonIncentiveLevel {
+    val fallbackSpendLimits = spendLimitPolicy.getOrDefault(levelCode, spendLimitPolicy["ENH"]!!)
 
-    // TODO: find sensible defaults or have these configured per-level on IncentiveLevel
+    return PrisonIncentiveLevel(
+      levelCode = levelCode,
+      prisonId = prisonId,
+      active = active ?: true,
+      defaultOnAdmission = defaultOnAdmission ?: false,
 
-    remandTransferLimitInPence = remandTransferLimitInPence ?: 5500,
-    remandSpendLimitInPence = remandSpendLimitInPence ?: 55000,
-    convictedTransferLimitInPence = convictedTransferLimitInPence ?: 1800,
-    convictedSpendLimitInPence = convictedSpendLimitInPence ?: 18000,
+      remandTransferLimitInPence = remandTransferLimitInPence
+        ?: fallbackSpendLimits.remandTransferLimitInPence,
+      remandSpendLimitInPence = remandSpendLimitInPence
+        ?: fallbackSpendLimits.remandSpendLimitInPence,
+      convictedTransferLimitInPence = convictedTransferLimitInPence
+        ?: fallbackSpendLimits.convictedTransferLimitInPence,
+      convictedSpendLimitInPence = convictedSpendLimitInPence
+        ?: fallbackSpendLimits.convictedSpendLimitInPence,
 
-    visitOrders = visitOrders ?: 2,
-    privilegedVisitOrders = privilegedVisitOrders ?: 1,
+      visitOrders = visitOrders ?: 2,
+      privilegedVisitOrders = privilegedVisitOrders ?: 1,
 
-    new = true,
-    whenUpdated = LocalDateTime.now(clock),
-  )
+      new = true,
+      whenUpdated = LocalDateTime.now(clock),
+    )
+  }
 
   private suspend fun Flow<PrisonIncentiveLevel>.toListOfDTO(): List<PrisonIncentiveLevelDTO> =
     map { it.toDTO() }.toList()
 }
+
+private data class SpendLimits(
+  val remandTransferLimitInPence: Int,
+  val remandSpendLimitInPence: Int,
+  val convictedTransferLimitInPence: Int,
+  val convictedSpendLimitInPence: Int,
+)
+
+private val spendLimitPolicy = mapOf(
+  "BAS" to SpendLimits(27_50, 275_00, 5_50, 55_00),
+  "STD" to SpendLimits(60_50, 605_00, 19_80, 198_00),
+  "ENH" to SpendLimits(66_00, 660_00, 33_00, 330_00),
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonIncentiveLevelRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonIncentiveLevelRepositoryTest.kt
@@ -65,10 +65,10 @@ class PrisonIncentiveLevelRepositoryTest : TestBase() {
       levelCode = "STD",
       prisonId = "MDI",
 
-      remandTransferLimitInPence = 2500,
-      remandSpendLimitInPence = 25000,
-      convictedTransferLimitInPence = 500,
-      convictedSpendLimitInPence = 5000,
+      remandTransferLimitInPence = 2750,
+      remandSpendLimitInPence = 27500,
+      convictedTransferLimitInPence = 550,
+      convictedSpendLimitInPence = 5500,
 
       visitOrders = 2,
       privilegedVisitOrders = 1,
@@ -81,10 +81,10 @@ class PrisonIncentiveLevelRepositoryTest : TestBase() {
       levelCode = "STD",
       prisonId = "MDI",
 
-      remandTransferLimitInPence = 5500,
-      remandSpendLimitInPence = 55000,
-      convictedTransferLimitInPence = 1800,
-      convictedSpendLimitInPence = 18000,
+      remandTransferLimitInPence = 6050,
+      remandSpendLimitInPence = 60500,
+      convictedTransferLimitInPence = 1980,
+      convictedSpendLimitInPence = 19800,
 
       visitOrders = 2,
       privilegedVisitOrders = 1,
@@ -101,10 +101,10 @@ class PrisonIncentiveLevelRepositoryTest : TestBase() {
       levelCode = "std", // ← does not exist
       prisonId = "MDI",
 
-      remandTransferLimitInPence = 5500,
-      remandSpendLimitInPence = 55000,
-      convictedTransferLimitInPence = 1800,
-      convictedSpendLimitInPence = 18000,
+      remandTransferLimitInPence = 6050,
+      remandSpendLimitInPence = 60500,
+      convictedTransferLimitInPence = 1980,
+      convictedSpendLimitInPence = 19800,
 
       visitOrders = 2,
       privilegedVisitOrders = 1,
@@ -121,10 +121,10 @@ class PrisonIncentiveLevelRepositoryTest : TestBase() {
       levelCode = "STD",
       prisonId = "MDI",
 
-      remandTransferLimitInPence = 5500,
-      remandSpendLimitInPence = 55000,
-      convictedTransferLimitInPence = 1800,
-      convictedSpendLimitInPence = -1000, // ← cannot be negative
+      remandTransferLimitInPence = 6050,
+      remandSpendLimitInPence = 60500,
+      convictedTransferLimitInPence = 1980,
+      convictedSpendLimitInPence = -19800, // ← cannot be negative
 
       visitOrders = 2,
       privilegedVisitOrders = 0,
@@ -144,10 +144,10 @@ class PrisonIncentiveLevelRepositoryTest : TestBase() {
         prisonId = "MDI",
         active = levelCode != "ENT",
 
-        remandTransferLimitInPence = 5500,
-        remandSpendLimitInPence = 55000,
-        convictedTransferLimitInPence = 1800,
-        convictedSpendLimitInPence = 18000,
+        remandTransferLimitInPence = 6050,
+        remandSpendLimitInPence = 60500,
+        convictedTransferLimitInPence = 1980,
+        convictedSpendLimitInPence = 19800,
 
         visitOrders = 2,
         privilegedVisitOrders = 1,
@@ -171,10 +171,10 @@ class PrisonIncentiveLevelRepositoryTest : TestBase() {
       levelCode = "ENH",
       prisonId = "MDI",
 
-      remandTransferLimitInPence = 5500,
-      remandSpendLimitInPence = 55000,
-      convictedTransferLimitInPence = 1800,
-      convictedSpendLimitInPence = 18000,
+      remandTransferLimitInPence = 6600,
+      remandSpendLimitInPence = 66000,
+      convictedTransferLimitInPence = 3300,
+      convictedSpendLimitInPence = 33000,
 
       visitOrders = 2,
       privilegedVisitOrders = 1,
@@ -198,10 +198,10 @@ class PrisonIncentiveLevelRepositoryTest : TestBase() {
           active = levelCode != "ENT",
           defaultOnAdmission = levelCode == "STD",
 
-          remandTransferLimitInPence = 5500,
-          remandSpendLimitInPence = 55000,
-          convictedTransferLimitInPence = 1800,
-          convictedSpendLimitInPence = 18000,
+          remandTransferLimitInPence = 6050,
+          remandSpendLimitInPence = 60500,
+          convictedTransferLimitInPence = 1980,
+          convictedSpendLimitInPence = 19800,
 
           visitOrders = 2,
           privilegedVisitOrders = 1,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResourceTest.kt
@@ -854,10 +854,10 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
               active = levelCode != "ENT",
               defaultOnAdmission = levelCode == "STD",
 
-              remandTransferLimitInPence = 5500,
-              remandSpendLimitInPence = 55000,
-              convictedTransferLimitInPence = 1800,
-              convictedSpendLimitInPence = 18000,
+              remandTransferLimitInPence = 6050,
+              remandSpendLimitInPence = 60500,
+              convictedTransferLimitInPence = 1980,
+              convictedSpendLimitInPence = 19800,
 
               visitOrders = 2,
               privilegedVisitOrders = 1,
@@ -882,17 +882,17 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           [
             {
               "levelCode": "BAS", "levelDescription": "Basic", "prisonId": "MDI", "active": true, "defaultOnAdmission": false,
-              "remandTransferLimitInPence": 5500, "remandSpendLimitInPence": 55000, "convictedTransferLimitInPence": 1800, "convictedSpendLimitInPence": 18000,
+              "remandTransferLimitInPence": 6050, "remandSpendLimitInPence": 60500, "convictedTransferLimitInPence": 1980, "convictedSpendLimitInPence": 19800,
               "visitOrders": 2, "privilegedVisitOrders": 1
             },
             {
               "levelCode": "STD", "levelDescription": "Standard", "prisonId": "MDI", "active": true, "defaultOnAdmission": true,
-              "remandTransferLimitInPence": 5500, "remandSpendLimitInPence": 55000, "convictedTransferLimitInPence": 1800, "convictedSpendLimitInPence": 18000,
+              "remandTransferLimitInPence": 6050, "remandSpendLimitInPence": 60500, "convictedTransferLimitInPence": 1980, "convictedSpendLimitInPence": 19800,
               "visitOrders": 2, "privilegedVisitOrders": 1
             },
             {
               "levelCode": "ENH", "levelDescription": "Enhanced", "prisonId": "MDI", "active": true, "defaultOnAdmission": false,
-              "remandTransferLimitInPence": 5500, "remandSpendLimitInPence": 55000, "convictedTransferLimitInPence": 1800, "convictedSpendLimitInPence": 18000,
+              "remandTransferLimitInPence": 6050, "remandSpendLimitInPence": 60500, "convictedTransferLimitInPence": 1980, "convictedSpendLimitInPence": 19800,
               "visitOrders": 2, "privilegedVisitOrders": 1
             }
           ]
@@ -913,7 +913,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
           {
             "levelCode": "ENH", "levelDescription": "Enhanced", "prisonId": "WRI", "active": true, "defaultOnAdmission": false,
-            "remandTransferLimitInPence": 5500, "remandSpendLimitInPence": 55000, "convictedTransferLimitInPence": 1800, "convictedSpendLimitInPence": 18000,
+            "remandTransferLimitInPence": 6050, "remandSpendLimitInPence": 60500, "convictedTransferLimitInPence": 1980, "convictedSpendLimitInPence": 19800,
             "visitOrders": 2, "privilegedVisitOrders": 1
           }
           """,
@@ -954,10 +954,26 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           active = levelCode != "ENT",
           defaultOnAdmission = levelCode == "STD",
 
-          remandTransferLimitInPence = 5500,
-          remandSpendLimitInPence = 55000,
-          convictedTransferLimitInPence = 1800,
-          convictedSpendLimitInPence = 18000,
+          remandTransferLimitInPence = when (levelCode) {
+            "BAS" -> 27_50
+            "STD" -> 60_50
+            else -> 66_00
+          },
+          remandSpendLimitInPence = when (levelCode) {
+            "BAS" -> 275_00
+            "STD" -> 605_00
+            else -> 660_00
+          },
+          convictedTransferLimitInPence = when (levelCode) {
+            "BAS" -> 5_50
+            "STD" -> 19_80
+            else -> 33_00
+          },
+          convictedSpendLimitInPence = when (levelCode) {
+            "BAS" -> 55_00
+            "STD" -> 198_00
+            else -> 330_00
+          },
 
           visitOrders = 2,
           privilegedVisitOrders = 1,
@@ -985,7 +1001,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
           {
             "levelCode": "STD", "prisonId": "MDI", "defaultOnAdmission": true,
-            "remandTransferLimitInPence": 5600, "remandSpendLimitInPence": 56000, "convictedTransferLimitInPence": 1900, "convictedSpendLimitInPence": 19000,
+            "remandTransferLimitInPence": 6150, "remandSpendLimitInPence": 61500, "convictedTransferLimitInPence": 2080, "convictedSpendLimitInPence": 20800,
             "visitOrders": 3, "privilegedVisitOrders": 2
           }
           """,
@@ -997,7 +1013,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
           {
             "levelCode": "STD", "levelDescription": "Standard", "prisonId": "MDI", "active": true, "defaultOnAdmission": true,
-            "remandTransferLimitInPence": 5600, "remandSpendLimitInPence": 56000, "convictedTransferLimitInPence": 1900, "convictedSpendLimitInPence": 19000,
+            "remandTransferLimitInPence": 6150, "remandSpendLimitInPence": 61500, "convictedTransferLimitInPence": 2080, "convictedSpendLimitInPence": 20800,
             "visitOrders": 3, "privilegedVisitOrders": 2
           }
           """,
@@ -1006,7 +1022,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("MDI", "STD")
-        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(5600)
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(6150)
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(3)
         assertThat(prisonIncentiveLevel?.whenUpdated).isEqualTo(now)
       }
@@ -1025,7 +1041,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
           {
             "levelCode": "ENH", "prisonId": "WRI", "defaultOnAdmission": true,
-            "remandTransferLimitInPence": 5500, "remandSpendLimitInPence": 55000, "convictedTransferLimitInPence": 1800, "convictedSpendLimitInPence": 18000,
+            "remandTransferLimitInPence": 6050, "remandSpendLimitInPence": 60500, "convictedTransferLimitInPence": 1980, "convictedSpendLimitInPence": 19800,
             "visitOrders": 2, "privilegedVisitOrders": 1
           }
           """,
@@ -1037,7 +1053,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
           {
             "levelCode": "ENH", "levelDescription": "Enhanced", "prisonId": "WRI", "active": true, "defaultOnAdmission": true,
-            "remandTransferLimitInPence": 5500, "remandSpendLimitInPence": 55000, "convictedTransferLimitInPence": 1800, "convictedSpendLimitInPence": 18000,
+            "remandTransferLimitInPence": 6050, "remandSpendLimitInPence": 60500, "convictedTransferLimitInPence": 1980, "convictedSpendLimitInPence": 19800,
             "visitOrders": 2, "privilegedVisitOrders": 1
           }
           """,
@@ -1046,13 +1062,13 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
 
       runBlocking {
         var prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("WRI", "STD")
-        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(5500)
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(6050)
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(2)
         assertThat(prisonIncentiveLevel?.active).isTrue
         assertThat(prisonIncentiveLevel?.defaultOnAdmission).isFalse
 
         prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("WRI", "ENH")
-        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(5500)
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(6050)
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(2)
         assertThat(prisonIncentiveLevel?.active).isTrue
         assertThat(prisonIncentiveLevel?.defaultOnAdmission).isTrue
@@ -1077,7 +1093,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
           {
             "levelCode": "STD", "prisonId": "MDI", "defaultOnAdmission": true,
-            "remandTransferLimitInPence": 5600, "remandSpendLimitInPence": 56000, "convictedTransferLimitInPence": 1900, "convictedSpendLimitInPence": 19000,
+            "remandTransferLimitInPence": 6150, "remandSpendLimitInPence": 61500, "convictedTransferLimitInPence": 2080, "convictedSpendLimitInPence": 20800,
             "visitOrders": 3, "privilegedVisitOrders": 2
           }
           """,
@@ -1087,7 +1103,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("MDI", "STD")
-        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(5500)
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(6050)
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(2)
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
@@ -1104,7 +1120,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
           {
             "levelCode": "std", "prisonId": "MDI",
-            "remandTransferLimitInPence": 5600, "remandSpendLimitInPence": 56000, "convictedTransferLimitInPence": 1900, "convictedSpendLimitInPence": 19000,
+            "remandTransferLimitInPence": 6150, "remandSpendLimitInPence": 61500, "convictedTransferLimitInPence": 2080, "convictedSpendLimitInPence": 20800,
             "visitOrders": 3, "privilegedVisitOrders": 2
           }
           """,
@@ -1128,7 +1144,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
           {
             "levelCode": "ENH", "prisonId": "MDI",
-            "remandTransferLimitInPence": 5600, "remandSpendLimitInPence": 56000, "convictedTransferLimitInPence": 1900, "convictedSpendLimitInPence": 19000,
+            "remandTransferLimitInPence": 6150, "remandSpendLimitInPence": 61500, "convictedTransferLimitInPence": 2080, "convictedSpendLimitInPence": 20800,
             "visitOrders": 3, "privilegedVisitOrders": 2
           }
           """,
@@ -1152,7 +1168,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
           {
             "levelCode": "STD", "prisonId": "WRI",
-            "remandTransferLimitInPence": 5600, "remandSpendLimitInPence": 56000, "convictedTransferLimitInPence": 1900, "convictedSpendLimitInPence": 19000,
+            "remandTransferLimitInPence": 6150, "remandSpendLimitInPence": 61500, "convictedTransferLimitInPence": 2080, "convictedSpendLimitInPence": 20800,
             "visitOrders": 3, "privilegedVisitOrders": 2
           }
           """,
@@ -1198,7 +1214,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
           {
             "levelCode": "ENH", "prisonId": "WRI",
-            "remandTransferLimitInPence": -5600, "remandSpendLimitInPence": 56000, "convictedTransferLimitInPence": 1900, "convictedSpendLimitInPence": 19000,
+            "remandTransferLimitInPence": -6150, "remandSpendLimitInPence": 61500, "convictedTransferLimitInPence": 2080, "convictedSpendLimitInPence": 20800,
             "visitOrders": 3, "privilegedVisitOrders": 2
           }
           """,
@@ -1222,7 +1238,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
           {
             "levelCode": "BAS", "prisonId": "BAI", "active": false, "defaultOnAdmission": true,
-            "remandTransferLimitInPence": 5600, "remandSpendLimitInPence": 56000, "convictedTransferLimitInPence": 1900, "convictedSpendLimitInPence": 19000,
+            "remandTransferLimitInPence": 6150, "remandSpendLimitInPence": 61500, "convictedTransferLimitInPence": 2080, "convictedSpendLimitInPence": 20800,
             "visitOrders": 3, "privilegedVisitOrders": 2
           }
           """,
@@ -1251,7 +1267,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
           {
             "levelCode": "STD", "prisonId": "BAI", "active": true, "defaultOnAdmission": false,
-            "remandTransferLimitInPence": 5600, "remandSpendLimitInPence": 56000, "convictedTransferLimitInPence": 1900, "convictedSpendLimitInPence": 19000,
+            "remandTransferLimitInPence": 6150, "remandSpendLimitInPence": 61500, "convictedTransferLimitInPence": 2080, "convictedSpendLimitInPence": 20800,
             "visitOrders": 3, "privilegedVisitOrders": 2
           }
           """,
@@ -1263,7 +1279,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("BAI", "STD")
         assertThat(prisonIncentiveLevel?.active).isTrue
         assertThat(prisonIncentiveLevel?.defaultOnAdmission).isTrue
-        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(5500)
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(6050)
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(2)
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
@@ -1284,7 +1300,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
           {
             "levelCode": "BAS", "prisonId": "BAI", "active": true, "defaultOnAdmission": false,
-            "remandTransferLimitInPence": 5600, "remandSpendLimitInPence": 56000, "convictedTransferLimitInPence": 1900, "convictedSpendLimitInPence": 19000,
+            "remandTransferLimitInPence": 6150, "remandSpendLimitInPence": 61500, "convictedTransferLimitInPence": 2080, "convictedSpendLimitInPence": 20800,
             "visitOrders": 3, "privilegedVisitOrders": 2
           }
           """,
@@ -1296,7 +1312,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("BAI", "BAS")
         assertThat(prisonIncentiveLevel?.active).isTrue
         assertThat(prisonIncentiveLevel?.defaultOnAdmission).isFalse
-        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(5500)
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(2750)
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(2)
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
@@ -1319,7 +1335,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
           {
             "defaultOnAdmission": true,
-            "remandTransferLimitInPence": 5600, "remandSpendLimitInPence": 56000,
+            "remandTransferLimitInPence": 2850, "remandSpendLimitInPence": 28500,
             "visitOrders": 3
           }
           """,
@@ -1331,7 +1347,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
           {
             "levelCode": "BAS", "levelDescription": "Basic", "prisonId": "BAI", "active": true, "defaultOnAdmission": true,
-            "remandTransferLimitInPence": 5600, "remandSpendLimitInPence": 56000, "convictedTransferLimitInPence": 1800, "convictedSpendLimitInPence": 18000,
+            "remandTransferLimitInPence": 2850, "remandSpendLimitInPence": 28500, "convictedTransferLimitInPence": 550, "convictedSpendLimitInPence": 5500,
             "visitOrders": 3, "privilegedVisitOrders": 1
           }
           """,
@@ -1340,8 +1356,9 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("BAI", "BAS")
-        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(5600)
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(2850)
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(3)
+        assertThat(prisonIncentiveLevel?.privilegedVisitOrders).isEqualTo(1)
         assertThat(prisonIncentiveLevel?.whenUpdated).isEqualTo(now)
       }
     }
@@ -1369,7 +1386,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
           {
             "levelCode": "ENH", "levelDescription": "Enhanced", "prisonId": "WRI", "active": true, "defaultOnAdmission": true,
-            "remandTransferLimitInPence": 5500, "remandSpendLimitInPence": 55000, "convictedTransferLimitInPence": 1800, "convictedSpendLimitInPence": 18000,
+            "remandTransferLimitInPence": 6600, "remandSpendLimitInPence": 66000, "convictedTransferLimitInPence": 3300, "convictedSpendLimitInPence": 33000,
             "visitOrders": 2, "privilegedVisitOrders": 1
           }
           """,
@@ -1378,13 +1395,13 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
 
       runBlocking {
         var prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("WRI", "STD")
-        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(5500)
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(6050)
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(2)
         assertThat(prisonIncentiveLevel?.active).isTrue
         assertThat(prisonIncentiveLevel?.defaultOnAdmission).isFalse
 
         prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("WRI", "ENH")
-        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(5500)
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(6600)
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(2)
         assertThat(prisonIncentiveLevel?.active).isTrue
         assertThat(prisonIncentiveLevel?.defaultOnAdmission).isTrue
@@ -1408,7 +1425,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           // language=json
           """
           {
-            "remandTransferLimitInPence": 5600, "remandSpendLimitInPence": 56000
+            "remandTransferLimitInPence": 6150, "remandSpendLimitInPence": 61500
           }
           """,
         )
@@ -1417,8 +1434,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("BAI", "BAS")
-        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(5500)
-        assertThat(prisonIncentiveLevel?.remandSpendLimitInPence).isEqualTo(55000)
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(2750)
+        assertThat(prisonIncentiveLevel?.remandSpendLimitInPence).isEqualTo(27500)
       }
     }
 
@@ -1456,7 +1473,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           // language=json
           """
           {
-            "remandTransferLimitInPence": -5600, "visitOrders": -1
+            "remandTransferLimitInPence": -6150, "visitOrders": -1
           }
           """,
         )
@@ -1465,7 +1482,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("WRI", "ENH")
-        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(5500)
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(6600)
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(2)
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
@@ -1551,7 +1568,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("BAI", "STD")
         assertThat(prisonIncentiveLevel?.active).isTrue
         assertThat(prisonIncentiveLevel?.defaultOnAdmission).isTrue
-        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(5500)
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(6050)
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(2)
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
@@ -1582,7 +1599,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("BAI", "BAS")
         assertThat(prisonIncentiveLevel?.active).isTrue
         assertThat(prisonIncentiveLevel?.defaultOnAdmission).isFalse
-        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(5500)
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(2750)
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
     }
@@ -1608,7 +1625,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           """
           {
             "levelCode": "EN2", "levelDescription": "Enhanced 2", "prisonId": "WRI", "active": false, "defaultOnAdmission": false,
-            "remandTransferLimitInPence": 5500, "remandSpendLimitInPence": 55000, "convictedTransferLimitInPence": 1800, "convictedSpendLimitInPence": 18000,
+            "remandTransferLimitInPence": 6600, "remandSpendLimitInPence": 66000, "convictedTransferLimitInPence": 3300, "convictedSpendLimitInPence": 33000,
             "visitOrders": 2, "privilegedVisitOrders": 1
           }
           """,
@@ -1619,7 +1636,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("WRI", "EN2")
         assertThat(prisonIncentiveLevel?.active).isFalse
         assertThat(prisonIncentiveLevel?.defaultOnAdmission).isFalse
-        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(5500)
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(6600)
+        assertThat(prisonIncentiveLevel?.convictedTransferLimitInPence).isEqualTo(3300)
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(2)
         assertThat(prisonIncentiveLevel?.whenUpdated).isEqualTo(now)
       }


### PR DESCRIPTION
This does not add any validation/ranges to spending limits; simply sets the fallback values for any newly-created incentive level information for a prison in cases where an incomplete payload is submitted.