### PR TITLE
Fix filtering offender search results when needing a whole prison's worth of people

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/CountPrisonersService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/CountPrisonersService.kt
@@ -15,7 +15,7 @@ class CountPrisonersService(
    * Returns the number of prisoners on given level at a prison
    */
   suspend fun countOfPrisonersOnLevelInPrison(prisonId: String, levelCode: String): Int {
-    return offenderSearchService.findOffendersAtLocation(prisonId, prisonId)
+    return offenderSearchService.findOffendersAtLocation(prisonId, "")
       .fold(0) { countSoFar, offenders ->
         val bookingIds = offenders.map { it.bookingId }
         countSoFar + prisonerIepLevelRepository.findAllByBookingIdInAndCurrentIsTrueOrderByReviewTimeDesc(bookingIds)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/CountPrisonersServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/CountPrisonersServiceTest.kt
@@ -30,7 +30,7 @@ class CountPrisonersServiceTest {
   @Test
   fun `count prisoners on a level in a prison`(): Unit = runBlocking {
     // mock offender search returning 2 pages of results with 3 prisoners, only 2 of which are on Standard in the repository
-    whenever(offenderSearchService.findOffendersAtLocation("MDI", "MDI")).thenReturn(
+    whenever(offenderSearchService.findOffendersAtLocation("MDI", "")).thenReturn(
       flowOf(
         listOf(
           OffenderSearchPrisoner(
@@ -106,7 +106,7 @@ class CountPrisonersServiceTest {
     val countOfPrisonersOnLevelInPrison = countPrisonersService.countOfPrisonersOnLevelInPrison("MDI", "STD")
 
     assertThat(countOfPrisonersOnLevelInPrison).isEqualTo(2)
-    verify(offenderSearchService, times(1)).findOffendersAtLocation("MDI", "MDI")
+    verify(offenderSearchService, times(1)).findOffendersAtLocation("MDI", "")
     verify(prisonerIepLevelRepository, times(2)).findAllByBookingIdInAndCurrentIsTrueOrderByReviewTimeDesc(any())
   }
 }


### PR DESCRIPTION
For a prison with fictional id AAI, the offender search endpoint works with `cellLocationPrefix` being `"AAI-"` or `""` but not `"AAI"`.