### PR TITLE
INC-1193: Add `description` field to Incentive levels

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IncentiveLevel.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IncentiveLevel.kt
@@ -13,6 +13,9 @@ data class IncentiveLevel(
   @Schema(description = "Name of the incentive level", example = "Standard", minLength = 1)
   @JsonProperty(required = true)
   val name: String,
+  @Schema(description = "Description of the incentive level", example = "Standard Incentive level", minLength = 0, required = false, defaultValue = "")
+  @JsonProperty(required = false, defaultValue = "")
+  val description: String = "",
   // TODO: suggest not exposing `sequence`: lists are returned in proper order
   // @Schema(description = "Order in which to display the incentive levels", example = "1")
   // @JsonProperty(required = true)
@@ -37,6 +40,7 @@ data class IncentiveLevel(
 
   fun toUpdate() = IncentiveLevelUpdate(
     name = name,
+    description = description,
     active = active,
     required = required,
   )
@@ -48,6 +52,8 @@ data class IncentiveLevel(
 data class IncentiveLevelUpdate(
   @Schema(description = "Name of the incentive level", example = "Standard", minLength = 1, required = false)
   val name: String? = null,
+  @Schema(description = "Description of the incentive level", example = "Standard Incentive level", minLength = 0, required = false)
+  val description: String? = null,
   @Schema(description = "Indicates that the incentive level is active; inactive levels are historic levels no longer in use", example = "true", required = false)
   val active: Boolean? = null,
   @Schema(description = "Indicates that all prisons must have this level active", example = "true", required = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/IncentiveLevel.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/IncentiveLevel.kt
@@ -14,6 +14,7 @@ data class IncentiveLevel(
   @Id
   val code: String,
   val name: String,
+  val description: String = "",
   val sequence: Int,
   val active: Boolean = true,
   val required: Boolean = false,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveLevelService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveLevelService.kt
@@ -144,6 +144,7 @@ class IncentiveLevelService(
   private fun IncentiveLevel.withUpdate(update: IncentiveLevelUpdateDTO): IncentiveLevel = copy(
     code = code,
     name = update.name ?: name,
+    description = update.description ?: description,
     active = update.active ?: active,
     required = update.required ?: required,
 
@@ -154,6 +155,7 @@ class IncentiveLevelService(
   private fun IncentiveLevel.toDTO(): IncentiveLevelDTO = IncentiveLevelDTO(
     code = code,
     name = name,
+    description = description,
     active = active,
     required = required,
   )
@@ -161,6 +163,7 @@ class IncentiveLevelService(
   private fun IncentiveLevelDTO.toNewEntity(sequence: Int): IncentiveLevel = IncentiveLevel(
     code = code,
     name = name,
+    description = description,
     sequence = sequence,
     active = active,
     required = required,

--- a/src/main/resources/db/migration/V1_31__incentive_level_add_description_column.sql
+++ b/src/main/resources/db/migration/V1_31__incentive_level_add_description_column.sql
@@ -1,0 +1,3 @@
+-- Add `description` column to Incentive levels
+ALTER TABLE incentive_level
+ADD COLUMN description TEXT NOT NULL DEFAULT '';

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResourceTest.kt
@@ -59,11 +59,11 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           // language=json
           """
           [
-            {"code": "BAS", "name": "Basic", "active": true, "required": true},
-            {"code": "STD", "name": "Standard", "active": true, "required": true},
-            {"code": "ENH", "name": "Enhanced", "active": true, "required": true},
-            {"code": "EN2", "name": "Enhanced 2", "active": true, "required": false},
-            {"code": "EN3", "name": "Enhanced 3", "active": true, "required": false}
+            {"code": "BAS", "name": "Basic", "description": "", "active": true, "required": true},
+            {"code": "STD", "name": "Standard", "description": "", "active": true, "required": true},
+            {"code": "ENH", "name": "Enhanced", "description": "", "active": true, "required": true},
+            {"code": "EN2", "name": "Enhanced 2", "description": "", "active": true, "required": false},
+            {"code": "EN3", "name": "Enhanced 3", "description": "", "active": true, "required": false}
           ]
           """,
           true,
@@ -81,12 +81,12 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           // language=json
           """
           [
-            {"code": "BAS", "name": "Basic", "active": true, "required": true},
-            {"code": "STD", "name": "Standard", "active": true, "required": true},
-            {"code": "ENH", "name": "Enhanced", "active": true, "required": true},
-            {"code": "EN2", "name": "Enhanced 2", "active": true, "required": false},
-            {"code": "EN3", "name": "Enhanced 3", "active": true, "required": false},
-            {"code": "ENT", "name": "Entry", "active": false, "required": false}
+            {"code": "BAS", "name": "Basic", "description": "", "active": true, "required": true},
+            {"code": "STD", "name": "Standard", "description": "", "active": true, "required": true},
+            {"code": "ENH", "name": "Enhanced", "description": "", "active": true, "required": true},
+            {"code": "EN2", "name": "Enhanced 2", "description": "", "active": true, "required": false},
+            {"code": "EN3", "name": "Enhanced 3", "description": "", "active": true, "required": false},
+            {"code": "ENT", "name": "Entry", "description": "", "active": false, "required": false}
           ]
           """,
           true,
@@ -103,7 +103,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectBody().json(
           // language=json
           """
-          {"code": "EN2", "name": "Enhanced 2", "active": true, "required": false}
+          {"code": "EN2", "name": "Enhanced 2", "description": "", "active": true, "required": false}
           """,
           true,
         )
@@ -119,7 +119,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectBody().json(
           // language=json
           """
-          {"code": "ENT", "name": "Entry", "active": false, "required": false}
+          {"code": "ENT", "name": "Entry", "description": "", "active": false, "required": false}
           """,
           true,
         )
@@ -160,7 +160,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .bodyValue(
           // language=json
           """
-          {"code": "EN4", "name": "Enhanced 4", "active": false}
+          {"code": "EN4", "name": "Enhanced 4", "description": "Enhanced 4 Incentive level", "active": false}
           """,
         )
         .exchange()
@@ -168,7 +168,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectBody().json(
           // language=json
           """
-          {"code": "EN4", "name": "Enhanced 4", "active": false, "required": false}
+          {"code": "EN4", "name": "Enhanced 4", "description": "Enhanced 4 Incentive level", "active": false, "required": false}
           """,
           true,
         )
@@ -179,6 +179,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         val incentiveLevel = incentiveLevelRepository.findById("EN4")
         assertThat(incentiveLevel?.code).isEqualTo("EN4")
         assertThat(incentiveLevel?.name).isEqualTo("Enhanced 4")
+        assertThat(incentiveLevel?.description).isEqualTo("Enhanced 4 Incentive level")
         assertThat(incentiveLevel?.active).isFalse
         assertThat(incentiveLevel?.sequence).isGreaterThan(maxSequence)
         assertThat(incentiveLevel?.whenUpdated).isEqualTo(now)
@@ -422,12 +423,12 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           // language=json
           """
           [
-            {"code": "EN3", "name": "Enhanced 3", "active": true, "required": false},
-            {"code": "EN2", "name": "Enhanced 2", "active": true, "required": false},
-            {"code": "ENT", "name": "Entry", "active": false, "required": false},
-            {"code": "ENH", "name": "Enhanced", "active": true, "required": true},
-            {"code": "STD", "name": "Standard", "active": true, "required": true},
-            {"code": "BAS", "name": "Basic", "active": true, "required": true}
+            {"code": "EN3", "name": "Enhanced 3", "description": "", "active": true, "required": false},
+            {"code": "EN2", "name": "Enhanced 2", "description": "", "active": true, "required": false},
+            {"code": "ENT", "name": "Entry", "description": "", "active": false, "required": false},
+            {"code": "ENH", "name": "Enhanced", "description": "", "active": true, "required": true},
+            {"code": "STD", "name": "Standard", "description": "", "active": true, "required": true},
+            {"code": "BAS", "name": "Basic", "description": "", "active": true, "required": true}
           ]
           """,
           true,
@@ -570,7 +571,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectBody().json(
           // language=json
           """
-          {"code": "STD", "name": "Silver", "active": true, "required": true}
+          {"code": "STD", "name": "Silver", "description": "", "active": true, "required": true}
           """,
           true,
         )
@@ -804,7 +805,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .bodyValue(
           // language=json
           """
-          {"name": "Silver"}
+          {"description": "Standard Incentive level"}
           """,
         )
         .exchange()
@@ -812,14 +813,15 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectBody().json(
           // language=json
           """
-          {"code": "STD", "name": "Silver", "active": true, "required": true}
+          {"code": "STD", "name": "Standard", "description": "Standard Incentive level", "active": true, "required": true}
           """,
           true,
         )
 
       runBlocking {
         val incentiveLevel = incentiveLevelRepository.findById("STD")
-        assertThat(incentiveLevel?.name).isEqualTo("Silver")
+        assertThat(incentiveLevel?.name).isEqualTo("Standard")
+        assertThat(incentiveLevel?.description).isEqualTo("Standard Incentive level")
         assertThat(incentiveLevel?.whenUpdated).isEqualTo(now)
       }
 
@@ -828,7 +830,8 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertThat(it.additionalInformation?.incentiveLevel).isEqualTo("STD")
       }
       assertAuditMessageSentWithMap("INCENTIVE_LEVEL_UPDATED").let {
-        assertThat(it["name"]).isEqualTo("Silver")
+        assertThat(it["name"]).isEqualTo("Standard")
+        assertThat(it["description"]).isEqualTo("Standard Incentive level")
       }
     }
 
@@ -956,7 +959,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectBody().json(
           // language=json
           """
-          {"code": "ENH", "name": "Gold", "active": false, "required": false}
+          {"code": "ENH", "name": "Gold", "description": "", "active": false, "required": false}
           """,
           true,
         )
@@ -1051,7 +1054,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectBody().json(
           // language=json
           """
-          {"code": "EN2", "name": "Enhanced 2", "active": false, "required": false}
+          {"code": "EN2", "name": "Enhanced 2", "description": "", "active": false, "required": false}
           """,
           true,
         )
@@ -1084,7 +1087,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectBody().json(
           // language=json
           """
-          {"code": "ENT", "name": "Entry", "active": false, "required": false}
+          {"code": "ENT", "name": "Entry", "description": "", "active": false, "required": false}
           """,
           true,
         )


### PR DESCRIPTION
This field can contain a human description of an Incentive level but it can be an empty string (it's not nullable in the DB tho)