### PR TITLE
Tweak Renovate config to only bump major versions of HMPPS Orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@7.3.0
+  hmpps: ministryofjustice/hmpps@7
 
 parameters:
   alerts-slack-channel:

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,12 @@
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non major Gradle dependencies",
       "groupSlug": "all-gradle-minor-patch"
+    },
+    {
+      "matchDatasources": ["orb"],
+      "matchDepNames": ["hmpps"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
I attempted with https://github.com/ministryofjustice/hmpps-renovate-config/commit/00c1104a133de6d64207fb95af91bad410095a4a but doesn't seem to be working as per https://github.com/ministryofjustice/hmpps-incentives-api/pull/421