### PR TITLE
INC-1202: Restrict activating a level in a prison if it is not globally active

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonIncentiveLevelService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonIncentiveLevelService.kt
@@ -96,6 +96,9 @@ class PrisonIncentiveLevelService(
           ?.withUpdate(update)
           ?: update.toNewEntity(prisonId, levelCode)
 
+      if (!incentiveLevel.active && prisonIncentiveLevel.active) {
+        throw ValidationException("A level cannot be made active and when it is globally inactive")
+      }
       if (incentiveLevel.required && !prisonIncentiveLevel.active) {
         throw ValidationException("A level cannot be made inactive and when it is globally required")
       }


### PR DESCRIPTION
It doesn't make sense for a level to be active in a prison when it's inactive globally. This particularly stopped making sense after part 1 of INC-1202 (#415) where a level could not be globally deactivated if it was active in some prison.