### PR TITLE
INC-1171: Allow globally-defined incentive levels to require per-prison information to be active

### DIFF
--- a/doc/architecture/decisions/0004-reference-data-sync.md
+++ b/doc/architecture/decisions/0004-reference-data-sync.md
@@ -15,11 +15,11 @@ Accepted
 This document will cover the approach for the incentive service to master incentive reference data and synchronisation this information back into NOMIS
 
 Reference data for incentives includes:-
-- List of values for incentive levels for available to all prisons.  These are 
-  - Basic (BAS), 
-  - Standard (STD), 
-  - Enhanced (ENH), 
-  - Enhanced 2 (EN2), 
+- List of values for incentive levels for available to all prisons.  These are
+  - Basic (BAS),
+  - Standard (STD),
+  - Enhanced (ENH),
+  - Enhanced 2 (EN2),
   - Enhanced 3 (EN3)
 - List of incentive levels that apply to a prison
 - Spends for each level in each prison
@@ -34,7 +34,7 @@ erDiagram
     Prison_Incentive_Level ||--o{ VisitAllowance: has_visit_attributes
     Prison_Incentive_Level ||--o{ Privileges: has_priv_attributes
     Incentive_Level ||--o{ Prison_Incentive_Level: define_allowed_levels
-   
+
 ```
 
 ### Tables Affected in **NOMIS**:
@@ -51,12 +51,12 @@ erDiagram
    CONSTRAINT "REFERENCE_CODES_PK" PRIMARY KEY ("DOMAIN", "CODE")
  )
 ```
-Levels are set with the DOMAIN of `IEP_LEVELS` as a central admin user on the Reference Codes screen ![](reference_codes.png) 
+Levels are set with the DOMAIN of `IEP_LEVELS` as a central admin user on the Reference Codes screen ![](reference_codes.png)
 
 The `IEP_OTH_PRIV` domain allows extra privileges to be added ![](other_privs_ref.png)
 
 **There are only 3 active privileges in production**
-             
+
 | Code | Description       | Active |
 |------|-------------------|--------|
 | INET | Internet Access   | Y      |
@@ -67,7 +67,7 @@ The `IEP_OTH_PRIV` domain allows extra privileges to be added ![](other_privs_re
 
 The **OIMOIEPS** NOMIS screen allows config of levels, visits and other privilages.
 
-- IEP_LEVELS 
+- IEP_LEVELS
 ```oracle
   CREATE TABLE "IEP_LEVELS"
   (
@@ -159,8 +159,8 @@ sequenceDiagram
     participant HMPPS NOMIS Prisoner API
     participant NOMIS DB
 
-    Prison Staff ->> DPS: Add Incentive Reference data 
-    
+    Prison Staff ->> DPS: Add Incentive Reference data
+
     DPS ->> Incentives API: Call API with changes
     activate Incentives API
     Incentives API->>Incentives Database: update DB
@@ -168,7 +168,7 @@ sequenceDiagram
     Note over Incentives API,Domain Events: INCENTIVE_LEVEL_REFERENCE_DATA_[INSERTED/UPDATED]
     Incentives API-->>DPS: Reference Data updated returned
     deactivate Incentives API
-    
+
     Domain Events-->>HMPPS Prisoner to NOMIS update: Receives INCENTIVE_LEVEL_REFERENCE_DATA_* domain event
     activate HMPPS Prisoner to NOMIS update
     HMPPS Prisoner to NOMIS update->>HMPPS NOMIS Prisoner API: Update NOMIS with reference data
@@ -179,7 +179,7 @@ sequenceDiagram
 
 #### Event Types:
 In both instances the domain event will contain the code of the reference data.
-- INCENTIVE_LEVEL_REFERENCE_DATA_INSERTED 
+- INCENTIVE_LEVEL_REFERENCE_DATA_INSERTED
 - INCENTIVE_LEVEL_REFERENCE_DATA_UPDATED
 
 Note these should be the standard way of notifying about reference data changes for all NOMIS related reference data.
@@ -225,18 +225,20 @@ These events are raised when changes are made to add or update incentive levels 
 Authorised requests do not require any roles.
 
 #### Get a list of active incentive levels globally of all prisons
-`GET /incentive/levels` - 
+`GET /incentive/levels` -
 ```json5
 [
   {
     "code": "BAS",
     "description": "Basic",
-    "active": true
+    "active": true,
+    "required": true
   },
   {
     "code": "STD",
     "description": "Standard",
-    "active": true
+    "active": true,
+    "required": true
   },
   // more entries…
 ]
@@ -249,18 +251,21 @@ Authorised requests do not require any roles.
   {
     "code": "BAS",
     "description": "Basic",
-    "active": true
+    "active": true,
+    "required": true
   },
   {
     "code": "STD",
     "description": "Standard",
-    "active": true
+    "active": true,
+    "required": true
   },
   // more entries…
   {
     "code": "ENT",
     "description": "Entry",
-    "active": false
+    "active": false,
+    "required": false
   }
 ]
 ```

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IncentiveLevel.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IncentiveLevel.kt
@@ -26,14 +26,14 @@ data class IncentiveLevel(
   // @JsonProperty(required = false, access = JsonProperty.Access.READ_ONLY)
   // val expiredOn: LocalDate,
 
-  // TODO: add `required` flag to indicate that all prisons must use it
-  // @Schema(description = "Indicates that all prisons must have this level active", example = "true", defaultValue = "false")
-  // @JsonProperty(required = false, defaultValue = "false")
-  // val required: Boolean = false,
+  @Schema(description = "Indicates that all prisons must have this level active", example = "true", defaultValue = "false")
+  @JsonProperty(required = false, defaultValue = "false")
+  val required: Boolean = false,
 ) {
   fun toUpdate() = IncentiveLevelUpdate(
     description = description,
     active = active,
+    required = required,
   )
 }
 
@@ -45,4 +45,6 @@ data class IncentiveLevelUpdate(
   val description: String? = null,
   @Schema(description = "Indicates that the incentive level is active; inactive levels are historic levels no longer in use", example = "true", required = false)
   val active: Boolean? = null,
+  @Schema(description = "Indicates that all prisons must have this level active", example = "true", required = false)
+  val required: Boolean? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/IncentiveLevel.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/IncentiveLevel.kt
@@ -16,6 +16,7 @@ data class IncentiveLevel(
   val description: String,
   val sequence: Int,
   val active: Boolean = true,
+  val required: Boolean = false,
   @ReadOnlyProperty
   val whenCreated: LocalDateTime = LocalDateTime.now(),
   val whenUpdated: LocalDateTime = LocalDateTime.now(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonIncentiveLevelRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonIncentiveLevelRepository.kt
@@ -113,5 +113,5 @@ interface PrisonIncentiveLevelRepository : CoroutineCrudRepository<PrisonIncenti
     WHERE active IS TRUE
     """,
   )
-  fun findPrisonIdsOfActiveLevels(): Flow<String>
+  fun findPrisonIdsWithActiveLevels(): Flow<String>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonIncentiveLevelRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonIncentiveLevelRepository.kt
@@ -101,4 +101,17 @@ interface PrisonIncentiveLevelRepository : CoroutineCrudRepository<PrisonIncenti
     """,
   )
   suspend fun setOtherLevelsNotDefaultForAdmission(prisonId: String, levelCode: String): Int?
+
+  /**
+   * All prisons that have active level configurations, effectively a way to find all active prisons
+   */
+  @Query(
+    // language=postgresql
+    """
+    SELECT DISTINCT prison_id
+    FROM prison_incentive_level
+    WHERE active IS TRUE
+    """,
+  )
+  fun findPrisonIdsOfActiveLevels(): Flow<String>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResource.kt
@@ -185,8 +185,9 @@ class IncentiveLevelResource(
   @PreAuthorize("hasRole('MAINTAIN_INCENTIVE_LEVELS') and hasAuthority('SCOPE_write')")
   @Operation(
     summary = "Updates an incentive level",
-    description = "Payload must include all required fields",
-    // TODO: decide and explain what happens to associated per-prison data
+    description = "Payload must include all required fields. A level marked as required must also be active.",
+    // TODO: decide and explain what happens to associated per-prison data when activating/deactivating;
+    //       especially if level is active and/or occupied in some prison
     responses = [
       ApiResponse(
         responseCode = "200",
@@ -194,7 +195,7 @@ class IncentiveLevelResource(
       ),
       ApiResponse(
         responseCode = "400",
-        description = "Invalid payload", // TODO: maybe also when deactivating and there are prisons with level activated?
+        description = "Invalid payload",
         content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
       ),
       ApiResponse(
@@ -233,8 +234,9 @@ class IncentiveLevelResource(
   @PreAuthorize("hasRole('MAINTAIN_INCENTIVE_LEVELS') and hasAuthority('SCOPE_write')")
   @Operation(
     summary = "Updates an incentive level",
-    description = "Partial updates are allowed",
-    // TODO: decide and explain what happens to associated per-prison data
+    description = "Partial updates are allowed. A level marked as required must also be active.",
+    // TODO: decide and explain what happens to associated per-prison data when activating/deactivating;
+    //       especially if level is active and/or occupied in some prison
     responses = [
       ApiResponse(
         responseCode = "200",
@@ -242,7 +244,7 @@ class IncentiveLevelResource(
       ),
       ApiResponse(
         responseCode = "400",
-        description = "Invalid payload", // TODO: maybe also when deactivating and there are prisons with level activated?
+        description = "Invalid payload",
         content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
       ),
       ApiResponse(
@@ -290,17 +292,19 @@ class IncentiveLevelResource(
   @PreAuthorize("hasRole('MAINTAIN_INCENTIVE_LEVELS') and hasAuthority('SCOPE_write')")
   @Operation(
     summary = "Deactivates an incentive level",
-    // TODO: decide and explain what happens to associated per-prison data
+    description = "A required level cannot be deactivated, needs to be updated first to be not required.",
+    // TODO: decide and explain what happens to associated per-prison data;
+    //       especially if level is active and/or occupied in some prison
     responses = [
       ApiResponse(
         responseCode = "200",
         description = "Incentive level deactivated",
       ),
-      // ApiResponse(
-      //   responseCode = "400",
-      //   description = "This incentive level is active in some prison so cannot be deactivated",
-      //   content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))]
-      // ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Incentive level is marked as required",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
       ApiResponse(
         responseCode = "401",
         description = "Unauthorized to access this endpoint",
@@ -323,6 +327,6 @@ class IncentiveLevelResource(
     @PathVariable
     code: String,
   ): IncentiveLevel {
-    return partiallyUpdateIncentiveLevel(code, IncentiveLevelUpdate(active = false, required = false))
+    return partiallyUpdateIncentiveLevel(code, IncentiveLevelUpdate(active = false))
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResource.kt
@@ -97,6 +97,10 @@ class IncentiveLevelResource(
     ensure {
       ("code" to incentiveLevel.code).hasLengthAtLeast(1).hasLengthAtMost(6)
       ("description" to incentiveLevel.description).hasLengthAtLeast(1)
+
+      if (!incentiveLevel.active && incentiveLevel.required) {
+        errors.add("A level must be active if it is required")
+      }
     }
     return incentiveLevelService.createIncentiveLevel(incentiveLevel)
   }
@@ -269,6 +273,14 @@ class IncentiveLevelResource(
       update.description?.let {
         ("description" to it).hasLengthAtLeast(1)
       }
+
+      update.active?.let { active ->
+        update.required?.let { required ->
+          if (!active && required) {
+            errors.add("A level must be active if it is required")
+          }
+        }
+      }
     }
     return incentiveLevelService.updateIncentiveLevel(code, update)
       ?: throw NoDataWithCodeFoundException("incentive level", code)
@@ -311,6 +323,6 @@ class IncentiveLevelResource(
     @PathVariable
     code: String,
   ): IncentiveLevel {
-    return partiallyUpdateIncentiveLevel(code, IncentiveLevelUpdate(active = false))
+    return partiallyUpdateIncentiveLevel(code, IncentiveLevelUpdate(active = false, required = false))
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveLevelService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveLevelService.kt
@@ -106,7 +106,7 @@ class IncentiveLevelService(
 
   // TODO: Many DB queries are made: does this warrant NOT being in a transaction?
   private suspend fun enablePrisonIncentiveLevelEverywhere(levelCode: String) {
-    prisonIncentiveLevelRepository.findPrisonIdsOfActiveLevels().collect { prisonId ->
+    prisonIncentiveLevelRepository.findPrisonIdsWithActiveLevels().collect { prisonId ->
       prisonIncentiveLevelService.updatePrisonIncentiveLevel(
         prisonId,
         levelCode,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonIncentiveLevelService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonIncentiveLevelService.kt
@@ -83,6 +83,9 @@ class PrisonIncentiveLevelService(
           ?.withUpdate(update)
           ?: update.toNewEntity(prisonId, levelCode)
 
+      if (incentiveLevel.required && !prisonIncentiveLevel.active) {
+        throw ValidationException("A level cannot be made inactive and when it is globally required")
+      }
       if (!prisonIncentiveLevel.active && prisonIncentiveLevel.defaultOnAdmission) {
         throw ValidationException("A level cannot be made inactive and still be the default for admission")
       }

--- a/src/main/resources/db/migration/V1_28__required_incentive_levels.sql
+++ b/src/main/resources/db/migration/V1_28__required_incentive_levels.sql
@@ -1,0 +1,13 @@
+ALTER TABLE incentive_level
+    ADD COLUMN required BOOLEAN NOT NULL DEFAULT FALSE;
+
+UPDATE incentive_level
+SET active = TRUE, required = TRUE
+WHERE code IN ('BAS', 'STD', 'ENH');
+
+ALTER TABLE incentive_level
+    ADD CONSTRAINT incentive_level_active_if_required CHECK (active OR NOT required);
+
+UPDATE prison_incentive_level
+SET active = TRUE
+WHERE level_code IN (SELECT code FROM incentive_level WHERE required IS TRUE);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/IncentiveLevelResourceTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/IncentiveLevelResourceTestBase.kt
@@ -36,9 +36,9 @@ class IncentiveLevelResourceTestBase : SqsIntegrationTestBase() {
     incentiveLevelRepository.deleteAll()
     incentiveLevelRepository.saveAll(
       listOf(
-        IncentiveLevel(code = "BAS", description = "Basic", sequence = 1, new = true),
-        IncentiveLevel(code = "STD", description = "Standard", sequence = 2, new = true),
-        IncentiveLevel(code = "ENH", description = "Enhanced", sequence = 3, new = true),
+        IncentiveLevel(code = "BAS", description = "Basic", sequence = 1, required = true, new = true),
+        IncentiveLevel(code = "STD", description = "Standard", sequence = 2, required = true, new = true),
+        IncentiveLevel(code = "ENH", description = "Enhanced", sequence = 3, required = true, new = true),
         IncentiveLevel(code = "EN2", description = "Enhanced 2", sequence = 4, new = true),
         IncentiveLevel(code = "EN3", description = "Enhanced 3", sequence = 5, new = true),
         IncentiveLevel(code = "ENT", description = "Entry", active = false, sequence = 99, new = true),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/IncentiveLevelResourceTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/IncentiveLevelResourceTestBase.kt
@@ -7,6 +7,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.IncentiveLevel
+import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonIncentiveLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.IncentiveLevelRepository
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonIncentiveLevelRepository
 import uk.gov.justice.digital.hmpps.incentivesapi.service.AuditEvent
@@ -74,5 +75,43 @@ class IncentiveLevelResourceTestBase : SqsIntegrationTestBase() {
   protected fun assertAuditMessageSentWithMap(eventType: String): Map<String, Any> {
     val event = assertAuditMessageSent(eventType)
     return objectMapper.readValue(event.details, object : TypeReference<Map<String, Any>>() {})
+  }
+
+  protected fun makePrisonIncentiveLevel(prisonId: String, levelCode: String) = runBlocking {
+    prisonIncentiveLevelRepository.save(
+      PrisonIncentiveLevel(
+        levelCode = levelCode,
+        prisonId = prisonId,
+        active = levelCode != "ENT",
+        defaultOnAdmission = levelCode == "STD",
+
+        remandTransferLimitInPence = when (levelCode) {
+          "BAS" -> 27_50
+          "STD" -> 60_50
+          else -> 66_00
+        },
+        remandSpendLimitInPence = when (levelCode) {
+          "BAS" -> 275_00
+          "STD" -> 605_00
+          else -> 660_00
+        },
+        convictedTransferLimitInPence = when (levelCode) {
+          "BAS" -> 5_50
+          "STD" -> 19_80
+          else -> 33_00
+        },
+        convictedSpendLimitInPence = when (levelCode) {
+          "BAS" -> 55_00
+          "STD" -> 198_00
+          else -> 330_00
+        },
+
+        visitOrders = 2,
+        privilegedVisitOrders = 1,
+
+        new = true,
+        whenUpdated = now.minusDays(3),
+      ),
+    )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/IncentiveLevelRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/IncentiveLevelRepositoryTest.kt
@@ -1,7 +1,9 @@
 package uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository
 
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.reduce
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -32,6 +34,8 @@ class IncentiveLevelRepositoryTest : TestBase() {
       assertThat(level.sequence).isGreaterThan(previous.sequence)
       level
     }
+    val requiredLevels = repository.findAllByOrderBySequence().filter { it.required }.map { it.code }.toList()
+    assertThat(requiredLevels).isEqualTo(listOf("BAS", "STD", "ENH"))
   }
 
   private fun assertThatEntityCannotBeSaved(entity: IncentiveLevel) {
@@ -66,6 +70,18 @@ class IncentiveLevelRepositoryTest : TestBase() {
       code = "ABC",
       description = "",
       sequence = 10,
+      new = true,
+    ),
+  )
+
+  @Test
+  fun `level cannot be required if inactive`(): Unit = assertThatEntityCannotBeSaved(
+    IncentiveLevel(
+      code = "STD",
+      description = "Standard",
+      sequence = 10,
+      active = false,
+      required = true,
       new = true,
     ),
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonIncentiveLevelRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonIncentiveLevelRepositoryTest.kt
@@ -190,26 +190,27 @@ class PrisonIncentiveLevelRepositoryTest : TestBase() {
     assertThat(savedEntity?.levelDescription).isEqualTo("Enhanced")
   }
 
+  private fun makeNewEntity(levelCode: String, prisonId: String) = PrisonIncentiveLevel(
+    levelCode = levelCode,
+    prisonId = prisonId,
+    active = levelCode != "ENT",
+    defaultOnAdmission = levelCode == "STD",
+
+    remandTransferLimitInPence = 6050,
+    remandSpendLimitInPence = 60500,
+    convictedTransferLimitInPence = 1980,
+    convictedSpendLimitInPence = 19800,
+
+    visitOrders = 2,
+    privilegedVisitOrders = 1,
+
+    new = true,
+  )
+
   private suspend fun generateDefaultData() {
     listOf("BAS", "STD", "ENH", "EN2", "ENT").forEach { levelCode ->
       listOf("BAI", "MDI", "WRI").forEach { prisonId ->
-        val entity = PrisonIncentiveLevel(
-          levelCode = levelCode,
-          prisonId = prisonId,
-          active = levelCode != "ENT",
-          defaultOnAdmission = levelCode == "STD",
-
-          remandTransferLimitInPence = 6050,
-          remandSpendLimitInPence = 60500,
-          convictedTransferLimitInPence = 1980,
-          convictedSpendLimitInPence = 19800,
-
-          visitOrders = 2,
-          privilegedVisitOrders = 1,
-
-          new = true,
-        )
-        repository.save(entity)
+        repository.save(makeNewEntity(levelCode, prisonId))
       }
     }
     assertThat(repository.count()).isEqualTo(15)
@@ -248,27 +249,11 @@ class PrisonIncentiveLevelRepositoryTest : TestBase() {
     // Generate inactive prisons that will not be returned:
     listOf("BAS", "STD", "ENH", "EN2", "ENT").forEach { levelCode ->
       listOf("EXI", "LEI").forEach { prisonId ->
-        val entity = PrisonIncentiveLevel(
-          levelCode = levelCode,
-          prisonId = prisonId,
-          active = false,
-          defaultOnAdmission = levelCode == "STD",
-
-          remandTransferLimitInPence = 6050,
-          remandSpendLimitInPence = 60500,
-          convictedTransferLimitInPence = 1980,
-          convictedSpendLimitInPence = 19800,
-
-          visitOrders = 2,
-          privilegedVisitOrders = 1,
-
-          new = true,
-        )
-        repository.save(entity)
+        repository.save(makeNewEntity(levelCode, prisonId).copy(active = false))
       }
     }
 
-    val prisonIds = repository.findPrisonIdsOfActiveLevels().toSet()
+    val prisonIds = repository.findPrisonIdsWithActiveLevels().toSet()
     assertThat(prisonIds).isEqualTo(setOf("BAI", "MDI", "WRI"))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonIncentiveLevelRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonIncentiveLevelRepositoryTest.kt
@@ -66,10 +66,10 @@ class PrisonIncentiveLevelRepositoryTest : TestBase() {
       levelCode = "STD",
       prisonId = "MDI",
 
-      remandTransferLimitInPence = 2750,
-      remandSpendLimitInPence = 27500,
-      convictedTransferLimitInPence = 550,
-      convictedSpendLimitInPence = 5500,
+      remandTransferLimitInPence = 27_50,
+      remandSpendLimitInPence = 275_00,
+      convictedTransferLimitInPence = 5_50,
+      convictedSpendLimitInPence = 55_00,
 
       visitOrders = 2,
       privilegedVisitOrders = 1,
@@ -82,10 +82,10 @@ class PrisonIncentiveLevelRepositoryTest : TestBase() {
       levelCode = "STD",
       prisonId = "MDI",
 
-      remandTransferLimitInPence = 6050,
-      remandSpendLimitInPence = 60500,
-      convictedTransferLimitInPence = 1980,
-      convictedSpendLimitInPence = 19800,
+      remandTransferLimitInPence = 60_50,
+      remandSpendLimitInPence = 605_00,
+      convictedTransferLimitInPence = 19_80,
+      convictedSpendLimitInPence = 198_00,
 
       visitOrders = 2,
       privilegedVisitOrders = 1,
@@ -102,10 +102,10 @@ class PrisonIncentiveLevelRepositoryTest : TestBase() {
       levelCode = "std", // ← does not exist
       prisonId = "MDI",
 
-      remandTransferLimitInPence = 6050,
-      remandSpendLimitInPence = 60500,
-      convictedTransferLimitInPence = 1980,
-      convictedSpendLimitInPence = 19800,
+      remandTransferLimitInPence = 60_50,
+      remandSpendLimitInPence = 605_00,
+      convictedTransferLimitInPence = 19_80,
+      convictedSpendLimitInPence = 198_00,
 
       visitOrders = 2,
       privilegedVisitOrders = 1,
@@ -122,10 +122,10 @@ class PrisonIncentiveLevelRepositoryTest : TestBase() {
       levelCode = "STD",
       prisonId = "MDI",
 
-      remandTransferLimitInPence = 6050,
-      remandSpendLimitInPence = 60500,
-      convictedTransferLimitInPence = 1980,
-      convictedSpendLimitInPence = -19800, // ← cannot be negative
+      remandTransferLimitInPence = 60_50,
+      remandSpendLimitInPence = 605_00,
+      convictedTransferLimitInPence = 19_80,
+      convictedSpendLimitInPence = -198_00, // ← cannot be negative
 
       visitOrders = 2,
       privilegedVisitOrders = 0,
@@ -145,10 +145,10 @@ class PrisonIncentiveLevelRepositoryTest : TestBase() {
         prisonId = "MDI",
         active = levelCode != "ENT",
 
-        remandTransferLimitInPence = 6050,
-        remandSpendLimitInPence = 60500,
-        convictedTransferLimitInPence = 1980,
-        convictedSpendLimitInPence = 19800,
+        remandTransferLimitInPence = 60_50,
+        remandSpendLimitInPence = 605_00,
+        convictedTransferLimitInPence = 19_80,
+        convictedSpendLimitInPence = 198_00,
 
         visitOrders = 2,
         privilegedVisitOrders = 1,
@@ -172,10 +172,10 @@ class PrisonIncentiveLevelRepositoryTest : TestBase() {
       levelCode = "ENH",
       prisonId = "MDI",
 
-      remandTransferLimitInPence = 6600,
-      remandSpendLimitInPence = 66000,
-      convictedTransferLimitInPence = 3300,
-      convictedSpendLimitInPence = 33000,
+      remandTransferLimitInPence = 66_00,
+      remandSpendLimitInPence = 660_00,
+      convictedTransferLimitInPence = 33_00,
+      convictedSpendLimitInPence = 330_00,
 
       visitOrders = 2,
       privilegedVisitOrders = 1,
@@ -196,10 +196,10 @@ class PrisonIncentiveLevelRepositoryTest : TestBase() {
     active = levelCode != "ENT",
     defaultOnAdmission = levelCode == "STD",
 
-    remandTransferLimitInPence = 6050,
-    remandSpendLimitInPence = 60500,
-    convictedTransferLimitInPence = 1980,
-    convictedSpendLimitInPence = 19800,
+    remandTransferLimitInPence = 60_50,
+    remandSpendLimitInPence = 605_00,
+    convictedTransferLimitInPence = 19_80,
+    convictedSpendLimitInPence = 198_00,
 
     visitOrders = 2,
     privilegedVisitOrders = 1,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResourceTest.kt
@@ -58,11 +58,11 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           // language=json
           """
           [
-            {"code": "BAS", "description": "Basic", "active": true},
-            {"code": "STD", "description": "Standard", "active": true},
-            {"code": "ENH", "description": "Enhanced", "active": true},
-            {"code": "EN2", "description": "Enhanced 2", "active": true},
-            {"code": "EN3", "description": "Enhanced 3", "active": true}
+            {"code": "BAS", "description": "Basic", "active": true, "required": true},
+            {"code": "STD", "description": "Standard", "active": true, "required": true},
+            {"code": "ENH", "description": "Enhanced", "active": true, "required": true},
+            {"code": "EN2", "description": "Enhanced 2", "active": true, "required": false},
+            {"code": "EN3", "description": "Enhanced 3", "active": true, "required": false}
           ]
           """,
           true,
@@ -80,12 +80,12 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           // language=json
           """
           [
-            {"code": "BAS", "description": "Basic", "active": true},
-            {"code": "STD", "description": "Standard", "active": true},
-            {"code": "ENH", "description": "Enhanced", "active": true},
-            {"code": "EN2", "description": "Enhanced 2", "active": true},
-            {"code": "EN3", "description": "Enhanced 3", "active": true},
-            {"code": "ENT", "description": "Entry", "active": false}
+            {"code": "BAS", "description": "Basic", "active": true, "required": true},
+            {"code": "STD", "description": "Standard", "active": true, "required": true},
+            {"code": "ENH", "description": "Enhanced", "active": true, "required": true},
+            {"code": "EN2", "description": "Enhanced 2", "active": true, "required": false},
+            {"code": "EN3", "description": "Enhanced 3", "active": true, "required": false},
+            {"code": "ENT", "description": "Entry", "active": false, "required": false}
           ]
           """,
           true,
@@ -102,7 +102,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectBody().json(
           // language=json
           """
-          {"code": "EN2", "description": "Enhanced 2", "active": true}
+          {"code": "EN2", "description": "Enhanced 2", "active": true, "required": false}
           """,
           true,
         )
@@ -118,7 +118,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectBody().json(
           // language=json
           """
-          {"code": "ENT", "description": "Entry", "active": false}
+          {"code": "ENT", "description": "Entry", "active": false, "required": false}
           """,
           true,
         )
@@ -167,7 +167,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectBody().json(
           // language=json
           """
-          {"code": "EN4", "description": "Enhanced 4", "active": false}
+          {"code": "EN4", "description": "Enhanced 4", "active": false, "required": false}
           """,
           true,
         )
@@ -315,6 +315,10 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         """
         {"code": "EN4", "description": "", "active": false}
         """,
+        // language=json
+        """
+        {"code": "EN4", "description": "Enhanced 4", "active": false, "required": true}
+        """,
       ],
     )
     fun `fails to create a level with invalid fields`(body: String) {
@@ -351,12 +355,12 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           // language=json
           """
           [
-            {"code": "EN3", "description": "Enhanced 3", "active": true},
-            {"code": "EN2", "description": "Enhanced 2", "active": true},
-            {"code": "ENT", "description": "Entry", "active": false},
-            {"code": "ENH", "description": "Enhanced", "active": true},
-            {"code": "STD", "description": "Standard", "active": true},
-            {"code": "BAS", "description": "Basic", "active": true}
+            {"code": "EN3", "description": "Enhanced 3", "active": true, "required": false},
+            {"code": "EN2", "description": "Enhanced 2", "active": true, "required": false},
+            {"code": "ENT", "description": "Entry", "active": false, "required": false},
+            {"code": "ENH", "description": "Enhanced", "active": true, "required": true},
+            {"code": "STD", "description": "Standard", "active": true, "required": true},
+            {"code": "BAS", "description": "Basic", "active": true, "required": true}
           ]
           """,
           true,
@@ -483,7 +487,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .bodyValue(
           // language=json
           """
-          {"code": "STD", "description": "Silver", "active": true}
+          {"code": "STD", "description": "Silver", "active": true, "required": true}
           """,
         )
         .exchange()
@@ -491,7 +495,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectBody().json(
           // language=json
           """
-          {"code": "STD", "description": "Silver", "active": true}
+          {"code": "STD", "description": "Silver", "active": true, "required": true}
           """,
           true,
         )
@@ -618,18 +622,25 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
       assertNoAuditMessageSent()
     }
 
-    @Test
-    fun `fails to update a level with invalid fields`() {
+    @ParameterizedTest
+    @ValueSource(
+      strings = [
+        // language=json
+        """
+        {"code": "STD", "description": "", "active": false}
+        """,
+        // language=json
+        """
+        {"code": "STD", "description": "Standard", "active": false, "required": true}
+        """,
+      ],
+    )
+    fun `fails to update a level with invalid fields`(body: String) {
       webTestClient.put()
         .uri("/incentive/levels/STD")
         .withCentralAuthorisation()
         .header("Content-Type", "application/json")
-        .bodyValue(
-          // language=json
-          """
-          {"code": "STD", "description": "", "active": false}
-          """,
-        )
+        .bodyValue(body)
         .exchange()
         .expectErrorResponse(HttpStatus.BAD_REQUEST, "Invalid parameters")
 
@@ -661,7 +672,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectBody().json(
           // language=json
           """
-          {"code": "STD", "description": "Silver", "active": true}
+          {"code": "STD", "description": "Silver", "active": true, "required": true}
           """,
           true,
         )
@@ -735,7 +746,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .bodyValue(
           // language=json
           """
-          {"code": "STD", "description": "Gold", "active": false}
+          {"code": "STD", "description": "Gold", "active": false, "required": false}
           """,
         )
         .exchange()
@@ -743,7 +754,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectBody().json(
           // language=json
           """
-          {"code": "ENH", "description": "Gold", "active": false}
+          {"code": "ENH", "description": "Gold", "active": false, "required": false}
           """,
           true,
         )
@@ -752,10 +763,12 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         var incentiveLevel = incentiveLevelRepository.findById("ENH")
         assertThat(incentiveLevel?.description).isEqualTo("Gold")
         assertThat(incentiveLevel?.active).isFalse
+        assertThat(incentiveLevel?.required).isFalse
         assertThat(incentiveLevel?.whenUpdated).isEqualTo(now)
         incentiveLevel = incentiveLevelRepository.findById("STD")
         assertThat(incentiveLevel?.description).isEqualTo("Standard")
         assertThat(incentiveLevel?.active).isTrue
+        assertThat(incentiveLevel?.required).isTrue
         assertThat(incentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
 
@@ -765,18 +778,25 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
       }
     }
 
-    @Test
-    fun `fails to partially update a level with invalid fields`() {
+    @ParameterizedTest
+    @ValueSource(
+      strings = [
+        // language=json
+        """
+        {"description": "", "active": false}
+        """,
+        // language=json
+        """
+        {"active": false, "required": true}
+        """,
+      ],
+    )
+    fun `fails to partially update a level with invalid fields`(body: String) {
       webTestClient.patch()
         .uri("/incentive/levels/STD")
         .withCentralAuthorisation()
         .header("Content-Type", "application/json")
-        .bodyValue(
-          // language=json
-          """
-          {"description": "", "active": false}
-          """,
-        )
+        .bodyValue(body)
         .exchange()
         .expectErrorResponse(HttpStatus.BAD_REQUEST, "Invalid parameters")
 
@@ -784,6 +804,30 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         val incentiveLevel = incentiveLevelRepository.findById("STD")
         assertThat(incentiveLevel?.description).isEqualTo("Standard")
         assertThat(incentiveLevel?.active).isTrue
+      }
+
+      assertNoAuditMessageSent()
+    }
+
+    @Test
+    fun `fails to partially update a level when inactive level is made required`() {
+      webTestClient.patch()
+        .uri("/incentive/levels/ENT")
+        .withCentralAuthorisation()
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          // language=json
+          """
+          {"required": true}
+          """,
+        )
+        .exchange()
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "A level must be active if it is required")
+
+      runBlocking {
+        val incentiveLevel = incentiveLevelRepository.findById("ENT")
+        assertThat(incentiveLevel?.active).isFalse
+        assertThat(incentiveLevel?.required).isFalse
       }
 
       assertNoAuditMessageSent()
@@ -799,7 +843,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectBody().json(
           // language=json
           """
-          {"code": "STD", "description": "Standard", "active": false}
+          {"code": "STD", "description": "Standard", "active": false, "required": false}
           """,
           true,
         )
@@ -826,7 +870,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectBody().json(
           // language=json
           """
-          {"code": "ENT", "description": "Entry", "active": false}
+          {"code": "ENT", "description": "Entry", "active": false, "required": false}
           """,
           true,
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/PrisonIncentiveLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/PrisonIncentiveLevelResourceTest.kt
@@ -15,7 +15,6 @@ import org.springframework.http.HttpStatus
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.incentivesapi.helper.expectErrorResponse
 import uk.gov.justice.digital.hmpps.incentivesapi.integration.IncentiveLevelResourceTestBase
-import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonIncentiveLevel
 import java.time.Clock
 
 class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
@@ -33,24 +32,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
       prisonIncentiveLevelRepository.deleteAll()
       listOf("BAS", "STD", "ENH", "ENT").forEach { levelCode ->
         listOf("BAI", "MDI", "WRI").forEach { prisonId ->
-          prisonIncentiveLevelRepository.save(
-            PrisonIncentiveLevel(
-              levelCode = levelCode,
-              prisonId = prisonId,
-              active = levelCode != "ENT",
-              defaultOnAdmission = levelCode == "STD",
-
-              remandTransferLimitInPence = 60_50,
-              remandSpendLimitInPence = 605_00,
-              convictedTransferLimitInPence = 19_80,
-              convictedSpendLimitInPence = 198_00,
-
-              visitOrders = 2,
-              privilegedVisitOrders = 1,
-
-              new = true,
-            ),
-          )
+          makePrisonIncentiveLevel(prisonId, levelCode)
         }
       }
     }
@@ -68,7 +50,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           [
             {
               "levelCode": "BAS", "levelDescription": "Basic", "prisonId": "MDI", "active": true, "defaultOnAdmission": false,
-              "remandTransferLimitInPence": 6050, "remandSpendLimitInPence": 60500, "convictedTransferLimitInPence": 1980, "convictedSpendLimitInPence": 19800,
+              "remandTransferLimitInPence": 2750, "remandSpendLimitInPence": 27500, "convictedTransferLimitInPence": 550, "convictedSpendLimitInPence": 5500,
               "visitOrders": 2, "privilegedVisitOrders": 1
             },
             {
@@ -78,7 +60,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
             },
             {
               "levelCode": "ENH", "levelDescription": "Enhanced", "prisonId": "MDI", "active": true, "defaultOnAdmission": false,
-              "remandTransferLimitInPence": 6050, "remandSpendLimitInPence": 60500, "convictedTransferLimitInPence": 1980, "convictedSpendLimitInPence": 19800,
+              "remandTransferLimitInPence": 6600, "remandSpendLimitInPence": 66000, "convictedTransferLimitInPence": 3300, "convictedSpendLimitInPence": 33000,
               "visitOrders": 2, "privilegedVisitOrders": 1
             }
           ]
@@ -99,7 +81,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """
           {
             "levelCode": "ENH", "levelDescription": "Enhanced", "prisonId": "WRI", "active": true, "defaultOnAdmission": false,
-            "remandTransferLimitInPence": 6050, "remandSpendLimitInPence": 60500, "convictedTransferLimitInPence": 1980, "convictedSpendLimitInPence": 19800,
+            "remandTransferLimitInPence": 6600, "remandSpendLimitInPence": 66000, "convictedTransferLimitInPence": 3300, "convictedSpendLimitInPence": 33000,
             "visitOrders": 2, "privilegedVisitOrders": 1
           }
           """,
@@ -138,47 +120,9 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
       )
     }
 
-    private fun saveLevel(prisonId: String, levelCode: String) = runBlocking {
-      prisonIncentiveLevelRepository.save(
-        PrisonIncentiveLevel(
-          levelCode = levelCode,
-          prisonId = prisonId,
-          active = levelCode != "ENT",
-          defaultOnAdmission = levelCode == "STD",
-
-          remandTransferLimitInPence = when (levelCode) {
-            "BAS" -> 27_50
-            "STD" -> 60_50
-            else -> 66_00
-          },
-          remandSpendLimitInPence = when (levelCode) {
-            "BAS" -> 275_00
-            "STD" -> 605_00
-            else -> 660_00
-          },
-          convictedTransferLimitInPence = when (levelCode) {
-            "BAS" -> 5_50
-            "STD" -> 19_80
-            else -> 33_00
-          },
-          convictedSpendLimitInPence = when (levelCode) {
-            "BAS" -> 55_00
-            "STD" -> 198_00
-            else -> 330_00
-          },
-
-          visitOrders = 2,
-          privilegedVisitOrders = 1,
-
-          new = true,
-          whenUpdated = now.minusDays(3),
-        ),
-      )
-    }
-
     @Test
     fun `updates a prison incentive level when one exists`() {
-      saveLevel("MDI", "STD")
+      makePrisonIncentiveLevel("MDI", "STD")
       `updates a prison incentive level when per-prison information does not exist`()
     }
 
@@ -233,7 +177,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
 
     @Test
     fun `updates the default prison incentive level for admission`() {
-      saveLevel("WRI", "STD") // Standard is the default for admission
+      makePrisonIncentiveLevel("WRI", "STD") // Standard is the default for admission
 
       webTestClient.put()
         .uri("/incentive/prison-levels/WRI/level/ENH")
@@ -296,7 +240,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
 
     @Test
     fun `requires correct role to update a prison incentive level`() {
-      saveLevel("MDI", "STD")
+      makePrisonIncentiveLevel("MDI", "STD")
 
       webTestClient.put()
         .uri("/incentive/prison-levels/MDI/level/STD")
@@ -484,7 +428,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
 
     @Test
     fun `fails to update a prison incentive level when no default for admission would remain`() {
-      saveLevel("BAI", "STD")
+      makePrisonIncentiveLevel("BAI", "STD")
 
       webTestClient.put()
         .uri("/incentive/prison-levels/BAI/level/STD")
@@ -518,8 +462,8 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
     @Test
     fun `fails to update a non-default prison incentive level when there is no other default level for admission`() {
       // data integrity problem: there is no default level for admission
-      saveLevel("BAI", "BAS")
-      saveLevel("BAI", "ENH")
+      makePrisonIncentiveLevel("BAI", "BAS")
+      makePrisonIncentiveLevel("BAI", "ENH")
 
       webTestClient.put()
         .uri("/incentive/prison-levels/BAI/level/BAS")
@@ -578,7 +522,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
 
     @Test
     fun `partially updates a prison incentive level when one exists`() {
-      saveLevel("BAI", "BAS")
+      makePrisonIncentiveLevel("BAI", "BAS")
       `partially updates a prison incentive level when per-prison information does not exist`()
     }
 
@@ -636,7 +580,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
 
     @Test
     fun `partially updates the default prison incentive level for admission`() {
-      saveLevel("WRI", "STD") // Standard is the default for admission
+      makePrisonIncentiveLevel("WRI", "STD") // Standard is the default for admission
 
       webTestClient.patch()
         .uri("/incentive/prison-levels/WRI/level/ENH")
@@ -697,7 +641,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
 
     @Test
     fun `requires correct role to partially update a prison incentive level`() {
-      saveLevel("BAI", "BAS")
+      makePrisonIncentiveLevel("BAI", "BAS")
 
       webTestClient.patch()
         .uri("/incentive/prison-levels/BAI/level/BAS")
@@ -749,7 +693,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
 
     @Test
     fun `fails to partially update a prison incentive level with invalid fields`() {
-      saveLevel("WRI", "ENH")
+      makePrisonIncentiveLevel("WRI", "ENH")
 
       webTestClient.patch()
         .uri("/incentive/prison-levels/WRI/level/ENH")
@@ -778,7 +722,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
 
     @Test
     fun `fails to partially update a prison incentive level when making inactive level the default`() {
-      saveLevel("MDI", "ENT") // Entry is inactive
+      makePrisonIncentiveLevel("MDI", "ENT") // Entry is inactive
 
       webTestClient.patch()
         .uri("/incentive/prison-levels/MDI/level/ENT")
@@ -815,7 +759,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         val standard = incentiveLevelRepository.findById("STD")!!.copy(required = false)
         incentiveLevelRepository.save(standard)
       }
-      saveLevel("MDI", "STD") // Standard is the default for admission
+      makePrisonIncentiveLevel("MDI", "STD") // Standard is the default for admission
 
       webTestClient.patch()
         .uri("/incentive/prison-levels/MDI/level/STD")
@@ -844,7 +788,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
 
     @Test
     fun `fails to partially update a prison incentive level when no default for admission would remain`() {
-      saveLevel("BAI", "STD") // Standard is the default for admission
+      makePrisonIncentiveLevel("BAI", "STD") // Standard is the default for admission
 
       webTestClient.patch()
         .uri("/incentive/prison-levels/MDI/level/STD")
@@ -876,8 +820,8 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
     @Test
     fun `fails to partially update a non-default prison incentive level when there is no other default level for admission`() {
       // data integrity problem: there is no default level for admission
-      saveLevel("BAI", "BAS")
-      saveLevel("BAI", "ENH")
+      makePrisonIncentiveLevel("BAI", "BAS")
+      makePrisonIncentiveLevel("BAI", "ENH")
 
       webTestClient.patch()
         .uri("/incentive/prison-levels/BAI/level/BAS")
@@ -907,7 +851,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
 
     @Test
     fun `fails to partially update a prison incentive level if it would become inactive despite being globally required`() {
-      saveLevel("BAI", "BAS") // Basic is required in all prisons
+      makePrisonIncentiveLevel("BAI", "BAS") // Basic is required in all prisons
 
       webTestClient.patch()
         .uri("/incentive/prison-levels/BAI/level/BAS")
@@ -935,13 +879,13 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
 
     @Test
     fun `deactivates a prison incentive level when one exists`() {
-      saveLevel("WRI", "EN2")
+      makePrisonIncentiveLevel("WRI", "EN2")
       `deactivates a prison incentive level when per-prison information does not exist`()
     }
 
     @Test
     fun `deactivates a prison incentive level when per-prison information does not exist`() {
-      saveLevel("WRI", "STD") // Standard is the default for admission, needed to allow deactivation of EN2
+      makePrisonIncentiveLevel("WRI", "STD") // Standard is the default for admission, needed to allow deactivation of EN2
 
       webTestClient.delete()
         .uri("/incentive/prison-levels/WRI/level/EN2")
@@ -985,7 +929,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
 
     @Test
     fun `requires correct role to deactivate a prison incentive level`() {
-      saveLevel("WRI", "ENH")
+      makePrisonIncentiveLevel("WRI", "ENH")
 
       webTestClient.delete()
         .uri("/incentive/prison-levels/WRI/level/ENH")
@@ -1025,7 +969,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         val standard = incentiveLevelRepository.findById("STD")!!.copy(required = false)
         incentiveLevelRepository.save(standard)
       }
-      saveLevel("MDI", "STD") // Standard is the default for admission
+      makePrisonIncentiveLevel("MDI", "STD") // Standard is the default for admission
 
       webTestClient.delete()
         .uri("/incentive/prison-levels/MDI/level/STD")
@@ -1049,7 +993,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
 
     @Test
     fun `fails to deactivate a prison incentive level which is required globally`() {
-      saveLevel("MDI", "BAS") // Basic is globally required
+      makePrisonIncentiveLevel("MDI", "BAS") // Basic is globally required
 
       webTestClient.delete()
         .uri("/incentive/prison-levels/MDI/level/BAS")


### PR DESCRIPTION
New business rules:
• If an incentive level is globally required, per-prison levels and associated information cannot be deactivated
• If an incentive level becomes globally required, it will be activated automatically in all prisons that currently have some active levels (essentially, in all active prisons); associated information will use policy defaults