### PR TITLE
INC-1202: Restrict prison incentive level deactivation 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsService.kt
@@ -51,7 +51,7 @@ class IncentiveReviewsService(
   ): IncentiveReviewResponse = coroutineScope {
     val deferredOffenders = async {
       // all offenders at location are required to determine total number with overdue reviews
-      offenderSearchService.findOffenders(prisonId, cellLocationPrefix)
+      offenderSearchService.getOffendersAtLocation(prisonId, cellLocationPrefix)
     }
     val deferredLocationDescription = async {
       try {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewService.kt
@@ -1,12 +1,10 @@
 package uk.gov.justice.digital.hmpps.incentivesapi.service
 
 import jakarta.validation.ValidationException
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.count
-import kotlinx.coroutines.flow.flattenMerge
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.toList
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -133,7 +131,8 @@ class PrisonerIepLevelReviewService(
   }
 
   suspend fun getReviewById(id: Long): IepDetail =
-    prisonerIepLevelRepository.findById(id)?.toIepDetail(incentiveLevelService.getAllIncentiveLevelsMapByCode()) ?: throw NoDataFoundException(id)
+    prisonerIepLevelRepository.findById(id)?.toIepDetail(incentiveLevelService.getAllIncentiveLevelsMapByCode())
+      ?: throw NoDataFoundException(id)
 
   suspend fun processOffenderEvent(prisonOffenderEvent: HMPPSDomainEvent) =
     when (prisonOffenderEvent.additionalInformation?.reason) {
@@ -377,9 +376,6 @@ class PrisonerIepLevelReviewService(
     }
   }
 }
-
-@OptIn(FlowPreview::class)
-fun <T> merge(vararg flows: Flow<T>): Flow<T> = flowOf(*flows).flattenMerge()
 
 class IncentiveReviewNotFoundException(message: String?) :
   RuntimeException(message),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsServiceTest.kt
@@ -112,7 +112,7 @@ class IncentiveReviewsServiceTest {
       ),
     )
     whenever(prisonApiService.getLocation(any())).thenReturnLocation("MDI-2-1")
-    whenever(offenderSearchService.findOffenders(any(), any())).thenReturn(offenders)
+    whenever(offenderSearchService.getOffendersAtLocation(any(), any())).thenReturn(offenders)
     val nextReviewDatesMap = mapOf(
       110001L to LocalDate.now(clock).plusYears(1),
       110002L to LocalDate.now(clock).plusYears(1),
@@ -121,7 +121,7 @@ class IncentiveReviewsServiceTest {
 
     val reviews = incentiveReviewsService.reviews("MDI", "MDI-2-1", "STD")
 
-    verify(offenderSearchService, times(1)).findOffenders(any(), eq("MDI-2-1"))
+    verify(offenderSearchService, times(1)).getOffendersAtLocation(any(), eq("MDI-2-1"))
     assertThat(reviews.locationDescription).isEqualTo("A houseblock")
     val reviewCount = reviews.levels.find { level -> level.levelCode == "STD" }?.reviewCount
     assertThat(reviewCount).isEqualTo(2)
@@ -163,7 +163,7 @@ class IncentiveReviewsServiceTest {
     val prisonerNumber = "G6123VU"
     whenever(prisonApiService.getLocation(any())).thenReturnLocation("MDI-2-1")
     val offenders = listOf(offenderSearchPrisoner(prisonerNumber))
-    whenever(offenderSearchService.findOffenders(any(), any())).thenReturn(offenders)
+    whenever(offenderSearchService.getOffendersAtLocation(any(), any())).thenReturn(offenders)
     val nextReviewDatesMap = mapOf(offenders[0].bookingId to LocalDate.now(clock).plusYears(1))
     whenever(nextReviewDateGetterService.getMany(offenders)).thenReturn(nextReviewDatesMap)
 
@@ -218,7 +218,7 @@ class IncentiveReviewsServiceTest {
     val expectedNextReviewDate = LocalDate.now(clock).plusYears(1)
 
     whenever(prisonApiService.getLocation(any())).thenReturnLocation("MDI-2-1")
-    whenever(offenderSearchService.findOffenders(any(), any())).thenReturn(listOf(offenderSearchPrisoner(prisonerNumber)))
+    whenever(offenderSearchService.getOffendersAtLocation(any(), any())).thenReturn(listOf(offenderSearchPrisoner(prisonerNumber)))
 
     whenever(nextReviewDateGetterService.getMany(any())).thenReturn(mapOf(110002L to expectedNextReviewDate))
 
@@ -255,7 +255,7 @@ class IncentiveReviewsServiceTest {
     val someFutureNextReviewDate = LocalDate.now(clock).plusYears(1)
 
     whenever(prisonApiService.getLocation(any())).thenReturnLocation("MDI-2-1")
-    whenever(offenderSearchService.findOffenders(any(), any())).thenReturn(offenders)
+    whenever(offenderSearchService.getOffendersAtLocation(any(), any())).thenReturn(offenders)
     whenever(prisonerIepLevelRepository.findAllByBookingIdInOrderByReviewTimeDesc(any()))
       .thenReturn(
         flowOf(
@@ -335,7 +335,7 @@ class IncentiveReviewsServiceTest {
         offenderSearchPrisoner("A1409AE", 110001L),
         offenderSearchPrisoner("G6123VU", 110002L),
       )
-      whenever(offenderSearchService.findOffenders(any(), any())).thenReturn(offenders)
+      whenever(offenderSearchService.getOffendersAtLocation(any(), any())).thenReturn(offenders)
       whenever(nextReviewDateGetterService.getMany(offenders)).thenReturn(nextReviewDatesMap)
 
       // When
@@ -382,7 +382,7 @@ class IncentiveReviewsServiceTest {
         offenderSearchPrisoner("A1409AE", 110001L),
         offenderSearchPrisoner("G6123VU", 110002L),
       )
-      whenever(offenderSearchService.findOffenders(any(), any())).thenReturn(offenders)
+      whenever(offenderSearchService.getOffendersAtLocation(any(), any())).thenReturn(offenders)
       whenever(nextReviewDateGetterService.getMany(offenders)).thenReturn(nextReviewDatesMap)
 
       // When
@@ -400,7 +400,7 @@ class IncentiveReviewsServiceTest {
         offenderSearchPrisoner("A1409AE", 110001L),
         offenderSearchPrisoner("G6123VU", 110002L),
       )
-      whenever(offenderSearchService.findOffenders(any(), any())).thenReturn(offenders)
+      whenever(offenderSearchService.getOffendersAtLocation(any(), any())).thenReturn(offenders)
       whenever(nextReviewDateGetterService.getMany(offenders)).thenReturn(nextReviewDatesMap)
 
       // When
@@ -421,7 +421,7 @@ class IncentiveReviewsServiceTest {
   fun `throw exception if cannot find incentive level one bookingId`(): Unit = runBlocking {
     // Given - we only have prisonerIepLevel records for 110001
     whenever(prisonApiService.getLocation(any())).thenReturnLocation("MDI-2-1")
-    whenever(offenderSearchService.findOffenders(any(), any())).thenReturn(
+    whenever(offenderSearchService.getOffendersAtLocation(any(), any())).thenReturn(
       listOf(
         offenderSearchPrisoner("A1409AE", 110001),
         offenderSearchPrisoner("G6123VU", 110002),
@@ -447,7 +447,7 @@ class IncentiveReviewsServiceTest {
   fun `throw exception if cannot find incentive levels all bookingIds`(): Unit = runBlocking {
     // Given - we don't have prisonerIepLevel records for either bookingId
     whenever(prisonApiService.getLocation(any())).thenReturnLocation("MDI-2-1")
-    whenever(offenderSearchService.findOffenders(any(), any())).thenReturn(
+    whenever(offenderSearchService.getOffendersAtLocation(any(), any())).thenReturn(
       listOf(
         offenderSearchPrisoner("A1409AE", 110001),
         offenderSearchPrisoner("G6123VU", 110002),
@@ -476,7 +476,7 @@ class IncentiveReviewsServiceTest {
       offenderSearchPrisoner("G6123VU", 110002),
       offenderSearchPrisoner("G6123VX", 110003),
     )
-    whenever(offenderSearchService.findOffenders(any(), any())).thenReturn(offenders)
+    whenever(offenderSearchService.getOffendersAtLocation(any(), any())).thenReturn(offenders)
     whenever(prisonerIepLevelRepository.findAllByBookingIdInOrderByReviewTimeDesc(any()))
       .thenReturn(
         flowOf(
@@ -521,7 +521,7 @@ class IncentiveReviewsServiceTest {
         offenderSearchPrisoner("G6123VU", 110002),
         offenderSearchPrisoner("G6123VX", 110003),
       )
-      whenever(offenderSearchService.findOffenders(any(), any())).thenReturn(offenders)
+      whenever(offenderSearchService.getOffendersAtLocation(any(), any())).thenReturn(offenders)
       whenever(prisonerIepLevelRepository.findAllByBookingIdInOrderByReviewTimeDesc(any())).thenReturn(emptyFlow())
 
       whenever(prisonerIepLevelRepository.findAllByBookingIdInAndCurrentIsTrueOrderByReviewTimeDesc(any()))
@@ -560,7 +560,7 @@ class IncentiveReviewsServiceTest {
       offenderSearchPrisoner("G6123VU", 110002),
       offenderSearchPrisoner("G6123VX", 110003),
     )
-    whenever(offenderSearchService.findOffenders(any(), any())).thenReturn(offenders)
+    whenever(offenderSearchService.getOffendersAtLocation(any(), any())).thenReturn(offenders)
     whenever(prisonerIepLevelRepository.findAllByBookingIdInOrderByReviewTimeDesc(any()))
       .thenReturn(
         flowOf(
@@ -604,7 +604,7 @@ class IncentiveReviewsServiceTest {
   fun `overdue count where no next reviews are in the past`(): Unit = runBlocking {
     // Given
     whenever(prisonApiService.getLocation(any())).thenReturnLocation("MDI-2-1")
-    whenever(offenderSearchService.findOffenders(any(), any())).thenReturn(
+    whenever(offenderSearchService.getOffendersAtLocation(any(), any())).thenReturn(
       listOf(
         offenderSearchPrisoner("A1409AE", 110001),
         offenderSearchPrisoner("G6123VU", 110002),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/OffenderSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/OffenderSearchServiceTest.kt
@@ -113,7 +113,7 @@ class OffenderSearchServiceTest {
       ),
     )
     val offenderSearchService = OffenderSearchService(webClient)
-    val offenders = offenderSearchService.findOffenders("MDI", "MDI-1")
+    val offenders = offenderSearchService.getOffendersAtLocation("MDI", "MDI-1")
     assertThat(offenders).hasSize(1)
   }
 
@@ -157,7 +157,7 @@ class OffenderSearchServiceTest {
       ),
     )
     val offenderSearchService = OffenderSearchService(webClient)
-    val offenders = offenderSearchService.findOffenders("MDI", "MDI-1")
+    val offenders = offenderSearchService.getOffendersAtLocation("MDI", "MDI-1")
     assertThat(offenders).hasSize(3)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIepLevelReviewServiceTest.kt
@@ -39,7 +39,7 @@ class PrisonerIepLevelReviewServiceTest {
   private val prisonApiService: PrisonApiService = mock()
   private val prisonerIepLevelRepository: PrisonerIepLevelRepository = mock()
   private val authenticationFacade: AuthenticationFacade = mock()
-  private var clock: Clock = Clock.fixed(Instant.ofEpochMilli(0), ZoneId.of("Europe/London"))
+  private val clock: Clock = Clock.fixed(Instant.ofEpochMilli(0), ZoneId.of("Europe/London"))
   private val snsService: SnsService = mock()
   private val auditService: AuditService = mock()
   private val nextReviewDateGetterService: NextReviewDateGetterService = mock()
@@ -179,28 +179,27 @@ class PrisonerIepLevelReviewServiceTest {
   inner class GetPrisonerIepLevelHistory {
 
     @Test
-    fun `will not return iep details if withDetails is false`(): Unit =
-      runBlocking {
-        val bookingId = currentLevel.bookingId
-        val expectedNextReviewDate = currentAndPreviousLevels.first().reviewTime.plusYears(1).toLocalDate()
+    fun `will not return iep details if withDetails is false`(): Unit = runBlocking {
+      val bookingId = currentLevel.bookingId
+      val expectedNextReviewDate = currentAndPreviousLevels.first().reviewTime.plusYears(1).toLocalDate()
 
-        whenever(incentiveLevelService.getAllIncentiveLevelsMapByCode()).thenReturn(incentiveLevels)
-        whenever(nextReviewDateGetterService.get(bookingId)).thenReturn(expectedNextReviewDate)
+      whenever(incentiveLevelService.getAllIncentiveLevelsMapByCode()).thenReturn(incentiveLevels)
+      whenever(nextReviewDateGetterService.get(bookingId)).thenReturn(expectedNextReviewDate)
 
-        // Given
-        whenever(prisonerIepLevelRepository.findAllByBookingIdOrderByReviewTimeDesc(bookingId)).thenReturn(
-          currentAndPreviousLevels,
-        )
+      // Given
+      whenever(prisonerIepLevelRepository.findAllByBookingIdOrderByReviewTimeDesc(bookingId)).thenReturn(
+        currentAndPreviousLevels,
+      )
 
-        // When
-        val result =
-          prisonerIepLevelReviewService.getPrisonerIepLevelHistory(bookingId, withDetails = false)
+      // When
+      val result =
+        prisonerIepLevelReviewService.getPrisonerIepLevelHistory(bookingId, withDetails = false)
 
-        // Then
-        verify(prisonerIepLevelRepository, times(1)).findAllByBookingIdOrderByReviewTimeDesc(bookingId)
-        assertThat(result.iepDetails.size).isZero
-        assertThat(result.nextReviewDate).isEqualTo(expectedNextReviewDate)
-      }
+      // Then
+      verify(prisonerIepLevelRepository, times(1)).findAllByBookingIdOrderByReviewTimeDesc(bookingId)
+      assertThat(result.iepDetails.size).isZero
+      assertThat(result.nextReviewDate).isEqualTo(expectedNextReviewDate)
+    }
   }
 
   @Nested
@@ -797,13 +796,13 @@ class PrisonerIepLevelReviewServiceTest {
       prisonerNumber = prisonerIepLevel.prisonerNumber,
       auditModuleName = "INCENTIVES_API",
     )
+
+  private val globalIncentiveLevels = listOf(
+    IncentiveLevel(code = "BAS", name = "Basic"),
+    IncentiveLevel(code = "STD", name = "Standard"),
+    IncentiveLevel(code = "ENH", name = "Enhanced"),
+    IncentiveLevel(code = "EN2", name = "Enhanced 2"),
+  )
+
+  private val incentiveLevels = globalIncentiveLevels.associateBy { iep -> iep.code }
 }
-
-val globalIncentiveLevels = listOf(
-  IncentiveLevel(code = "BAS", name = "Basic"),
-  IncentiveLevel(code = "STD", name = "Standard"),
-  IncentiveLevel(code = "ENH", name = "Enhanced"),
-  IncentiveLevel(code = "EN2", name = "Enhanced 2"),
-)
-
-val incentiveLevels = globalIncentiveLevels.associateBy { iep -> iep.code }


### PR DESCRIPTION
To be allowed to deactivate a level in a prison, there must not be any prisoners currently on the level.
Offender search is used to get list of residents; this is matched against the incentives DB (which by definition is the source of truth on current levels).