### PR TITLE
Tidying up

### DIFF
--- a/doc/architecture/decisions/0002-incentive-api-architecture.md
+++ b/doc/architecture/decisions/0002-incentive-api-architecture.md
@@ -15,7 +15,7 @@ Accepted
 New service to aggregate and capture incentive related data in a single micro service. 
 
 Initially this service will:-
-- Asynchronously call off to the Prison API to obtain information relating to positive and negative case notes, adjuication history, IEP review history and basic prisoner data (name, number, location, image)
+- Asynchronously call off to the Prison API to obtain information relating to positive and negative case notes, adjudication history, IEP review history and basic prisoner data (name, number, location, image)
 - Aggregate this information into a restful response that can be consumed by the [Incentive UI](https://github.com/ministryofjustice/hmpps-incentives-ui)
 
 ### Future Work

--- a/doc/architecture/decisions/0004-reference-data-sync.md
+++ b/doc/architecture/decisions/0004-reference-data-sync.md
@@ -65,7 +65,7 @@ The `IEP_OTH_PRIV` domain allows extra privileges to be added ![](other_privs_re
 | SP2  | Sony Playstation  | Y      |
 
 
-The **OIMOIEPS** NOMIS screen allows config of levels, visits and other privilages.
+The **OIMOIEPS** NOMIS screen allows config of levels, visits and other privileges.
 
 - IEP_LEVELS
 ```oracle
@@ -124,7 +124,7 @@ CREATE TABLE "OTHER_PRIVILEGES_LEVELS"
 
 This screen represents the Other Privileges ![](other_privs.png)
 
-In production there are only 12 records across all prisons for 1 privilege (Play Station PS2) for privilages and most records were added over 8 years ago.
+In production there are only 12 records across all prisons for 1 privilege (Play Station PS2) for privileges and most records were added over 8 years ago.
 
 | Code | Prison Id | Min Incentive Level | Active |
 |------|-----------|---------------------|--------|
@@ -462,7 +462,7 @@ Authorised requests will require roles with write scope.
 
 ## Decision
 - Other privileges data will NOT be moved off NOMIS as it is not used
-- SYSCON will not migrate data - a one off SQL script will set-up the data in the incentive DB
+- SYSCON will not migrate data - a one-off SQL script will set-up the data in the incentive DB
 - One way sync only will be performed
 - NOMIS screens can be turned off / made read only - but timescale is not urgent as this data changes very infrequently
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IepSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IepSummary.kt
@@ -36,6 +36,8 @@ data class IepSummary(
   val nextReviewDate: LocalDate,
 ) {
 
+  // NOTE: This is part of the public `GET /iep/reviews/` API response format.
+  //       Ignore IntelliJ saying it's "not used".
   @get:Schema(description = "Days since last review", example = "23", required = true)
   @get:JsonProperty
   val daysSinceReview: Int

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterService.kt
@@ -21,7 +21,6 @@ class NextReviewDateUpdaterService(
   private val prisonerIepLevelRepository: PrisonerIepLevelRepository,
   private val nextReviewDateRepository: NextReviewDateRepository,
   private val prisonApiService: PrisonApiService,
-  private val incentiveLevelService: IncentiveLevelService,
   private val snsService: SnsService,
 ) {
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -54,7 +54,6 @@ class PrisonerIepLevelReviewService(
   suspend fun getPrisonerIepLevelHistory(
     bookingId: Long,
     withDetails: Boolean = true,
-    useClientCredentials: Boolean = false,
   ): IepSummary {
     val reviews = prisonerIepLevelRepository.findAllByBookingIdOrderByReviewTimeDesc(bookingId)
     if (reviews.count() == 0) throw IncentiveReviewNotFoundException("No Incentive Reviews for booking ID $bookingId")
@@ -274,7 +273,6 @@ class PrisonerIepLevelReviewService(
             getPrisonerIepLevelHistory(
               prisonerInfo.bookingId,
               withDetails = true,
-              useClientCredentials = true,
             ).iepDetails
           val levelCodeBeforeTransfer =
             iepHistory.sortedBy(IepDetail::iepTime).lastOrNull { it.agencyId != prisonerInfo.agencyId }?.iepCode

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterServiceTest.kt
@@ -26,7 +26,6 @@ class NextReviewDateUpdaterServiceTest {
   private val prisonerIepLevelRepository: PrisonerIepLevelRepository = mock()
   private val nextReviewDateRepository: NextReviewDateRepository = mock()
   private val prisonApiService: PrisonApiService = mock()
-  private val incentiveLevelService: IncentiveLevelService = mock()
   private val snsService: SnsService = mock()
 
   private val nextReviewDateUpdaterService = NextReviewDateUpdaterService(
@@ -34,7 +33,6 @@ class NextReviewDateUpdaterServiceTest {
     prisonerIepLevelRepository,
     nextReviewDateRepository,
     prisonApiService,
-    incentiveLevelService,
     snsService,
   )
 


### PR DESCRIPTION
While working on removing the migration/sync endpoint I've came across a few small things that can be sorted/merged before that PR:
- unused params
  - `NextReviewDateUpdaterService` no longer uses the `IncentiveLevelService`
  - `useClientCredentials` is no longer used in `getPrisonerIepLevelHistory()` (because Incentive records now come from our database, not a Prison API call)
- typos, spelling mistakes etc
- added a comment about `daysSinceReview` to warn IntelliJ is wrong and it's actually used.
