### PR TITLE
INC-1148: Audit changes to incentive levels and their per-prison information

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/AuditService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/AuditService.kt
@@ -63,9 +63,14 @@ data class AuditEvent(
   val service: String,
   val details: String? = null,
 )
+
 enum class AuditType {
   IEP_REVIEW_ADDED,
   IEP_REVIEW_UPDATED,
   IEP_REVIEW_DELETED,
   PRISONER_NUMBER_MERGE,
+  INCENTIVE_LEVEL_ADDED,
+  INCENTIVE_LEVEL_UPDATED,
+  INCENTIVE_LEVELS_REORDERED,
+  PRISON_INCENTIVE_LEVEL_UPDATED,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveLevelService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveLevelService.kt
@@ -111,7 +111,8 @@ class IncentiveLevelService(
     return incentiveLevelRepository.saveAll(incentiveLevelsWithNewSequences)
       .toListOfDTO()
       .also {
-        auditService.sendMessage(INCENTIVE_LEVELS_REORDERED, "*", it.map(IncentiveLevelDTO::code))
+        val orderedCodes = it.map(IncentiveLevelDTO::code)
+        auditService.sendMessage(INCENTIVE_LEVELS_REORDERED, orderedCodes.joinToString(", "), orderedCodes)
       }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveLevelService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveLevelService.kt
@@ -8,6 +8,9 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.incentivesapi.config.NoDataWithCodeFoundException
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.IncentiveLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.IncentiveLevelRepository
+import uk.gov.justice.digital.hmpps.incentivesapi.service.AuditType.INCENTIVE_LEVELS_REORDERED
+import uk.gov.justice.digital.hmpps.incentivesapi.service.AuditType.INCENTIVE_LEVEL_ADDED
+import uk.gov.justice.digital.hmpps.incentivesapi.service.AuditType.INCENTIVE_LEVEL_UPDATED
 import uk.gov.justice.digital.hmpps.incentivesapi.util.flow.associateByTo
 import java.time.Clock
 import java.time.LocalDateTime
@@ -24,6 +27,7 @@ import uk.gov.justice.digital.hmpps.incentivesapi.dto.IncentiveLevelUpdate as In
 class IncentiveLevelService(
   private val clock: Clock,
   private val incentiveLevelRepository: IncentiveLevelRepository,
+  private val auditService: AuditService,
 ) {
   /**
    * Returns all incentive levels, including inactive ones, in globally-defined order
@@ -56,7 +60,11 @@ class IncentiveLevelService(
     }
     val highestSequence = incentiveLevelRepository.findMaxSequence() ?: 0
     val incentiveLevel = dto.toNewEntity(highestSequence + 1)
-    return incentiveLevelRepository.save(incentiveLevel).toDTO()
+    return incentiveLevelRepository.save(incentiveLevel)
+      .toDTO()
+      .also {
+        auditService.sendMessage(INCENTIVE_LEVEL_ADDED, it.code, it)
+      }
   }
 
   /**
@@ -67,8 +75,11 @@ class IncentiveLevelService(
     return incentiveLevelRepository.findById(code)
       ?.let {
         incentiveLevelRepository.save(it.withUpdate(update))
+          .toDTO()
+          .also {
+            auditService.sendMessage(INCENTIVE_LEVEL_UPDATED, it.code, it)
+          }
       }
-      ?.toDTO()
   }
 
   /**
@@ -97,7 +108,11 @@ class IncentiveLevelService(
       )
     }
 
-    return incentiveLevelRepository.saveAll(incentiveLevelsWithNewSequences).toListOfDTO()
+    return incentiveLevelRepository.saveAll(incentiveLevelsWithNewSequences)
+      .toListOfDTO()
+      .also {
+        auditService.sendMessage(INCENTIVE_LEVELS_REORDERED, "*", it.map(IncentiveLevelDTO::code))
+      }
   }
 
   private fun IncentiveLevel.withUpdate(update: IncentiveLevelUpdateDTO): IncentiveLevel = copy(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonIncentiveLevelService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonIncentiveLevelService.kt
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonIncentiveLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.IncentiveLevelRepository
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonIncentiveLevelRepository
+import uk.gov.justice.digital.hmpps.incentivesapi.service.AuditType.PRISON_INCENTIVE_LEVEL_UPDATED
 import java.time.Clock
 import java.time.LocalDateTime
 import javax.validation.ValidationException
@@ -30,6 +31,7 @@ class PrisonIncentiveLevelService(
   private val clock: Clock,
   private val incentiveLevelRepository: IncentiveLevelRepository,
   private val prisonIncentiveLevelRepository: PrisonIncentiveLevelRepository,
+  private val auditService: AuditService,
 ) {
   /**
    * Returns all active incentive levels for given prison, along with associated information, in globally-defined order
@@ -99,6 +101,9 @@ class PrisonIncentiveLevelService(
       prisonIncentiveLevelRepository.save(prisonIncentiveLevel)
         .copy(levelDescription = incentiveLevel.description)
         .toDTO()
+        .also {
+          auditService.sendMessage(PRISON_INCENTIVE_LEVEL_UPDATED, "${it.prisonId} - ${it.levelCode}", it)
+        }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResourceTest.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.incentivesapi.jpa.IncentiveLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonIncentiveLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.IncentiveLevelRepository
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonIncentiveLevelRepository
+import uk.gov.justice.digital.hmpps.incentivesapi.service.AuditEvent
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDateTime
@@ -65,6 +66,26 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         IncentiveLevel(code = "ENT", description = "Entry", active = false, sequence = 99, new = true),
       ),
     ).collect()
+  }
+
+  private fun assertNoAuditMessageSent() {
+    val queueSize = auditQueue.sqsClient.getQueueAttributes(auditQueue.queueUrl, listOf("ApproximateNumberOfMessages"))
+      .attributes["ApproximateNumberOfMessages"]?.toInt()
+    assertThat(queueSize).isEqualTo(0)
+  }
+
+  private inline fun <reified T> assertAuditMessageSent(eventType: String): T {
+    val queueSize = auditQueue.sqsClient.getQueueAttributes(auditQueue.queueUrl, listOf("ApproximateNumberOfMessages"))
+      .attributes["ApproximateNumberOfMessages"]?.toInt()
+    assertThat(queueSize).isEqualTo(1)
+
+    val message = auditQueue.sqsClient.receiveMessage(auditQueue.queueUrl).messages[0].body
+    val event = objectMapper.readValue(message, AuditEvent::class.java)
+    assertThat(event.what).isEqualTo(eventType)
+    assertThat(event.who).isEqualTo("USER_ADM")
+    assertThat(event.service).isEqualTo("hmpps-incentives-api")
+
+    return objectMapper.readValue(event.details, T::class.java)
   }
 
   @Nested
@@ -179,7 +200,13 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
   @Nested
   inner class `modifying incentive levels` {
     private fun <T : WebTestClient.RequestHeadersSpec<*>> T.withCentralAuthorisation(): T = apply {
-      headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_INCENTIVE_LEVELS"), scopes = listOf("read", "write")))
+      headers(
+        setAuthorisation(
+          user = "USER_ADM",
+          roles = listOf("ROLE_MAINTAIN_INCENTIVE_LEVELS"),
+          scopes = listOf("read", "write"),
+        ),
+      )
     }
 
     @Test
@@ -218,6 +245,10 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         assertThat(incentiveLevel?.sequence).isGreaterThan(maxSequence)
         assertThat(incentiveLevel?.whenUpdated).isEqualTo(now)
       }
+
+      assertAuditMessageSent<Map<String, Any>>("INCENTIVE_LEVEL_ADDED").let {
+        assertThat(it["code"]).isEqualTo("EN4")
+      }
     }
 
     @Test
@@ -238,6 +269,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
       runBlocking {
         assertThat(incentiveLevelRepository.count()).isEqualTo(6)
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -269,6 +302,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         assertThat(incentiveLevel?.description).isEqualTo("Standard")
         assertThat(incentiveLevel?.active).isTrue
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -295,6 +330,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         assertThat(incentiveLevel?.active).isTrue
         assertThat(incentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
+
+      assertNoAuditMessageSent()
     }
 
     @ParameterizedTest
@@ -322,6 +359,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
       runBlocking {
         assertThat(incentiveLevelRepository.count()).isEqualTo(6)
       }
+
+      assertNoAuditMessageSent()
     }
 
     @ParameterizedTest
@@ -353,6 +392,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
       runBlocking {
         assertThat(incentiveLevelRepository.count()).isEqualTo(6)
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -392,6 +433,10 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           assertThat(it).isEqualTo(now)
         }
       }
+
+      assertAuditMessageSent<List<String>>("INCENTIVE_LEVELS_REORDERED").let {
+        assertThat(it).isEqualTo(listOf("EN3", "EN2", "ENT", "ENH", "STD", "BAS"))
+      }
     }
 
     @Test
@@ -413,6 +458,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         val incentiveLevelCodes = incentiveLevelRepository.findAllByOrderBySequence().map { it.code }.toList()
         assertThat(incentiveLevelCodes).isEqualTo(listOf("BAS", "STD", "ENH", "EN2", "EN3", "ENT"))
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -438,6 +485,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           assertThat(it).isNotEqualTo(now)
         }
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -460,6 +509,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         assertThat(incentiveLevels.map { it.code }).isEqualTo(listOf("BAS", "STD", "ENH", "EN2", "EN3", "ENT"))
         assertThat(incentiveLevels.map { it.sequence }).isEqualTo(listOf(1, 2, 3, 4, 5, 99))
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -476,6 +527,14 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         )
         .exchange()
         .expectErrorResponse(HttpStatus.BAD_REQUEST, "All incentive levels required when setting order. Missing: `ENT`")
+
+      runBlocking {
+        val incentiveLevels = incentiveLevelRepository.findAllByOrderBySequence().toList()
+        assertThat(incentiveLevels.map { it.code }).isEqualTo(listOf("BAS", "STD", "ENH", "EN2", "EN3", "ENT"))
+        assertThat(incentiveLevels.map { it.sequence }).isEqualTo(listOf(1, 2, 3, 4, 5, 99))
+      }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -505,6 +564,10 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         assertThat(incentiveLevel?.description).isEqualTo("Silver")
         assertThat(incentiveLevel?.whenUpdated).isEqualTo(now)
       }
+
+      assertAuditMessageSent<Map<String, Any>>("INCENTIVE_LEVEL_UPDATED").let {
+        assertThat(it["description"]).isEqualTo("Silver")
+      }
     }
 
     @Test
@@ -526,6 +589,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         val incentiveLevel = incentiveLevelRepository.findById("STD")
         assertThat(incentiveLevel?.description).isNotEqualTo("Silver")
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -550,6 +615,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         assertThat(incentiveLevel?.description).isEqualTo("Standard")
         assertThat(incentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -575,6 +642,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         assertThat(incentiveLevel?.description).isEqualTo("Enhanced")
         assertThat(incentiveLevel?.active).isTrue
       }
+
+      assertNoAuditMessageSent()
     }
 
     @ParameterizedTest
@@ -608,6 +677,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         assertThat(incentiveLevel?.description).isEqualTo("Standard")
         assertThat(incentiveLevel?.active).isTrue
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -632,6 +703,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         incentiveLevel = incentiveLevelRepository.findById("")
         assertThat(incentiveLevel).isNull()
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -661,6 +734,10 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         assertThat(incentiveLevel?.description).isEqualTo("Silver")
         assertThat(incentiveLevel?.whenUpdated).isEqualTo(now)
       }
+
+      assertAuditMessageSent<Map<String, Any>>("INCENTIVE_LEVEL_UPDATED").let {
+        assertThat(it["description"]).isEqualTo("Silver")
+      }
     }
 
     @Test
@@ -682,6 +759,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         val incentiveLevel = incentiveLevelRepository.findById("STD")
         assertThat(incentiveLevel?.description).isNotEqualTo("Silver")
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -706,6 +785,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         assertThat(incentiveLevel?.description).isEqualTo("Standard")
         assertThat(incentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -740,6 +821,11 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         assertThat(incentiveLevel?.active).isTrue
         assertThat(incentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
+
+      assertAuditMessageSent<Map<String, Any>>("INCENTIVE_LEVEL_UPDATED").let {
+        assertThat(it["code"]).isEqualTo("ENH")
+        assertThat(it["description"]).isEqualTo("Gold")
+      }
     }
 
     @Test
@@ -762,6 +848,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         assertThat(incentiveLevel?.description).isEqualTo("Standard")
         assertThat(incentiveLevel?.active).isTrue
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -783,6 +871,11 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         val incentiveLevel = incentiveLevelRepository.findById("STD")
         assertThat(incentiveLevel?.active).isFalse
         assertThat(incentiveLevel?.whenUpdated).isEqualTo(now)
+      }
+
+      assertAuditMessageSent<Map<String, Any>>("INCENTIVE_LEVEL_UPDATED").let {
+        assertThat(it["code"]).isEqualTo("STD")
+        assertThat(it["active"]).isEqualTo(false)
       }
     }
 
@@ -806,6 +899,11 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         assertThat(incentiveLevel?.active).isFalse
         assertThat(incentiveLevel?.whenUpdated).isEqualTo(now)
       }
+
+      assertAuditMessageSent<Map<String, Any>>("INCENTIVE_LEVEL_UPDATED").let {
+        assertThat(it["code"]).isEqualTo("ENT")
+        assertThat(it["active"]).isEqualTo(false)
+      }
     }
 
     @Test
@@ -820,6 +918,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         val incentiveLevel = incentiveLevelRepository.findById("STD")
         assertThat(incentiveLevel?.active).isTrue
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -837,6 +937,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         assertThat(incentiveLevel?.active).isTrue
         assertThat(incentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
+
+      assertNoAuditMessageSent()
     }
   }
 
@@ -943,7 +1045,13 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
   @Nested
   inner class `modifying prison incentive levels` {
     private fun <T : WebTestClient.RequestHeadersSpec<*>> T.withLocalAuthorisation(): T = apply {
-      headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_PRISON_IEP_LEVELS"), scopes = listOf("read", "write")))
+      headers(
+        setAuthorisation(
+          user = "USER_ADM",
+          roles = listOf("ROLE_MAINTAIN_PRISON_IEP_LEVELS"),
+          scopes = listOf("read", "write"),
+        ),
+      )
     }
 
     private fun saveLevel(prisonId: String, levelCode: String) = runBlocking {
@@ -1026,6 +1134,17 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(3)
         assertThat(prisonIncentiveLevel?.whenUpdated).isEqualTo(now)
       }
+
+      assertAuditMessageSent<Map<String, Any>>("PRISON_INCENTIVE_LEVEL_UPDATED").let {
+        assertThat(it).containsAllEntriesOf(
+          mapOf(
+            "prisonId" to "MDI",
+            "levelCode" to "STD",
+            "remandTransferLimitInPence" to 6150,
+            "visitOrders" to 3,
+          ),
+        )
+      }
     }
 
     @Test
@@ -1078,6 +1197,17 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
             .map { it.prisonId to it.levelCode }.toList()
         assertThat(defaultLevelCodes).isEqualTo(listOf("WRI" to "ENH"))
       }
+
+      assertAuditMessageSent<Map<String, Any>>("PRISON_INCENTIVE_LEVEL_UPDATED").let {
+        assertThat(it).containsAllEntriesOf(
+          mapOf(
+            "prisonId" to "WRI",
+            "levelCode" to "ENH",
+            "active" to true,
+            "defaultOnAdmission" to true,
+          ),
+        )
+      }
     }
 
     @Test
@@ -1107,6 +1237,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(2)
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -1131,6 +1263,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
       runBlocking {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -1155,6 +1289,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
       runBlocking {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -1179,6 +1315,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
       runBlocking {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -1201,6 +1339,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
       runBlocking {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -1225,6 +1365,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
       runBlocking {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -1252,6 +1394,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
       runBlocking {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -1283,6 +1427,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(2)
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -1316,6 +1462,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(2)
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -1357,9 +1505,22 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("BAI", "BAS")
         assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(2850)
+        assertThat(prisonIncentiveLevel?.convictedTransferLimitInPence).isEqualTo(550)
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(3)
         assertThat(prisonIncentiveLevel?.privilegedVisitOrders).isEqualTo(1)
         assertThat(prisonIncentiveLevel?.whenUpdated).isEqualTo(now)
+      }
+
+      assertAuditMessageSent<Map<String, Any>>("PRISON_INCENTIVE_LEVEL_UPDATED").let {
+        assertThat(it).containsAllEntriesOf(
+          mapOf(
+            "prisonId" to "BAI",
+            "levelCode" to "BAS",
+            "remandTransferLimitInPence" to 2850,
+            "convictedTransferLimitInPence" to 550,
+            "visitOrders" to 3,
+          ),
+        )
       }
     }
 
@@ -1411,6 +1572,17 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
             .map { it.prisonId to it.levelCode }.toList()
         assertThat(defaultLevelCodes).isEqualTo(listOf("WRI" to "ENH"))
       }
+
+      assertAuditMessageSent<Map<String, Any>>("PRISON_INCENTIVE_LEVEL_UPDATED").let {
+        assertThat(it).containsAllEntriesOf(
+          mapOf(
+            "prisonId" to "WRI",
+            "levelCode" to "ENH",
+            "remandTransferLimitInPence" to 6600,
+            "visitOrders" to 2,
+          ),
+        )
+      }
     }
 
     @Test
@@ -1437,6 +1609,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(2750)
         assertThat(prisonIncentiveLevel?.remandSpendLimitInPence).isEqualTo(27500)
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -1459,6 +1633,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
       runBlocking {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -1486,6 +1662,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(2)
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -1516,6 +1694,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         assertThat(prisonIncentiveLevel?.defaultOnAdmission).isFalse
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -1543,6 +1723,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         assertThat(prisonIncentiveLevel?.defaultOnAdmission).isTrue
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -1572,6 +1754,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(2)
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -1602,6 +1786,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(2750)
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -1641,6 +1827,17 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(2)
         assertThat(prisonIncentiveLevel?.whenUpdated).isEqualTo(now)
       }
+
+      assertAuditMessageSent<Map<String, Any>>("PRISON_INCENTIVE_LEVEL_UPDATED").let {
+        assertThat(it).containsAllEntriesOf(
+          mapOf(
+            "prisonId" to "WRI",
+            "levelCode" to "EN2",
+            "active" to false,
+            "defaultOnAdmission" to false,
+          ),
+        )
+      }
     }
 
     @Test
@@ -1658,6 +1855,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("WRI", "ENH")
         assertThat(prisonIncentiveLevel?.active).isTrue
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -1672,6 +1871,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
       runBlocking {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
       }
+
+      assertNoAuditMessageSent()
     }
 
     @Test
@@ -1694,6 +1895,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         assertThat(prisonIncentiveLevel?.defaultOnAdmission).isTrue
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
+
+      assertNoAuditMessageSent()
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResourceTest.kt
@@ -956,10 +956,10 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
               active = levelCode != "ENT",
               defaultOnAdmission = levelCode == "STD",
 
-              remandTransferLimitInPence = 6050,
-              remandSpendLimitInPence = 60500,
-              convictedTransferLimitInPence = 1980,
-              convictedSpendLimitInPence = 19800,
+              remandTransferLimitInPence = 60_50,
+              remandSpendLimitInPence = 605_00,
+              convictedTransferLimitInPence = 19_80,
+              convictedSpendLimitInPence = 198_00,
 
               visitOrders = 2,
               privilegedVisitOrders = 1,
@@ -1130,7 +1130,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("MDI", "STD")
-        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(6150)
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(61_50)
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(3)
         assertThat(prisonIncentiveLevel?.whenUpdated).isEqualTo(now)
       }
@@ -1140,7 +1140,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           mapOf(
             "prisonId" to "MDI",
             "levelCode" to "STD",
-            "remandTransferLimitInPence" to 6150,
+            "remandTransferLimitInPence" to 61_50,
             "visitOrders" to 3,
           ),
         )
@@ -1181,13 +1181,13 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
 
       runBlocking {
         var prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("WRI", "STD")
-        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(6050)
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(60_50)
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(2)
         assertThat(prisonIncentiveLevel?.active).isTrue
         assertThat(prisonIncentiveLevel?.defaultOnAdmission).isFalse
 
         prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("WRI", "ENH")
-        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(6050)
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(60_50)
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(2)
         assertThat(prisonIncentiveLevel?.active).isTrue
         assertThat(prisonIncentiveLevel?.defaultOnAdmission).isTrue
@@ -1233,7 +1233,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("MDI", "STD")
-        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(6050)
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(60_50)
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(2)
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
@@ -1423,7 +1423,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("BAI", "STD")
         assertThat(prisonIncentiveLevel?.active).isTrue
         assertThat(prisonIncentiveLevel?.defaultOnAdmission).isTrue
-        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(6050)
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(60_50)
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(2)
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
@@ -1458,7 +1458,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("BAI", "BAS")
         assertThat(prisonIncentiveLevel?.active).isTrue
         assertThat(prisonIncentiveLevel?.defaultOnAdmission).isFalse
-        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(2750)
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(27_50)
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(2)
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
@@ -1504,8 +1504,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("BAI", "BAS")
-        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(2850)
-        assertThat(prisonIncentiveLevel?.convictedTransferLimitInPence).isEqualTo(550)
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(28_50)
+        assertThat(prisonIncentiveLevel?.convictedTransferLimitInPence).isEqualTo(5_50)
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(3)
         assertThat(prisonIncentiveLevel?.privilegedVisitOrders).isEqualTo(1)
         assertThat(prisonIncentiveLevel?.whenUpdated).isEqualTo(now)
@@ -1516,8 +1516,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           mapOf(
             "prisonId" to "BAI",
             "levelCode" to "BAS",
-            "remandTransferLimitInPence" to 2850,
-            "convictedTransferLimitInPence" to 550,
+            "remandTransferLimitInPence" to 28_50,
+            "convictedTransferLimitInPence" to 5_50,
             "visitOrders" to 3,
           ),
         )
@@ -1556,13 +1556,13 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
 
       runBlocking {
         var prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("WRI", "STD")
-        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(6050)
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(60_50)
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(2)
         assertThat(prisonIncentiveLevel?.active).isTrue
         assertThat(prisonIncentiveLevel?.defaultOnAdmission).isFalse
 
         prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("WRI", "ENH")
-        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(6600)
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(66_00)
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(2)
         assertThat(prisonIncentiveLevel?.active).isTrue
         assertThat(prisonIncentiveLevel?.defaultOnAdmission).isTrue
@@ -1578,7 +1578,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
           mapOf(
             "prisonId" to "WRI",
             "levelCode" to "ENH",
-            "remandTransferLimitInPence" to 6600,
+            "remandTransferLimitInPence" to 66_00,
             "visitOrders" to 2,
           ),
         )
@@ -1606,8 +1606,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("BAI", "BAS")
-        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(2750)
-        assertThat(prisonIncentiveLevel?.remandSpendLimitInPence).isEqualTo(27500)
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(27_50)
+        assertThat(prisonIncentiveLevel?.remandSpendLimitInPence).isEqualTo(275_00)
       }
 
       assertNoAuditMessageSent()
@@ -1658,7 +1658,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("WRI", "ENH")
-        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(6600)
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(66_00)
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(2)
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
@@ -1750,7 +1750,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("BAI", "STD")
         assertThat(prisonIncentiveLevel?.active).isTrue
         assertThat(prisonIncentiveLevel?.defaultOnAdmission).isTrue
-        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(6050)
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(60_50)
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(2)
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
@@ -1783,7 +1783,7 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("BAI", "BAS")
         assertThat(prisonIncentiveLevel?.active).isTrue
         assertThat(prisonIncentiveLevel?.defaultOnAdmission).isFalse
-        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(2750)
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(27_50)
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
 
@@ -1822,8 +1822,8 @@ class IncentiveLevelResourceTest : SqsIntegrationTestBase() {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("WRI", "EN2")
         assertThat(prisonIncentiveLevel?.active).isFalse
         assertThat(prisonIncentiveLevel?.defaultOnAdmission).isFalse
-        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(6600)
-        assertThat(prisonIncentiveLevel?.convictedTransferLimitInPence).isEqualTo(3300)
+        assertThat(prisonIncentiveLevel?.remandTransferLimitInPence).isEqualTo(66_00)
+        assertThat(prisonIncentiveLevel?.convictedTransferLimitInPence).isEqualTo(33_00)
         assertThat(prisonIncentiveLevel?.visitOrders).isEqualTo(2)
         assertThat(prisonIncentiveLevel?.whenUpdated).isEqualTo(now)
       }


### PR DESCRIPTION
Submit SQS messages when an `IncentiveLevel` or `PrisonIncentiveLevel` is modified.

NB: For now, this happens inside transactions so data will not be committed to database at the point the message is received somewhere. This shouldn't hugely matter in case of audit events, but "HMPPS domain events" will need to be outside transactions so suggest moving the audit submissions too at that point.