### PR TITLE
`/iep/` resources tidy up

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelsResource.kt
@@ -1,0 +1,60 @@
+package uk.gov.justice.digital.hmpps.incentivesapi.resource
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.incentivesapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.IepLevel
+import uk.gov.justice.digital.hmpps.incentivesapi.service.IepLevelService
+import uk.gov.justice.digital.hmpps.incentivesapi.util.ensure
+
+@RestController
+@RequestMapping("/iep", produces = [MediaType.APPLICATION_JSON_VALUE])
+@Tag(name = "Prison incentive levels", description = "Retrieve incentive levels for a prison")
+class IepLevelsResource(
+  private val iepLevelService: IepLevelService,
+) {
+  @GetMapping("/levels/{prisonId}")
+  @Operation(
+    summary = "Returns the valid IEP levels for specified prison",
+    description = "prison ID should be a 3 character string e.g. MDI = Moorland",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "IEP Level Information returned",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Incorrect data specified to return IEP Level data",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Incorrect permissions to use this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  suspend fun getPrisonIepLevels(
+    @Schema(description = "Prison Id", example = "MDI", required = true, minLength = 3, maxLength = 5)
+    @PathVariable
+    prisonId: String,
+  ): List<IepLevel> {
+    ensure {
+      ("prisonId" to prisonId).hasLengthAtLeast(3).hasLengthAtMost(5)
+    }
+    return iepLevelService.getIepLevelsForPrison(prisonId)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepReviewsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepReviewsResource.kt
@@ -22,55 +22,15 @@ import uk.gov.justice.digital.hmpps.incentivesapi.dto.CurrentIepLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepDetail
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepReview
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepSummary
-import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.IepLevel
-import uk.gov.justice.digital.hmpps.incentivesapi.service.IepLevelService
 import uk.gov.justice.digital.hmpps.incentivesapi.service.PrisonerIepLevelReviewService
 import uk.gov.justice.digital.hmpps.incentivesapi.util.ensure
 
 @RestController
 @RequestMapping("/iep", produces = [MediaType.APPLICATION_JSON_VALUE])
 @Tag(name = "Incentive reviews", description = "Retrieve and add incentive review records. Ported from prison-api")
-class IepLevelResource(
-  private val iepLevelService: IepLevelService,
+class IepReviewsResource(
   private val prisonerIepLevelReviewService: PrisonerIepLevelReviewService,
 ) {
-  @GetMapping("/levels/{prisonId}")
-  @Operation(
-    summary = "Returns the valid IEP levels for specified prison",
-    description = "prison ID should be a 3 character string e.g. MDI = Moorland",
-    responses = [
-      ApiResponse(
-        responseCode = "200",
-        description = "IEP Level Information returned",
-      ),
-      ApiResponse(
-        responseCode = "400",
-        description = "Incorrect data specified to return IEP Level data",
-        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
-      ),
-      ApiResponse(
-        responseCode = "401",
-        description = "Unauthorized to access this endpoint",
-        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
-      ),
-      ApiResponse(
-        responseCode = "403",
-        description = "Incorrect permissions to use this endpoint",
-        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
-      ),
-    ],
-  )
-  suspend fun getPrisonIepLevels(
-    @Schema(description = "Prison Id", example = "MDI", required = true, minLength = 3, maxLength = 5)
-    @PathVariable
-    prisonId: String,
-  ): List<IepLevel> {
-    ensure {
-      ("prisonId" to prisonId).hasLengthAtLeast(3).hasLengthAtMost(5)
-    }
-    return iepLevelService.getIepLevelsForPrison(prisonId)
-  }
-
   @GetMapping("/reviews/booking/{bookingId}")
   @Operation(
     summary = "Returns a history of IEP reviews for a prisoner",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepLevelsResourceTest.kt
@@ -1,0 +1,70 @@
+package uk.gov.justice.digital.hmpps.incentivesapi.resource
+
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.incentivesapi.integration.IncentiveLevelResourceTestBase
+
+class IepLevelsResourceTest : IncentiveLevelResourceTestBase() {
+
+  @BeforeEach
+  fun setUp(): Unit = runBlocking {
+    prisonApiMockServer.resetAll()
+  }
+
+  @AfterEach
+  override fun tearDown(): Unit = runBlocking {
+    prisonApiMockServer.resetRequests()
+    super.tearDown()
+  }
+
+  @Test
+  fun `requires a valid token to retrieve data`() {
+    webTestClient.get()
+      .uri("/iep/levels/MDI")
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `get IEP Levels for a prison`() {
+    val prisonId = "MDI"
+    listOf("BAS", "STD", "ENH", "ENT").forEach { levelCode ->
+      listOf("MDI").forEach { prisonId ->
+        makePrisonIncentiveLevel(prisonId, levelCode)
+      }
+    }
+
+    webTestClient.get().uri("/iep/levels/$prisonId")
+      .headers(setAuthorisation())
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .json(
+        """
+        [
+            {
+                "iepLevel": "BAS",
+                "iepDescription": "Basic",
+                "sequence": 1,
+                "default": false
+            },
+            {
+                "iepLevel": "STD",
+                "iepDescription": "Standard",
+                "sequence": 2,
+                "default": true
+            },
+            {
+                "iepLevel": "ENH",
+                "iepDescription": "Enhanced",
+                "sequence": 3,
+                "default": false
+            }
+        ]
+        """.trimIndent(),
+      )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepReviewsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepReviewsResourceTest.kt
@@ -30,15 +30,6 @@ class IepReviewsResourceTest : IncentiveLevelResourceTestBase() {
   }
 
   @Test
-  fun `requires a valid token to retrieve data`() {
-    webTestClient.get()
-      .uri("/iep/levels/MDI")
-      .exchange()
-      .expectStatus()
-      .isUnauthorized
-  }
-
-  @Test
   fun `Prison API '404 Not Found' responses are handled instead of responding 500 Internal Server Error`() {
     val bookingId: Long = 1234134
 
@@ -48,46 +39,6 @@ class IepReviewsResourceTest : IncentiveLevelResourceTestBase() {
       .headers(setAuthorisation())
       .exchange()
       .expectStatus().isNotFound
-  }
-
-  @Test
-  fun `get IEP Levels for a prison`() {
-    val prisonId = "MDI"
-    listOf("BAS", "STD", "ENH", "ENT").forEach { levelCode ->
-      listOf("MDI").forEach { prisonId ->
-        makePrisonIncentiveLevel(prisonId, levelCode)
-      }
-    }
-
-    webTestClient.get().uri("/iep/levels/$prisonId")
-      .headers(setAuthorisation())
-      .exchange()
-      .expectStatus().isOk
-      .expectBody()
-      .json(
-        """
-        [
-            {
-                "iepLevel": "BAS",
-                "iepDescription": "Basic",
-                "sequence": 1,
-                "default": false
-            },
-            {
-                "iepLevel": "STD",
-                "iepDescription": "Standard",
-                "sequence": 2,
-                "default": true
-            },
-            {
-                "iepLevel": "ENH",
-                "iepDescription": "Enhanced",
-                "sequence": 3,
-                "default": false
-            }
-        ]
-        """.trimIndent(),
-      )
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepReviewsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepReviewsResourceTest.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonerIepLeve
 import java.time.LocalDate.now
 import java.time.format.DateTimeFormatter
 
-class IepLevelResourceTest : IncentiveLevelResourceTestBase() {
+class IepReviewsResourceTest : IncentiveLevelResourceTestBase() {
   @Autowired
   private lateinit var repository: PrisonerIepLevelRepository
 


### PR DESCRIPTION
The old `IepLevelResource` class contained endpoints to manage Incentive records (`/iep/reviews/*`) but also an endpoint to get the list of Incentive levels for a given prison (`GET /iep/levels/{prisonId}`).

I've moved the latter in its own `IepLevelsResource` updating the Swagger name to reflect this and renamed the existing resource class to `IepReviewsResource`.

Relevant tests were also moved or removed to the correct test file.

**NOTE**: The API didn't change, the endpoints are working as before, this is an internal refactoring for clarity.
Also note that the `GET /iep/levels/{prisonId}` and corresponding resource will probably be deprecated and removed in favour of the new `/incentives/` endpoints once we migrated the reference data off NOMIS.