### PR TITLE
INC-1219: Offender Search API fetches more prisoners per request

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/OffenderSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/OffenderSearchService.kt
@@ -23,7 +23,7 @@ class OffenderSearchService(private val offenderSearchWebClient: WebClient) {
           mapOf(
             "prisonId" to prisonId,
             "cellLocationPrefix" to cellLocationPrefix,
-            "size" to 200, // NB: this is the max allowed page size
+            "size" to 500, // NB: API allows up 3,000 results per page
             "page" to page,
             "sort" to "prisonerNumber,ASC",
           ),


### PR DESCRIPTION
Increasing the number of prisoners fetched per request from 200 to 500.

This used to be 200 because it was the maximum, but since then the Offender Search API has changed to allow the `size` query param to be a maximum of 3,000.