### PR TITLE
`NextReviewDateService` no longer uses `IepDetail`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IncentiveLevel.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IncentiveLevel.kt
@@ -30,6 +30,11 @@ data class IncentiveLevel(
   @JsonProperty(required = false, defaultValue = "false")
   val required: Boolean = false,
 ) {
+
+  companion object {
+    const val BasicCode = "BAS"
+  }
+
   fun toUpdate() = IncentiveLevelUpdate(
     description = description,
     active = active,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/PrisonerIepLevel.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/PrisonerIepLevel.kt
@@ -2,10 +2,12 @@ package uk.gov.justice.digital.hmpps.incentivesapi.jpa
 
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.ReadOnlyProperty
 import org.springframework.data.annotation.Transient
 import org.springframework.data.domain.Persistable
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IsRealReview
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 data class PrisonerIepLevel(
@@ -34,4 +36,8 @@ data class PrisonerIepLevel(
   override fun isNew(): Boolean = new
 
   override fun getId(): Long = id
+
+  @Transient
+  @ReadOnlyProperty
+  val reviewDate: LocalDate = reviewTime.toLocalDate()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/Adapters.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/Adapters.kt
@@ -24,10 +24,6 @@ fun PrisonerIepLevel.toIepDetail(incentiveLevels: Map<String, IncentiveLevel>) =
     auditModuleName = SYSTEM_USERNAME,
   )
 
-fun List<PrisonerIepLevel>.toIepDetails(iepLevels: Map<String, IncentiveLevel>): List<IepDetail> {
-  return map { review -> review.toIepDetail(iepLevels) }
-}
-
 fun List<NextReviewDate>.toMapByBookingId(): Map<Long, LocalDate> {
   return associate { it.bookingId to it.nextReviewDate }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateService.kt
@@ -1,11 +1,10 @@
 package uk.gov.justice.digital.hmpps.incentivesapi.service
 
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.IncentiveLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
 import java.time.LocalDate
 import java.time.Period
-
-private const val BASIC = "BAS"
 
 data class NextReviewDateInput(
   val hasAcctOpen: Boolean,
@@ -76,7 +75,7 @@ class NextReviewDateService(private val input: NextReviewDateInput) {
   }
 
   private fun isOnBasic(): Boolean {
-    return lastReview()?.iepCode == BASIC
+    return lastReview()?.iepCode == IncentiveLevel.BasicCode
   }
 
   private fun lastReviewDate(): LocalDate {
@@ -86,7 +85,7 @@ class NextReviewDateService(private val input: NextReviewDateInput) {
   private fun wasConfirmedBasic(): Boolean {
     val reviews = reviews()
 
-    return isOnBasic() && reviews.size >= 2 && reviews[1].iepCode == BASIC
+    return isOnBasic() && reviews.size >= 2 && reviews[1].iepCode == IncentiveLevel.BasicCode
   }
 
   private fun isNewPrisoner(): Boolean {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateService.kt
@@ -1,24 +1,24 @@
 package uk.gov.justice.digital.hmpps.incentivesapi.service
 
-import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepDetail
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
+import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
 import java.time.LocalDate
 import java.time.Period
 
-private const val BASIC = "Basic"
+private const val BASIC = "BAS"
 
 data class NextReviewDateInput(
   val hasAcctOpen: Boolean,
   val dateOfBirth: LocalDate,
   val receptionDate: LocalDate,
-  val iepDetails: List<IepDetail>,
+  val incentiveRecords: List<PrisonerIepLevel>,
 )
 
 class NextReviewDateService(private val input: NextReviewDateInput) {
 
   fun calculate(): LocalDate {
     if (isReadmission()) {
-      val readmissionDate = reviews(includeReadmissions = true).first().iepDate
+      val readmissionDate = reviews(includeReadmissions = true).first().reviewDate
       return ruleForNewPrisoners(readmissionDate)
     }
 
@@ -71,22 +71,22 @@ class NextReviewDateService(private val input: NextReviewDateInput) {
     return ageOnDate < 18
   }
 
-  private fun lastReview(): IepDetail? {
+  private fun lastReview(): PrisonerIepLevel? {
     return reviews().firstOrNull()
   }
 
   private fun isOnBasic(): Boolean {
-    return lastReview()?.iepLevel == BASIC
+    return lastReview()?.iepCode == BASIC
   }
 
   private fun lastReviewDate(): LocalDate {
-    return lastReview()?.iepDate ?: input.receptionDate
+    return lastReview()?.reviewDate ?: input.receptionDate
   }
 
   private fun wasConfirmedBasic(): Boolean {
     val reviews = reviews()
 
-    return isOnBasic() && reviews.size >= 2 && reviews[1].iepLevel == BASIC
+    return isOnBasic() && reviews.size >= 2 && reviews[1].iepCode == BASIC
   }
 
   private fun isNewPrisoner(): Boolean {
@@ -98,10 +98,10 @@ class NextReviewDateService(private val input: NextReviewDateInput) {
     return reviews(includeReadmissions = true).firstOrNull()?.reviewType == ReviewType.READMISSION
   }
 
-  private fun reviews(includeReadmissions: Boolean = false): List<IepDetail> {
-    return input.iepDetails.filter { iepDetail ->
-      iepDetail.isRealReview() ||
-        (includeReadmissions && iepDetail.reviewType == ReviewType.READMISSION)
+  private fun reviews(includeReadmissions: Boolean = false): List<PrisonerIepLevel> {
+    return input.incentiveRecords.filter { incentiveRecord ->
+      incentiveRecord.isRealReview() ||
+        (includeReadmissions && incentiveRecord.reviewType == ReviewType.READMISSION)
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterService.kt
@@ -64,9 +64,7 @@ class NextReviewDateUpdaterService(
       .toList()
       .groupBy(PrisonerIepLevel::bookingId)
 
-    val nextReviewDateRecords = reviewsMap.map {
-      val bookingId = it.key
-      val iepDetails = it.value.toIepDetails(iepLevels)
+    val nextReviewDateRecords = reviewsMap.map { (bookingId, incentiveRecords) ->
       val offender = offendersMap[bookingId]!!
 
       val nextReviewDate = NextReviewDateService(
@@ -74,7 +72,7 @@ class NextReviewDateUpdaterService(
           dateOfBirth = offender.dateOfBirth,
           receptionDate = offender.receptionDate,
           hasAcctOpen = offender.hasAcctOpen,
-          iepDetails = iepDetails,
+          incentiveRecords = incentiveRecords,
         ),
       ).calculate()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterService.kt
@@ -4,7 +4,6 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.incentivesapi.dto.IncentiveLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.NextReviewDate
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.NextReviewDateRepository
@@ -55,8 +54,6 @@ class NextReviewDateUpdaterService(
     val bookingIds = offendersMap.keys.toList()
 
     val nextReviewDatesBeforeUpdate: Map<Long, LocalDate> = nextReviewDateRepository.findAllById(bookingIds).toList().toMapByBookingId()
-
-    val iepLevels: Map<String, IncentiveLevel> = incentiveLevelService.getAllIncentiveLevelsMapByCode()
 
     // NOTE: This is to account for bookingIds potentially without any review record
     val bookingIdsNoReviews = bookingIds.associateWith { emptyList<PrisonerIepLevel>() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateServiceTest.kt
@@ -3,9 +3,8 @@ package uk.gov.justice.digital.hmpps.incentivesapi.service
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.incentivesapi.SYSTEM_USERNAME
-import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepDetail
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
+import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
 import java.time.LocalDate
 
 class NextReviewDateServiceTest {
@@ -13,17 +12,17 @@ class NextReviewDateServiceTest {
   @Test
   fun `when IEP level is not Basic, returns +1 year`() {
     val input = NextReviewDateInput(
-      iepDetails = listOf(
-        review("2015-08-01", "ACI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.MIGRATED),
-        review("2015-07-01", "ACI", iepCode = "BAS", iepLevel = "Basic", reviewType = ReviewType.MIGRATED),
-        review("2010-07-01", "MDI", iepCode = "ENH", iepLevel = "Enhanced", reviewType = ReviewType.MIGRATED),
-        review("2000-07-01", "MDI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.MIGRATED),
+      incentiveRecords = listOf(
+        incentiveRecord("2015-08-01", "ACI", iepCode = "STD", reviewType = ReviewType.MIGRATED),
+        incentiveRecord("2015-07-01", "ACI", iepCode = "BAS", reviewType = ReviewType.MIGRATED),
+        incentiveRecord("2010-07-01", "MDI", iepCode = "ENH", reviewType = ReviewType.MIGRATED),
+        incentiveRecord("2000-07-01", "MDI", iepCode = "STD", reviewType = ReviewType.MIGRATED),
       ),
       hasAcctOpen = false,
       dateOfBirth = LocalDate.parse("1971-07-01"),
       receptionDate = LocalDate.parse("2000-07-01"),
     )
-    val expectedNextReviewDate = input.iepDetails[0].iepDate.plusYears(1)
+    val expectedNextReviewDate = input.incentiveRecords[0].reviewDate.plusYears(1)
 
     val nextReviewDate = NextReviewDateService(input).calculate()
 
@@ -33,17 +32,17 @@ class NextReviewDateServiceTest {
   @Test
   fun `when IEP level is not Basic, returns +1 year (data from NOMIS)`() {
     val input = NextReviewDateInput(
-      iepDetails = listOf(
-        review("2015-08-01", "ACI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.MIGRATED),
-        review("2015-07-01", "ACI", iepCode = "BAS", iepLevel = "Basic", reviewType = ReviewType.MIGRATED),
-        review("2010-07-01", "MDI", iepCode = "ENH", iepLevel = "Enhanced", reviewType = ReviewType.MIGRATED),
-        review("2000-07-01", "MDI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.MIGRATED),
+      incentiveRecords = listOf(
+        incentiveRecord("2015-08-01", "ACI", iepCode = "STD", reviewType = ReviewType.MIGRATED),
+        incentiveRecord("2015-07-01", "ACI", iepCode = "BAS", reviewType = ReviewType.MIGRATED),
+        incentiveRecord("2010-07-01", "MDI", iepCode = "ENH", reviewType = ReviewType.MIGRATED),
+        incentiveRecord("2000-07-01", "MDI", iepCode = "STD", reviewType = ReviewType.MIGRATED),
       ),
       hasAcctOpen = false,
       dateOfBirth = LocalDate.parse("1971-07-01"),
       receptionDate = LocalDate.parse("2000-07-01"),
     )
-    val expectedNextReviewDate = input.iepDetails[0].iepDate.plusYears(1)
+    val expectedNextReviewDate = input.incentiveRecords[0].reviewDate.plusYears(1)
 
     val nextReviewDate = NextReviewDateService(input).calculate()
 
@@ -56,14 +55,14 @@ class NextReviewDateServiceTest {
     @Test
     fun `when IEP level is Basic and there is no previous review, returns +7 days`() {
       val input = NextReviewDateInput(
-        iepDetails = listOf(
-          review("2000-07-01", "MDI", iepCode = "BAS", iepLevel = "Basic", reviewType = ReviewType.MIGRATED),
+        incentiveRecords = listOf(
+          incentiveRecord("2000-07-01", "MDI", iepCode = "BAS", reviewType = ReviewType.MIGRATED),
         ),
         hasAcctOpen = false,
         dateOfBirth = LocalDate.parse("1971-07-01"),
         receptionDate = LocalDate.parse("2000-07-01"),
       )
-      val expectedNextReviewDate = input.iepDetails[0].iepDate.plusDays(7)
+      val expectedNextReviewDate = input.incentiveRecords[0].reviewDate.plusDays(7)
 
       val nextReviewDate = NextReviewDateService(input).calculate()
 
@@ -73,14 +72,14 @@ class NextReviewDateServiceTest {
     @Test
     fun `when IEP level is Basic and there is no previous review, returns +7 days (data from NOMIS)`() {
       val input = NextReviewDateInput(
-        iepDetails = listOf(
-          review("2000-07-01", "MDI", iepCode = "BAS", iepLevel = "Basic", reviewType = ReviewType.MIGRATED),
+        incentiveRecords = listOf(
+          incentiveRecord("2000-07-01", "MDI", iepCode = "BAS", reviewType = ReviewType.MIGRATED),
         ),
         hasAcctOpen = false,
         dateOfBirth = LocalDate.parse("1971-07-01"),
         receptionDate = LocalDate.parse("2000-07-01"),
       )
-      val expectedNextReviewDate = input.iepDetails[0].iepDate.plusDays(7)
+      val expectedNextReviewDate = input.incentiveRecords[0].reviewDate.plusDays(7)
 
       val nextReviewDate = NextReviewDateService(input).calculate()
 
@@ -90,16 +89,16 @@ class NextReviewDateServiceTest {
     @Test
     fun `when IEP level is Basic and there is no previous 'real' review, returns +7 days`() {
       val input = NextReviewDateInput(
-        iepDetails = listOf(
-          review("2023-01-29", "ACI", iepCode = "BAS", iepLevel = "Basic", reviewType = ReviewType.REVIEW),
-          review("2022-12-01", "ACI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.TRANSFER),
-          review("2022-11-29", "MDI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.INITIAL),
+        incentiveRecords = listOf(
+          incentiveRecord("2023-01-29", "ACI", iepCode = "BAS", reviewType = ReviewType.REVIEW),
+          incentiveRecord("2022-12-01", "ACI", iepCode = "STD", reviewType = ReviewType.TRANSFER),
+          incentiveRecord("2022-11-29", "MDI", iepCode = "STD", reviewType = ReviewType.INITIAL),
         ),
         hasAcctOpen = false,
         dateOfBirth = LocalDate.parse("1971-07-01"),
         receptionDate = LocalDate.parse("2022-11-29"),
       )
-      val expectedNextReviewDate = input.iepDetails[0].iepDate.plusDays(7)
+      val expectedNextReviewDate = input.incentiveRecords[0].reviewDate.plusDays(7)
 
       val nextReviewDate = NextReviewDateService(input).calculate()
 
@@ -109,15 +108,15 @@ class NextReviewDateServiceTest {
     @Test
     fun `when IEP level is Basic but previous review is at different level, returns +7 days`() {
       val input = NextReviewDateInput(
-        iepDetails = listOf(
-          review("2010-07-01", "MDI", iepCode = "BAS", iepLevel = "Basic", reviewType = ReviewType.MIGRATED),
-          review("2000-07-01", "MDI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.MIGRATED),
+        incentiveRecords = listOf(
+          incentiveRecord("2010-07-01", "MDI", iepCode = "BAS", reviewType = ReviewType.MIGRATED),
+          incentiveRecord("2000-07-01", "MDI", iepCode = "STD", reviewType = ReviewType.MIGRATED),
         ),
         hasAcctOpen = false,
         dateOfBirth = LocalDate.parse("1971-07-01"),
         receptionDate = LocalDate.now(),
       )
-      val expectedNextReviewDate = input.iepDetails[0].iepDate.plusDays(7)
+      val expectedNextReviewDate = input.incentiveRecords[0].reviewDate.plusDays(7)
 
       val nextReviewDate = NextReviewDateService(input).calculate()
 
@@ -127,15 +126,15 @@ class NextReviewDateServiceTest {
     @Test
     fun `when IEP level is Basic and previous IEP level was also Basic, returns +28 days`() {
       val input = NextReviewDateInput(
-        iepDetails = listOf(
-          review("2010-07-01", "MDI", iepCode = "BAS", iepLevel = "Basic", reviewType = ReviewType.MIGRATED),
-          review("2000-07-01", "MDI", iepCode = "BAS", iepLevel = "Basic", reviewType = ReviewType.MIGRATED),
+        incentiveRecords = listOf(
+          incentiveRecord("2010-07-01", "MDI", iepCode = "BAS", reviewType = ReviewType.MIGRATED),
+          incentiveRecord("2000-07-01", "MDI", iepCode = "BAS", reviewType = ReviewType.MIGRATED),
         ),
         hasAcctOpen = false,
         dateOfBirth = LocalDate.parse("1971-07-01"),
         receptionDate = LocalDate.parse("2000-07-01"),
       )
-      val expectedNextReviewDate = input.iepDetails[0].iepDate.plusDays(28)
+      val expectedNextReviewDate = input.incentiveRecords[0].reviewDate.plusDays(28)
 
       val nextReviewDate = NextReviewDateService(input).calculate()
 
@@ -149,14 +148,14 @@ class NextReviewDateServiceTest {
     @Test
     fun `when prisoner has open ACCT but they're not on Basic, returns +1 year`() {
       val input = NextReviewDateInput(
-        iepDetails = listOf(
-          review("2000-07-01", "MDI", iepLevel = "Standard", reviewType = ReviewType.MIGRATED),
+        incentiveRecords = listOf(
+          incentiveRecord("2000-07-01", "MDI", reviewType = ReviewType.MIGRATED),
         ),
         hasAcctOpen = true,
         dateOfBirth = LocalDate.parse("1971-07-01"),
         receptionDate = LocalDate.parse("2000-07-01"),
       )
-      val expectedNextReviewDate = input.iepDetails[0].iepDate.plusYears(1)
+      val expectedNextReviewDate = input.incentiveRecords[0].reviewDate.plusYears(1)
 
       val nextReviewDate = NextReviewDateService(input).calculate()
 
@@ -166,15 +165,15 @@ class NextReviewDateServiceTest {
     @Test
     fun `when last two IEP levels were Basic but prisoner has open ACCT, returns +14 days`() {
       val input = NextReviewDateInput(
-        iepDetails = listOf(
-          review("2010-07-01", "MDI", iepCode = "BAS", iepLevel = "Basic", reviewType = ReviewType.MIGRATED),
-          review("2000-07-01", "MDI", iepCode = "BAS", iepLevel = "Basic", reviewType = ReviewType.MIGRATED),
+        incentiveRecords = listOf(
+          incentiveRecord("2010-07-01", "MDI", iepCode = "BAS", reviewType = ReviewType.MIGRATED),
+          incentiveRecord("2000-07-01", "MDI", iepCode = "BAS", reviewType = ReviewType.MIGRATED),
         ),
         hasAcctOpen = true,
         dateOfBirth = LocalDate.parse("1971-07-01"),
         receptionDate = LocalDate.parse("2000-07-01"),
       )
-      val expectedNextReviewDate = input.iepDetails[0].iepDate.plusDays(14)
+      val expectedNextReviewDate = input.incentiveRecords[0].reviewDate.plusDays(14)
 
       val nextReviewDate = NextReviewDateService(input).calculate()
 
@@ -184,16 +183,16 @@ class NextReviewDateServiceTest {
     @Test
     fun `when last two IEP levels were Basic but is 'young person', returns +14 days`() {
       val input = NextReviewDateInput(
-        iepDetails = listOf(
+        incentiveRecords = listOf(
           // 16yo on last review date
-          review("2016-07-01", "MDI", iepCode = "BAS", iepLevel = "Basic", reviewType = ReviewType.MIGRATED),
-          review("2016-05-01", "MDI", iepCode = "BAS", iepLevel = "Basic", reviewType = ReviewType.MIGRATED),
+          incentiveRecord("2016-07-01", "MDI", iepCode = "BAS", reviewType = ReviewType.MIGRATED),
+          incentiveRecord("2016-05-01", "MDI", iepCode = "BAS", reviewType = ReviewType.MIGRATED),
         ),
         hasAcctOpen = false,
         dateOfBirth = LocalDate.parse("2000-07-01"),
         receptionDate = LocalDate.parse("2016-05-01"),
       )
-      val expectedNextReviewDate = input.iepDetails[0].iepDate.plusDays(14)
+      val expectedNextReviewDate = input.incentiveRecords[0].reviewDate.plusDays(14)
 
       val nextReviewDate = NextReviewDateService(input).calculate()
 
@@ -203,16 +202,16 @@ class NextReviewDateServiceTest {
     @Test
     fun `when IEP level is Basic, previous review is at different level but has open ACCT, returns +7 days`() {
       val input = NextReviewDateInput(
-        iepDetails = listOf(
-          review("2023-01-07", "MDI", iepCode = "BAS", iepLevel = "Basic", reviewType = ReviewType.REVIEW),
-          review("2022-12-01", "MDI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.REVIEW),
-          review("2000-07-01", "MDI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.MIGRATED),
+        incentiveRecords = listOf(
+          incentiveRecord("2023-01-07", "MDI", iepCode = "BAS", reviewType = ReviewType.REVIEW),
+          incentiveRecord("2022-12-01", "MDI", iepCode = "STD", reviewType = ReviewType.REVIEW),
+          incentiveRecord("2000-07-01", "MDI", iepCode = "STD", reviewType = ReviewType.MIGRATED),
         ),
         hasAcctOpen = true,
         dateOfBirth = LocalDate.parse("1971-07-01"),
         receptionDate = LocalDate.parse("2000-07-01"),
       )
-      val expectedNextReviewDate = input.iepDetails[0].iepDate.plusDays(7)
+      val expectedNextReviewDate = input.incentiveRecords[0].reviewDate.plusDays(7)
 
       val nextReviewDate = NextReviewDateService(input).calculate()
 
@@ -222,15 +221,15 @@ class NextReviewDateServiceTest {
     @Test
     fun `when IEP level is Basic, previous review is at different level but has open ACCT, returns +7 days (data from NOMIS)`() {
       val input = NextReviewDateInput(
-        iepDetails = listOf(
-          review("2023-01-07", "MDI", iepCode = "BAS", iepLevel = "Basic", reviewType = ReviewType.MIGRATED),
-          review("2000-07-01", "MDI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.MIGRATED),
+        incentiveRecords = listOf(
+          incentiveRecord("2023-01-07", "MDI", iepCode = "BAS", reviewType = ReviewType.MIGRATED),
+          incentiveRecord("2000-07-01", "MDI", iepCode = "STD", reviewType = ReviewType.MIGRATED),
         ),
         hasAcctOpen = true,
         dateOfBirth = LocalDate.parse("1971-07-01"),
         receptionDate = LocalDate.parse("2000-07-01"),
       )
-      val expectedNextReviewDate = input.iepDetails[0].iepDate.plusDays(7)
+      val expectedNextReviewDate = input.incentiveRecords[0].reviewDate.plusDays(7)
 
       val nextReviewDate = NextReviewDateService(input).calculate()
 
@@ -245,7 +244,7 @@ class NextReviewDateServiceTest {
     fun `when prisoner is new (age 18+), returns +3 months`() {
       val receptionDate = LocalDate.now().minusMonths(6)
       val input = NextReviewDateInput(
-        iepDetails = emptyList(),
+        incentiveRecords = emptyList(),
         hasAcctOpen = true,
         // At reception, was 18th birthday, not a "young person" anymore
         dateOfBirth = receptionDate.minusYears(18),
@@ -261,9 +260,9 @@ class NextReviewDateServiceTest {
     @Test
     fun `has no real reviews yet (age 18+), returns +3 months`() {
       val input = NextReviewDateInput(
-        iepDetails = listOf(
-          review("2018-08-15", "ACI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.TRANSFER),
-          review("2018-07-01", "MDI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.INITIAL),
+        incentiveRecords = listOf(
+          incentiveRecord("2018-08-15", "ACI", iepCode = "STD", reviewType = ReviewType.TRANSFER),
+          incentiveRecord("2018-07-01", "MDI", iepCode = "STD", reviewType = ReviewType.INITIAL),
         ),
         hasAcctOpen = true,
         dateOfBirth = LocalDate.parse("2000-07-01"),
@@ -280,7 +279,7 @@ class NextReviewDateServiceTest {
     @Test
     fun `when prisoner is new and 'young person' (under age of 18), returns +1 months`() {
       val input = NextReviewDateInput(
-        iepDetails = emptyList(),
+        incentiveRecords = emptyList(),
         hasAcctOpen = true,
         dateOfBirth = LocalDate.parse("2000-07-01"),
         // At reception, was almost 18yo, so still a "young person"
@@ -296,9 +295,9 @@ class NextReviewDateServiceTest {
     @Test
     fun `has no real reviews yet and is 'young person' (under age of 18), returns +1 months`() {
       val input = NextReviewDateInput(
-        iepDetails = listOf(
-          review("2018-08-15", "ACI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.TRANSFER),
-          review("2018-06-30", "MDI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.INITIAL),
+        incentiveRecords = listOf(
+          incentiveRecord("2018-08-15", "ACI", iepCode = "STD", reviewType = ReviewType.TRANSFER),
+          incentiveRecord("2018-06-30", "MDI", iepCode = "STD", reviewType = ReviewType.INITIAL),
         ),
         hasAcctOpen = true,
         dateOfBirth = LocalDate.parse("2000-07-01"),
@@ -319,17 +318,17 @@ class NextReviewDateServiceTest {
     @Test
     fun `when prisoner is readmitted (age 18+), returns +3 months`() {
       val input = NextReviewDateInput(
-        iepDetails = listOf(
+        incentiveRecords = listOf(
           // When readmitted, was 18th birthday, not a "young person" anymore
-          review("2018-07-01", "ACI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.READMISSION),
-          review("2016-08-01", "MDI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.REVIEW),
-          review("2016-07-01", "MDI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.INITIAL),
+          incentiveRecord("2018-07-01", "ACI", iepCode = "STD", reviewType = ReviewType.READMISSION),
+          incentiveRecord("2016-08-01", "MDI", iepCode = "STD", reviewType = ReviewType.REVIEW),
+          incentiveRecord("2016-07-01", "MDI", iepCode = "STD", reviewType = ReviewType.INITIAL),
         ),
         hasAcctOpen = true,
         dateOfBirth = LocalDate.parse("2000-07-01"),
         receptionDate = LocalDate.parse("2016-07-01"),
       )
-      val readmissionDate = input.iepDetails.first().iepDate
+      val readmissionDate = input.incentiveRecords.first().reviewDate
       val expectedNextReviewDate = readmissionDate.plusMonths(3)
 
       val nextReviewDate = NextReviewDateService(input).calculate()
@@ -340,17 +339,17 @@ class NextReviewDateServiceTest {
     @Test
     fun `when prisoner is readmitted and 'young person' (under age of 18), returns +1 months`() {
       val input = NextReviewDateInput(
-        iepDetails = listOf(
+        incentiveRecords = listOf(
           // When readmitted, was almost 18yo, so still a "young person"
-          review("2018-06-30", "ACI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.READMISSION),
-          review("2016-08-01", "MDI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.REVIEW),
-          review("2016-07-01", "MDI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.INITIAL),
+          incentiveRecord("2018-06-30", "ACI", iepCode = "STD", reviewType = ReviewType.READMISSION),
+          incentiveRecord("2016-08-01", "MDI", iepCode = "STD", reviewType = ReviewType.REVIEW),
+          incentiveRecord("2016-07-01", "MDI", iepCode = "STD", reviewType = ReviewType.INITIAL),
         ),
         hasAcctOpen = true,
         dateOfBirth = LocalDate.parse("2000-07-01"),
         receptionDate = LocalDate.parse("2016-07-01"),
       )
-      val readmissionDate = input.iepDetails.first().iepDate
+      val readmissionDate = input.incentiveRecords.first().reviewDate
       val expectedNextReviewDate = readmissionDate.plusMonths(1)
 
       val nextReviewDate = NextReviewDateService(input).calculate()
@@ -361,12 +360,12 @@ class NextReviewDateServiceTest {
     @Test
     fun `when prisoner is readmitted (age 18+) then transferred, it still returns +3 months`() {
       val input = NextReviewDateInput(
-        iepDetails = listOf(
-          review("2018-07-02", "MDI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.TRANSFER),
+        incentiveRecords = listOf(
+          incentiveRecord("2018-07-02", "MDI", iepCode = "STD", reviewType = ReviewType.TRANSFER),
           // When readmitted, was 18th birthday, not a "young person" anymore
-          review("2018-07-01", "ACI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.READMISSION),
-          review("2016-08-01", "MDI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.REVIEW),
-          review("2016-07-01", "MDI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.INITIAL),
+          incentiveRecord("2018-07-01", "ACI", iepCode = "STD", reviewType = ReviewType.READMISSION),
+          incentiveRecord("2016-08-01", "MDI", iepCode = "STD", reviewType = ReviewType.REVIEW),
+          incentiveRecord("2016-07-01", "MDI", iepCode = "STD", reviewType = ReviewType.INITIAL),
         ),
         hasAcctOpen = true,
         dateOfBirth = LocalDate.parse("2000-07-01"),
@@ -383,12 +382,12 @@ class NextReviewDateServiceTest {
     @Test
     fun `when prisoner is readmitted and 'young person' (under age of 18), then transferred it still returns +1 months`() {
       val input = NextReviewDateInput(
-        iepDetails = listOf(
-          review("2018-07-02", "MDI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.TRANSFER),
+        incentiveRecords = listOf(
+          incentiveRecord("2018-07-02", "MDI", iepCode = "STD", reviewType = ReviewType.TRANSFER),
           // When readmitted, was almost 18yo, so still a "young person"
-          review("2018-06-30", "ACI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.READMISSION),
-          review("2016-08-01", "MDI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.REVIEW),
-          review("2016-07-01", "MDI", iepCode = "STD", iepLevel = "Standard", reviewType = ReviewType.INITIAL),
+          incentiveRecord("2018-06-30", "ACI", iepCode = "STD", reviewType = ReviewType.READMISSION),
+          incentiveRecord("2016-08-01", "MDI", iepCode = "STD", reviewType = ReviewType.REVIEW),
+          incentiveRecord("2016-07-01", "MDI", iepCode = "STD", reviewType = ReviewType.INITIAL),
         ),
         hasAcctOpen = true,
         dateOfBirth = LocalDate.parse("2000-07-01"),
@@ -404,25 +403,20 @@ class NextReviewDateServiceTest {
   }
 }
 
-private fun review(
+private fun incentiveRecord(
   iepDateString: String,
   prisonId: String,
   iepCode: String = "STD",
-  iepLevel: String = "Standard",
   reviewType: ReviewType = ReviewType.REVIEW,
-): IepDetail {
+): PrisonerIepLevel {
   val iepDate = LocalDate.parse(iepDateString)
-  return IepDetail(
+  return PrisonerIepLevel(
     id = 111,
     prisonerNumber = "A1234BC",
-    iepLevel = iepLevel,
     iepCode = iepCode,
-    iepTime = iepDate.atTime(10, 0),
-    iepDate = iepDate,
+    reviewTime = iepDate.atTime(10, 0),
     reviewType = reviewType,
-    agencyId = prisonId,
+    prisonId = prisonId,
     bookingId = 1234567L,
-    userId = null,
-    auditModuleName = SYSTEM_USERNAME,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterServiceTest.kt
@@ -80,7 +80,7 @@ class NextReviewDateUpdaterServiceTest {
           dateOfBirth = offender1.dateOfBirth,
           receptionDate = offender1.receptionDate,
           hasAcctOpen = offender1.hasAcctOpen,
-          iepDetails = emptyList(),
+          incentiveRecords = emptyList(),
         ),
       ).calculate()
       val expectedDate2 = NextReviewDateService(
@@ -88,7 +88,7 @@ class NextReviewDateUpdaterServiceTest {
           dateOfBirth = offender2.dateOfBirth,
           receptionDate = offender2.receptionDate,
           hasAcctOpen = offender2.hasAcctOpen,
-          iepDetails = emptyList(),
+          incentiveRecords = emptyList(),
         ),
       ).calculate()
 
@@ -150,7 +150,7 @@ class NextReviewDateUpdaterServiceTest {
           dateOfBirth = offender1.dateOfBirth,
           receptionDate = offender1.receptionDate,
           hasAcctOpen = offender1.hasAcctOpen,
-          iepDetails = emptyList(),
+          incentiveRecords = emptyList(),
         ),
       ).calculate()
       val expectedDate2 = NextReviewDateService(
@@ -158,7 +158,7 @@ class NextReviewDateUpdaterServiceTest {
           dateOfBirth = offender2.dateOfBirth,
           receptionDate = offender2.receptionDate,
           hasAcctOpen = offender2.hasAcctOpen,
-          iepDetails = offender2Reviews.toList().toIepDetails(iepLevels),
+          incentiveRecords = offender2Reviews.toList(),
         ),
       ).calculate()
 
@@ -231,7 +231,7 @@ class NextReviewDateUpdaterServiceTest {
         dateOfBirth = prisonerExtraInfo.dateOfBirth,
         receptionDate = prisonerExtraInfo.receptionDate,
         hasAcctOpen = prisonerExtraInfo.hasAcctOpen,
-        iepDetails = reviews.toList().toIepDetails(iepLevels),
+        incentiveRecords = reviews.toList(),
       ),
     ).calculate()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterServiceTest.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.flow.last
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -14,7 +13,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import uk.gov.justice.digital.hmpps.incentivesapi.dto.IncentiveLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.NextReviewDate
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.NextReviewDateRepository
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonerIepLevelRepository
@@ -40,31 +38,12 @@ class NextReviewDateUpdaterServiceTest {
     snsService,
   )
 
-  private val iepLevels = mapOf(
-    "BAS" to IncentiveLevel(code = "BAS", description = "Basic"),
-    "STD" to IncentiveLevel(code = "STD", description = "Standard"),
-    "ENH" to IncentiveLevel(code = "ENH", description = "Enhanced"),
-    "EN2" to IncentiveLevel(code = "EN2", description = "Enhanced 2"),
-  )
-
-  @BeforeEach
-  fun setUp(): Unit = runBlocking {
-    whenever(incentiveLevelService.getAllIncentiveLevelsMapByCode())
-      .thenReturn(iepLevels)
-  }
-
   @Nested
   inner class UpdateAllTest {
     private val offender1 = offenderSearchPrisoner("AB123C", 123L)
     private val offender2 = offenderSearchPrisoner("XY456Z", 456L)
 
     private val offenders = listOf(offender1, offender2)
-
-    @BeforeEach
-    fun setUp(): Unit = runBlocking {
-      whenever(incentiveLevelService.getAllIncentiveLevelsMapByCode())
-        .thenReturn(iepLevels)
-    }
 
     @Test
     fun `updateMany() when no reviews in database`(): Unit = runBlocking {


### PR DESCRIPTION
The `IepDetail` class is still used, and in fact even part of the public interface
of some of the endpoints. However is kinda a legacy data class.

The `NextReviewDateService` now uses `PrisonerIepLevel` values which is
what's stored in the database. This is the new representation of an incentive
record.