### PR TITLE
INC-1202: Restrict global incentive level deactivation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonIncentiveLevelRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonIncentiveLevelRepository.kt
@@ -97,4 +97,17 @@ interface PrisonIncentiveLevelRepository : CoroutineCrudRepository<PrisonIncenti
     """,
   )
   fun findPrisonIdsWithActiveLevels(): Flow<String>
+
+  /**
+   * All prisons that have this level active
+   */
+  @Query(
+    // language=postgresql
+    """
+    SELECT prison_id
+    FROM prison_incentive_level
+    WHERE active IS TRUE AND level_code = :levelCode
+    """,
+  )
+  fun findPrisonIdsWithActiveLevel(levelCode: String): Flow<String>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveLevelService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveLevelService.kt
@@ -100,6 +100,11 @@ class IncentiveLevelService(
         if (!incentiveLevel.active && incentiveLevel.required) {
           throw ValidationException("A level must be active if it is required")
         }
+        if (originalIncentiveLevel.active && !incentiveLevel.active) {
+          if (prisonIncentiveLevelService.getPrisonIdsWithActivePrisonIncentiveLevel(incentiveLevel.code).isNotEmpty()) {
+            throw ValidationException("A level must remain active if it is active in some prison")
+          }
+        }
 
         incentiveLevelRepository.save(incentiveLevel)
           .toDTO()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonIncentiveLevelService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonIncentiveLevelService.kt
@@ -54,6 +54,13 @@ class PrisonIncentiveLevelService(
   }
 
   /**
+   * Returns prison ids which have given level active
+   */
+  suspend fun getPrisonIdsWithActivePrisonIncentiveLevel(levelCode: String): List<String> {
+    return prisonIncentiveLevelRepository.findPrisonIdsWithActiveLevel(levelCode).toList()
+  }
+
+  /**
    * Updates an incentive level for given prison and level code; will fail if data integrity is not maintained.
    * Conceptually, every incentive level exists in every prison but is considered inactive if it does not exist in the database.
    * NB: Default values may be used for associated information if not fully specified and not already in database.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/WebClientUtil.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/WebClientUtil.kt
@@ -5,5 +5,6 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import reactor.core.publisher.Mono
 
 fun <T> emptyWhenNotFound(exception: WebClientResponseException): Mono<T> = emptyWhen(exception, HttpStatus.NOT_FOUND)
+
 fun <T> emptyWhen(exception: WebClientResponseException, statusCode: HttpStatus): Mono<T> =
-  if (exception.rawStatusCode == statusCode.value()) Mono.empty() else Mono.error(exception)
+  if (exception.statusCode.value() == statusCode.value()) Mono.empty() else Mono.error(exception)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonIncentiveLevelRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonIncentiveLevelRepositoryTest.kt
@@ -254,4 +254,21 @@ class PrisonIncentiveLevelRepositoryTest : TestBase() {
     val prisonIds = repository.findPrisonIdsWithActiveLevels().toSet()
     assertThat(prisonIds).isEqualTo(setOf("BAI", "MDI", "WRI"))
   }
+
+  @Test
+  fun `find prisons that have specific level active`(): Unit = runBlocking {
+    generateDefaultData()
+    // Generate active prisons with inactive EN2 that will not be returned:
+    listOf("BAS", "STD", "ENH", "EN2").forEach { levelCode ->
+      listOf("EXI", "LEI").forEach { prisonId ->
+        repository.save(makeNewEntity(levelCode, prisonId).copy(active = levelCode != "EN2"))
+      }
+    }
+
+    var prisonIds = repository.findPrisonIdsWithActiveLevels().toSet()
+    assertThat(prisonIds).isEqualTo(setOf("BAI", "MDI", "WRI", "EXI", "LEI"))
+
+    prisonIds = repository.findPrisonIdsWithActiveLevel("EN2").toSet()
+    assertThat(prisonIds).isEqualTo(setOf("BAI", "MDI", "WRI"))
+  }
 }


### PR DESCRIPTION
To be allowed to deactivate a level globally, it must not be active in any prison