### PR TITLE
Scale `preprod` replicas from 4 to 2

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -2,6 +2,7 @@
 # Per environment values which override defaults in hmpps-incentives-api/values.yaml
 
 generic-service:
+  replicaCount: 2
 
   ingress:
     host: incentives-api-preprod.hmpps.service.justice.gov.uk


### PR DESCRIPTION
This environment is hardly used and does not warrant 4 pods running at all times.