### PR TITLE
INC-1188: Test domain events are raised when incentive levels are modified

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelResource.kt
@@ -105,7 +105,7 @@ class IepLevelResource(
     @Schema(description = "Booking Id", example = "3000002", required = true, type = "integer", format = "int64", pattern = "^[0-9]{1,20}$")
     @PathVariable
     bookingId: Long,
-    @Schema(description = "Toggle to return IEP detail entries in response (or not)", example = "true", required = false, defaultValue = "true", type = "boolean", pattern = "^[true|false]$")
+    @Schema(description = "Toggle to return IEP detail entries in response (or not)", example = "true", required = false, defaultValue = "true", type = "boolean", pattern = "^true|false$")
     @RequestParam(defaultValue = "true", value = "with-details", required = false)
     withDetails: Boolean = true,
   ): IepSummary =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResource.kt
@@ -37,6 +37,7 @@ class IncentiveLevelResource(
   @GetMapping("levels")
   @Operation(
     summary = "Lists all incentive levels, optionally including inactive ones",
+    description = "For the majority of use cases, inactive levels in a prison should be ignored.",
     responses = [
       ApiResponse(
         responseCode = "200",
@@ -71,6 +72,7 @@ class IncentiveLevelResource(
   @ResponseStatus(HttpStatus.CREATED)
   @Operation(
     summary = "Creates a new incentive level",
+    description = "New incentive levels are added to the end of the list",
     responses = [
       ApiResponse(
         responseCode = "201",
@@ -152,7 +154,7 @@ class IncentiveLevelResource(
   @GetMapping("levels/{code}")
   @Operation(
     summary = "Returns an incentive level by code",
-    description = "Note that it may be inactive",
+    description = "Note that it may be inactive. For the majority of use cases, inactive levels in a prison should be ignored.",
     responses = [
       ApiResponse(
         responseCode = "200",
@@ -188,7 +190,7 @@ class IncentiveLevelResource(
   @PreAuthorize("hasRole('MAINTAIN_INCENTIVE_LEVELS') and hasAuthority('SCOPE_write')")
   @Operation(
     summary = "Updates an incentive level",
-    description = "Payload must include all required fields. A level marked as required must also be active.",
+    description = "Payload must include all required fields. A level marked as required must also be active. Deactivated incentive levels remain in the same position with respect to the others.",
     // TODO: decide and explain what happens to associated per-prison data when activating/deactivating;
     //       especially if level is active and/or occupied in some prison
     responses = [
@@ -237,7 +239,7 @@ class IncentiveLevelResource(
   @PreAuthorize("hasRole('MAINTAIN_INCENTIVE_LEVELS') and hasAuthority('SCOPE_write')")
   @Operation(
     summary = "Updates an incentive level",
-    description = "Partial updates are allowed. A level marked as required must also be active.",
+    description = "Partial updates are allowed. A level marked as required must also be active. Deactivated incentive levels remain in the same position with respect to the others.",
     // TODO: decide and explain what happens to associated per-prison data when activating/deactivating;
     //       especially if level is active and/or occupied in some prison
     responses = [
@@ -295,7 +297,7 @@ class IncentiveLevelResource(
   @PreAuthorize("hasRole('MAINTAIN_INCENTIVE_LEVELS') and hasAuthority('SCOPE_write')")
   @Operation(
     summary = "Deactivates an incentive level",
-    description = "A required level cannot be deactivated, needs to be updated first to be not required.",
+    description = "A required level cannot be deactivated, needs to be updated first to be not required. Deactivated incentive levels remain in the same position with respect to the others.",
     // TODO: decide and explain what happens to associated per-prison data;
     //       especially if level is active and/or occupied in some prison
     responses = [

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResource.kt
@@ -72,7 +72,8 @@ class IncentiveLevelResource(
   @ResponseStatus(HttpStatus.CREATED)
   @Operation(
     summary = "Creates a new incentive level",
-    description = "New incentive levels are added to the end of the list",
+    description = "New incentive levels are added to the end of the list." +
+      "\n\nRaises HMPPS domain event: \"incentives.level.changed\"",
     responses = [
       ApiResponse(
         responseCode = "201",
@@ -113,7 +114,8 @@ class IncentiveLevelResource(
   @PreAuthorize("hasRole('MAINTAIN_INCENTIVE_LEVELS') and hasAuthority('SCOPE_write')")
   @Operation(
     summary = "Sets the order of incentive levels",
-    description = "All existing incentive level codes must be provided",
+    description = "All existing incentive level codes must be provided." +
+      "\n\nRaises HMPPS domain event: \"incentives.levels.reordered\"",
     responses = [
       ApiResponse(
         responseCode = "200",
@@ -190,7 +192,8 @@ class IncentiveLevelResource(
   @PreAuthorize("hasRole('MAINTAIN_INCENTIVE_LEVELS') and hasAuthority('SCOPE_write')")
   @Operation(
     summary = "Updates an incentive level",
-    description = "Payload must include all required fields. A level marked as required must also be active. Deactivated incentive levels remain in the same position with respect to the others.",
+    description = "Payload must include all required fields. A level marked as required must also be active. Deactivated incentive levels remain in the same position with respect to the others." +
+      "\n\nRaises HMPPS domain event: \"incentives.level.changed\"",
     // TODO: decide and explain what happens to associated per-prison data when activating/deactivating;
     //       especially if level is active and/or occupied in some prison
     responses = [
@@ -239,7 +242,8 @@ class IncentiveLevelResource(
   @PreAuthorize("hasRole('MAINTAIN_INCENTIVE_LEVELS') and hasAuthority('SCOPE_write')")
   @Operation(
     summary = "Updates an incentive level",
-    description = "Partial updates are allowed. A level marked as required must also be active. Deactivated incentive levels remain in the same position with respect to the others.",
+    description = "Partial updates are allowed. A level marked as required must also be active. Deactivated incentive levels remain in the same position with respect to the others." +
+      "\n\nRaises HMPPS domain event: \"incentives.level.changed\"",
     // TODO: decide and explain what happens to associated per-prison data when activating/deactivating;
     //       especially if level is active and/or occupied in some prison
     responses = [
@@ -297,7 +301,8 @@ class IncentiveLevelResource(
   @PreAuthorize("hasRole('MAINTAIN_INCENTIVE_LEVELS') and hasAuthority('SCOPE_write')")
   @Operation(
     summary = "Deactivates an incentive level",
-    description = "A required level cannot be deactivated, needs to be updated first to be not required. Deactivated incentive levels remain in the same position with respect to the others.",
+    description = "A required level cannot be deactivated, needs to be updated first to be not required. Deactivated incentive levels remain in the same position with respect to the others." +
+      "\n\nRaises HMPPS domain event: \"incentives.level.changed\"",
     // TODO: decide and explain what happens to associated per-prison data;
     //       especially if level is active and/or occupied in some prison
     responses = [

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResource.kt
@@ -73,7 +73,8 @@ class IncentiveLevelResource(
   @Operation(
     summary = "Creates a new incentive level",
     description = "New incentive levels are added to the end of the list." +
-      "\n\nRaises HMPPS domain event: \"incentives.level.changed\"",
+      "\n\nRequires role: MAINTAIN_INCENTIVE_LEVELS with write scope" +
+      "\nRaises HMPPS domain event: \"incentives.level.changed\"",
     responses = [
       ApiResponse(
         responseCode = "201",
@@ -115,7 +116,8 @@ class IncentiveLevelResource(
   @Operation(
     summary = "Sets the order of incentive levels",
     description = "All existing incentive level codes must be provided." +
-      "\n\nRaises HMPPS domain event: \"incentives.levels.reordered\"",
+      "\n\nRequires role: MAINTAIN_INCENTIVE_LEVELS with write scope" +
+      "\nRaises HMPPS domain event: \"incentives.levels.reordered\"",
     responses = [
       ApiResponse(
         responseCode = "200",
@@ -193,7 +195,8 @@ class IncentiveLevelResource(
   @Operation(
     summary = "Updates an incentive level",
     description = "Payload must include all required fields. A level marked as required must also be active. Deactivated incentive levels remain in the same position with respect to the others." +
-      "\n\nRaises HMPPS domain event: \"incentives.level.changed\"",
+      "\n\nRequires role: MAINTAIN_INCENTIVE_LEVELS with write scope" +
+      "\nRaises HMPPS domain event: \"incentives.level.changed\"",
     // TODO: decide and explain what happens to associated per-prison data when activating/deactivating;
     //       especially if level is active and/or occupied in some prison
     responses = [
@@ -243,7 +246,8 @@ class IncentiveLevelResource(
   @Operation(
     summary = "Updates an incentive level",
     description = "Partial updates are allowed. A level marked as required must also be active. Deactivated incentive levels remain in the same position with respect to the others." +
-      "\n\nRaises HMPPS domain event: \"incentives.level.changed\"",
+      "\n\nRequires role: MAINTAIN_INCENTIVE_LEVELS with write scope" +
+      "\nRaises HMPPS domain event: \"incentives.level.changed\"",
     // TODO: decide and explain what happens to associated per-prison data when activating/deactivating;
     //       especially if level is active and/or occupied in some prison
     responses = [
@@ -302,7 +306,8 @@ class IncentiveLevelResource(
   @Operation(
     summary = "Deactivates an incentive level",
     description = "A required level cannot be deactivated, needs to be updated first to be not required. Deactivated incentive levels remain in the same position with respect to the others." +
-      "\n\nRaises HMPPS domain event: \"incentives.level.changed\"",
+      "\n\nRequires role: MAINTAIN_INCENTIVE_LEVELS with write scope" +
+      "\nRaises HMPPS domain event: \"incentives.level.changed\"",
     // TODO: decide and explain what happens to associated per-prison data;
     //       especially if level is active and/or occupied in some prison
     responses = [

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResource.kt
@@ -56,7 +56,7 @@ class IncentiveLevelResource(
     ],
   )
   suspend fun getIncentiveLevels(
-    @Schema(description = "Include inactive incentive levels", example = "true", required = false, defaultValue = "false", type = "boolean", pattern = "^[true|false]$")
+    @Schema(description = "Include inactive incentive levels", example = "true", required = false, defaultValue = "false", type = "boolean", pattern = "^true|false$")
     @RequestParam(defaultValue = "false", value = "with-inactive", required = false)
     withInactive: Boolean = false,
   ): List<IncentiveLevel> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/PrisonIncentiveLevelResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/PrisonIncentiveLevelResource.kt
@@ -110,7 +110,8 @@ class PrisonIncentiveLevelResource(
   @Operation(
     summary = "Updates prison incentive level information",
     description = "Payload must include all required fields." +
-      "\n\nRaises HMPPS domain event: \"incentives.prison-level.changed\"",
+      "\n\nRequires role: MAINTAIN_PRISON_IEP_LEVELS with write scope" +
+      "\nRaises HMPPS domain event: \"incentives.prison-level.changed\"",
     // TODO: decide and explain what happens to prisoners if level is deactivated
     responses = [
       ApiResponse(
@@ -165,7 +166,8 @@ class PrisonIncentiveLevelResource(
   @Operation(
     summary = "Updates prison incentive level information",
     description = "Partial updates are allowed." +
-    "\n\nRaises HMPPS domain event: \"incentives.prison-level.changed\"",
+      "\n\nRequires role: MAINTAIN_PRISON_IEP_LEVELS with write scope" +
+      "\nRaises HMPPS domain event: \"incentives.prison-level.changed\"",
     // TODO: decide and explain what happens to prisoners if level is deactivated
     responses = [
       ApiResponse(
@@ -242,7 +244,8 @@ class PrisonIncentiveLevelResource(
   @PreAuthorize("hasRole('MAINTAIN_PRISON_IEP_LEVELS') and hasAuthority('SCOPE_write')")
   @Operation(
     summary = "Deactivate an incentive level for a prison." +
-    "\n\nRaises HMPPS domain event: \"incentives.prison-level.changed\"",
+      "\n\nRequires role: MAINTAIN_PRISON_IEP_LEVELS with write scope" +
+      "\nRaises HMPPS domain event: \"incentives.prison-level.changed\"",
     // TODO: decide and explain what happens to prisoners if level is deactivated
     responses = [
       ApiResponse(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/PrisonIncentiveLevelResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/PrisonIncentiveLevelResource.kt
@@ -56,7 +56,7 @@ class PrisonIncentiveLevelResource(
     @Schema(description = "Prison id", example = "MDI", required = true, minLength = 3, maxLength = 6)
     @PathVariable
     prisonId: String,
-    @Schema(description = "Include inactive prison incentive levels", example = "true", required = false, defaultValue = "false", type = "boolean", pattern = "^[true|false]$")
+    @Schema(description = "Include inactive prison incentive levels", example = "true", required = false, defaultValue = "false", type = "boolean", pattern = "^true|false$")
     @RequestParam(defaultValue = "false", value = "with-inactive", required = false)
     withInactive: Boolean = false,
   ): List<PrisonIncentiveLevel> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/PrisonIncentiveLevelResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/PrisonIncentiveLevelResource.kt
@@ -109,7 +109,8 @@ class PrisonIncentiveLevelResource(
   @PreAuthorize("hasRole('MAINTAIN_PRISON_IEP_LEVELS') and hasAuthority('SCOPE_write')")
   @Operation(
     summary = "Updates prison incentive level information",
-    description = "Payload must include all required fields",
+    description = "Payload must include all required fields." +
+      "\n\nRaises HMPPS domain event: \"incentives.prison-level.changed\"",
     // TODO: decide and explain what happens to prisoners if level is deactivated
     responses = [
       ApiResponse(
@@ -163,7 +164,8 @@ class PrisonIncentiveLevelResource(
   @PreAuthorize("hasRole('MAINTAIN_PRISON_IEP_LEVELS') and hasAuthority('SCOPE_write')")
   @Operation(
     summary = "Updates prison incentive level information",
-    description = "Partial updates are allowed",
+    description = "Partial updates are allowed." +
+    "\n\nRaises HMPPS domain event: \"incentives.prison-level.changed\"",
     // TODO: decide and explain what happens to prisoners if level is deactivated
     responses = [
       ApiResponse(
@@ -239,7 +241,8 @@ class PrisonIncentiveLevelResource(
   @DeleteMapping("{prisonId}/level/{levelCode}")
   @PreAuthorize("hasRole('MAINTAIN_PRISON_IEP_LEVELS') and hasAuthority('SCOPE_write')")
   @Operation(
-    summary = "Deactivate an incentive level for a prison",
+    summary = "Deactivate an incentive level for a prison." +
+    "\n\nRaises HMPPS domain event: \"incentives.prison-level.changed\"",
     // TODO: decide and explain what happens to prisoners if level is deactivated
     responses = [
       ApiResponse(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/PrisonIncentiveLevelResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/PrisonIncentiveLevelResource.kt
@@ -34,6 +34,7 @@ class PrisonIncentiveLevelResource(
   @GetMapping("{prisonId}")
   @Operation(
     summary = "Lists incentive levels in this prison along with associated information, optionally including inactive ones",
+    description = "Inactive incentive levels in the prison were previously active at some point. Not all global inactive incentive levels are necessarily included. For the majority of use cases, inactive levels in a prison should be ignored.",
     responses = [
       ApiResponse(
         responseCode = "200",
@@ -69,7 +70,7 @@ class PrisonIncentiveLevelResource(
   @GetMapping("{prisonId}/level/{levelCode}")
   @Operation(
     summary = "Returns an incentive level in this prison along with associated information",
-    description = "Note that it may be inactive in the prison",
+    description = "Note that it may be inactive in the prison. For the majority of use cases, inactive levels in a prison should be ignored.",
     responses = [
       ApiResponse(
         responseCode = "200",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/SnsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/SnsService.kt
@@ -66,7 +66,6 @@ data class AdditionalInformation(
   val alertsRemoved: List<String>? = null,
   val incentiveLevel: String? = null,
   val prisonId: String? = null,
-
 )
 
 data class HMPPSDomainEvent(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/IncentiveLevelResourceTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/IncentiveLevelResourceTestBase.kt
@@ -1,16 +1,21 @@
 package uk.gov.justice.digital.hmpps.incentivesapi.integration
 
+import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.model.PurgeQueueRequest
 import com.fasterxml.jackson.core.type.TypeReference
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.IncentiveLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonIncentiveLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.IncentiveLevelRepository
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonIncentiveLevelRepository
 import uk.gov.justice.digital.hmpps.incentivesapi.service.AuditEvent
+import uk.gov.justice.digital.hmpps.incentivesapi.service.HMPPSDomainEvent
+import uk.gov.justice.digital.hmpps.incentivesapi.service.HMPPSMessage
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDateTime
@@ -23,6 +28,8 @@ class IncentiveLevelResourceTestBase : SqsIntegrationTestBase() {
       ZoneId.of("Europe/London"),
     )
     val now: LocalDateTime = LocalDateTime.now(clock)
+
+    var testDomainEventQueueUrl: String? = null
   }
 
   @Autowired
@@ -30,6 +37,17 @@ class IncentiveLevelResourceTestBase : SqsIntegrationTestBase() {
 
   @Autowired
   protected lateinit var prisonIncentiveLevelRepository: PrisonIncentiveLevelRepository
+
+  @BeforeEach
+  fun subscribeToDomainEvents() {
+    val sqsClient = incentivesQueue.sqsClient
+    if (testDomainEventQueueUrl == null) {
+      testDomainEventQueueUrl = sqsClient.createQueue("test-domain-events").queueUrl
+      val snsClient = domainEventsTopic.snsClient
+      snsClient.subscribe(domainEventsTopicArn, "sqs", testDomainEventQueueUrl)
+    }
+    sqsClient.purgeQueue(PurgeQueueRequest(testDomainEventQueueUrl))
+  }
 
   @AfterEach
   fun tearDown(): Unit = runBlocking {
@@ -47,15 +65,37 @@ class IncentiveLevelResourceTestBase : SqsIntegrationTestBase() {
     ).collect()
   }
 
-  protected fun assertNoAuditMessageSent() {
-    val queueSize = auditQueue.sqsClient.getQueueAttributes(auditQueue.queueUrl, listOf("ApproximateNumberOfMessages"))
+  private fun AmazonSQS.getApproxQueueSize(queueUrl: String): Int? =
+    getQueueAttributes(queueUrl, listOf("ApproximateNumberOfMessages"))
       .attributes["ApproximateNumberOfMessages"]?.toInt()
+
+  protected fun assertNoDomainEventSent() {
+    val sqsClient = incentivesQueue.sqsClient
+    val queueSize = sqsClient.getApproxQueueSize(testDomainEventQueueUrl!!)
+    assertThat(queueSize).isEqualTo(0)
+  }
+
+  protected fun assertDomainEventSent(eventType: String): HMPPSDomainEvent {
+    val sqsClient = incentivesQueue.sqsClient
+    val queueSize = sqsClient.getApproxQueueSize(testDomainEventQueueUrl!!)
+    assertThat(queueSize).isEqualTo(1)
+
+    val body = sqsClient.receiveMessage(testDomainEventQueueUrl).messages[0].body
+    val (message, attributes) = objectMapper.readValue(body, HMPPSMessage::class.java)
+    assertThat(attributes.eventType.Value).isEqualTo(eventType)
+    val domainEvent = objectMapper.readValue(message, HMPPSDomainEvent::class.java)
+    assertThat(domainEvent.eventType).isEqualTo(eventType)
+
+    return domainEvent
+  }
+
+  protected fun assertNoAuditMessageSent() {
+    val queueSize = auditQueue.sqsClient.getApproxQueueSize(auditQueue.queueUrl)
     assertThat(queueSize).isEqualTo(0)
   }
 
   private fun assertAuditMessageSent(eventType: String): AuditEvent {
-    val queueSize = auditQueue.sqsClient.getQueueAttributes(auditQueue.queueUrl, listOf("ApproximateNumberOfMessages"))
-      .attributes["ApproximateNumberOfMessages"]?.toInt()
+    val queueSize = auditQueue.sqsClient.getApproxQueueSize(auditQueue.queueUrl)
     assertThat(queueSize).isEqualTo(1)
 
     val message = auditQueue.sqsClient.receiveMessage(auditQueue.queueUrl).messages[0].body

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/SqsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/SqsIntegrationTestBase.kt
@@ -29,7 +29,7 @@ class SqsIntegrationTestBase : IntegrationTestBase() {
   @Autowired
   protected lateinit var objectMapper: ObjectMapper
 
-  private val domainEventsTopic by lazy {
+  protected val domainEventsTopic by lazy {
     hmppsQueueService.findByTopicId("domainevents")
       ?: throw MissingQueueException("HmppsTopic domainevents not found")
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResourceTest.kt
@@ -185,6 +185,10 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(prisonIncentiveLevelRepository.count()).isEqualTo(0)
       }
 
+      assertDomainEventSent("incentives.level.changed").let {
+        assertThat(it.description).isEqualTo("An incentive level has been changed: EN4")
+        assertThat(it.additionalInformation?.incentiveLevel).isEqualTo("EN4")
+      }
       assertAuditMessageSentWithMap("INCENTIVE_LEVEL_ADDED").let {
         assertThat(it["code"]).isEqualTo("EN4")
       }
@@ -245,6 +249,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(incentiveLevelRepository.count()).isEqualTo(6)
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -278,6 +283,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(incentiveLevel?.active).isTrue
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -306,6 +312,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(incentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -335,6 +342,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(incentiveLevelRepository.count()).isEqualTo(6)
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -372,6 +380,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(incentiveLevelRepository.count()).isEqualTo(6)
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -413,6 +422,10 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         }
       }
 
+      assertDomainEventSent("incentives.levels.reordered").let {
+        assertThat(it.description).isEqualTo("Incentive levels have been re-ordered")
+        assertThat(it.additionalInformation).isNull()
+      }
       assertAuditMessageSentWithList<String>("INCENTIVE_LEVELS_REORDERED").let {
         assertThat(it).isEqualTo(listOf("EN3", "EN2", "ENT", "ENH", "STD", "BAS"))
       }
@@ -438,6 +451,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(incentiveLevelCodes).isEqualTo(listOf("BAS", "STD", "ENH", "EN2", "EN3", "ENT"))
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -465,6 +479,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         }
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -489,6 +504,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(incentiveLevels.map { it.sequence }).isEqualTo(listOf(1, 2, 3, 4, 5, 99))
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -513,6 +529,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(incentiveLevels.map { it.sequence }).isEqualTo(listOf(1, 2, 3, 4, 5, 99))
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -544,6 +561,10 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(incentiveLevel?.whenUpdated).isEqualTo(now)
       }
 
+      assertDomainEventSent("incentives.level.changed").let {
+        assertThat(it.description).isEqualTo("An incentive level has been changed: STD")
+        assertThat(it.additionalInformation?.incentiveLevel).isEqualTo("STD")
+      }
       assertAuditMessageSentWithMap("INCENTIVE_LEVEL_UPDATED").let {
         assertThat(it["description"]).isEqualTo("Silver")
       }
@@ -606,6 +627,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(incentiveLevel?.description).isNotEqualTo("Silver")
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -632,6 +654,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(incentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -659,6 +682,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(incentiveLevel?.active).isTrue
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -694,6 +718,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(incentiveLevel?.active).isTrue
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -727,6 +752,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(incentiveLevel).isNull()
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -758,6 +784,10 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(incentiveLevel?.whenUpdated).isEqualTo(now)
       }
 
+      assertDomainEventSent("incentives.level.changed").let {
+        assertThat(it.description).isEqualTo("An incentive level has been changed: STD")
+        assertThat(it.additionalInformation?.incentiveLevel).isEqualTo("STD")
+      }
       assertAuditMessageSentWithMap("INCENTIVE_LEVEL_UPDATED").let {
         assertThat(it["description"]).isEqualTo("Silver")
       }
@@ -820,6 +850,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(incentiveLevel?.description).isNotEqualTo("Silver")
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -846,6 +877,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(incentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -884,6 +916,10 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(incentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
 
+      assertDomainEventSent("incentives.level.changed").let {
+        assertThat(it.description).isEqualTo("An incentive level has been changed: ENH")
+        assertThat(it.additionalInformation?.incentiveLevel).isEqualTo("ENH")
+      }
       assertAuditMessageSentWithMap("INCENTIVE_LEVEL_UPDATED").let {
         assertThat(it["code"]).isEqualTo("ENH")
         assertThat(it["description"]).isEqualTo("Gold")
@@ -918,6 +954,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(incentiveLevel?.active).isTrue
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -942,6 +979,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(incentiveLevel?.required).isFalse
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -967,6 +1005,10 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(incentiveLevel?.whenUpdated).isEqualTo(now)
       }
 
+      assertDomainEventSent("incentives.level.changed").let {
+        assertThat(it.description).isEqualTo("An incentive level has been changed: EN2")
+        assertThat(it.additionalInformation?.incentiveLevel).isEqualTo("EN2")
+      }
       assertAuditMessageSentWithMap("INCENTIVE_LEVEL_UPDATED").let {
         assertThat(it["code"]).isEqualTo("EN2")
         assertThat(it["active"]).isEqualTo(false)
@@ -995,6 +1037,10 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(incentiveLevel?.whenUpdated).isEqualTo(now)
       }
 
+      assertDomainEventSent("incentives.level.changed").let {
+        assertThat(it.description).isEqualTo("An incentive level has been changed: ENT")
+        assertThat(it.additionalInformation?.incentiveLevel).isEqualTo("ENT")
+      }
       assertAuditMessageSentWithMap("INCENTIVE_LEVEL_UPDATED").let {
         assertThat(it["code"]).isEqualTo("ENT")
         assertThat(it["active"]).isEqualTo(false)
@@ -1014,6 +1060,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(incentiveLevel?.active).isTrue
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -1033,6 +1080,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(incentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -1051,6 +1099,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(incentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/PrisonIncentiveLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/PrisonIncentiveLevelResourceTest.kt
@@ -210,6 +210,11 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(prisonIncentiveLevel?.whenUpdated).isEqualTo(now)
       }
 
+      assertDomainEventSent("incentives.prison-level.changed").let {
+        assertThat(it.description).isEqualTo("Incentive level (STD) in prison MDI has been updated")
+        assertThat(it.additionalInformation?.incentiveLevel).isEqualTo("STD")
+        assertThat(it.additionalInformation?.prisonId).isEqualTo("MDI")
+      }
       assertAuditMessageSentWithMap("PRISON_INCENTIVE_LEVEL_UPDATED").let {
         assertThat(it).containsAllEntriesOf(
           mapOf(
@@ -273,6 +278,11 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(defaultLevelCodes).isEqualTo(listOf("WRI" to "ENH"))
       }
 
+      assertDomainEventSent("incentives.prison-level.changed").let {
+        assertThat(it.description).isEqualTo("Incentive level (ENH) in prison WRI has been updated")
+        assertThat(it.additionalInformation?.incentiveLevel).isEqualTo("ENH")
+        assertThat(it.additionalInformation?.prisonId).isEqualTo("WRI")
+      }
       assertAuditMessageSentWithMap("PRISON_INCENTIVE_LEVEL_UPDATED").let {
         assertThat(it).containsAllEntriesOf(
           mapOf(
@@ -313,6 +323,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -339,6 +350,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -365,6 +377,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -391,6 +404,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -415,6 +429,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -441,6 +456,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -470,6 +486,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -503,6 +520,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -538,6 +556,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -564,6 +583,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -612,6 +632,11 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(prisonIncentiveLevel?.whenUpdated).isEqualTo(now)
       }
 
+      assertDomainEventSent("incentives.prison-level.changed").let {
+        assertThat(it.description).isEqualTo("Incentive level (BAS) in prison BAI has been updated")
+        assertThat(it.additionalInformation?.incentiveLevel).isEqualTo("BAS")
+        assertThat(it.additionalInformation?.prisonId).isEqualTo("BAI")
+      }
       assertAuditMessageSentWithMap("PRISON_INCENTIVE_LEVEL_UPDATED").let {
         assertThat(it).containsAllEntriesOf(
           mapOf(
@@ -674,6 +699,11 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(defaultLevelCodes).isEqualTo(listOf("WRI" to "ENH"))
       }
 
+      assertDomainEventSent("incentives.prison-level.changed").let {
+        assertThat(it.description).isEqualTo("Incentive level (ENH) in prison WRI has been updated")
+        assertThat(it.additionalInformation?.incentiveLevel).isEqualTo("ENH")
+        assertThat(it.additionalInformation?.prisonId).isEqualTo("WRI")
+      }
       assertAuditMessageSentWithMap("PRISON_INCENTIVE_LEVEL_UPDATED").let {
         assertThat(it).containsAllEntriesOf(
           mapOf(
@@ -711,6 +741,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(prisonIncentiveLevel?.remandSpendLimitInPence).isEqualTo(275_00)
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -735,6 +766,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -764,6 +796,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -796,6 +829,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -830,6 +864,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -861,6 +896,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -893,6 +929,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -921,6 +958,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -962,6 +1000,11 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(prisonIncentiveLevel?.whenUpdated).isEqualTo(now)
       }
 
+      assertDomainEventSent("incentives.prison-level.changed").let {
+        assertThat(it.description).isEqualTo("Incentive level (EN2) in prison WRI has been updated")
+        assertThat(it.additionalInformation?.incentiveLevel).isEqualTo("EN2")
+        assertThat(it.additionalInformation?.prisonId).isEqualTo("WRI")
+      }
       assertAuditMessageSentWithMap("PRISON_INCENTIVE_LEVEL_UPDATED").let {
         assertThat(it).containsAllEntriesOf(
           mapOf(
@@ -990,6 +1033,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(prisonIncentiveLevel?.active).isTrue
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -1006,6 +1050,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -1035,6 +1080,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
 
@@ -1058,6 +1104,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(prisonIncentiveLevel?.whenUpdated).isNotEqualTo(now)
       }
 
+      assertNoDomainEventSent()
       assertNoAuditMessageSent()
     }
   }


### PR DESCRIPTION
When incentive levels or per-prison associated data is modified, HMPPS domain events are sent using SNS. Now tests assert that this happens at appropriately. This ensures that changes in #395 are correctly implemented.

Also might as well document the api endpoints more thoroughly.