### PR TITLE
INC-1202: Return better error responses when incentive levels cannot be modified

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/HmppsIncentivesApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/HmppsIncentivesApiExceptionHandler.kt
@@ -71,6 +71,11 @@ class HmppsIncentivesApiExceptionHandler {
           },
           userMessage = "Validation failure: ${e.message}",
           developerMessage = e.message,
+          moreInfo = if (e is ValidationExceptionWithErrorCode) {
+            e.moreInfo
+          } else {
+            null
+          },
         ),
       )
   }
@@ -248,7 +253,7 @@ class ListOfDataNotFoundException(dataType: String, ids: Collection<Long>) :
 class DataIntegrityException(message: String) :
   Exception(message)
 
-class ValidationExceptionWithErrorCode(message: String, val errorCode: ErrorCode) :
+class ValidationExceptionWithErrorCode(message: String, val errorCode: ErrorCode, val moreInfo: String? = null) :
   ValidationException(message)
 
 enum class ErrorCode(val errorCode: Int) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/HmppsIncentivesApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/HmppsIncentivesApiExceptionHandler.kt
@@ -64,6 +64,11 @@ class HmppsIncentivesApiExceptionHandler {
       .body(
         ErrorResponse(
           status = BAD_REQUEST,
+          errorCode = if (e is ValidationExceptionWithErrorCode) {
+            e.errorCode
+          } else {
+            null
+          },
           userMessage = "Validation failure: ${e.message}",
           developerMessage = e.message,
         ),
@@ -243,6 +248,22 @@ class ListOfDataNotFoundException(dataType: String, ids: Collection<Long>) :
 class DataIntegrityException(message: String) :
   Exception(message)
 
+class ValidationExceptionWithErrorCode(message: String, val errorCode: ErrorCode) :
+  ValidationException(message)
+
+enum class ErrorCode(val errorCode: Int) {
+  IncentiveLevelActiveIfRequired(100),
+  IncentiveLevelActiveIfActiveInPrison(101),
+  IncentiveLevelCodeNotUnique(102),
+  IncentiveLevelReorderNeedsFullSet(103),
+
+  PrisonIncentiveLevelActiveIfRequired(200),
+  PrisonIncentiveLevelActiveIfDefault(201),
+  PrisonIncentiveLevelActiveIfPrisonersExist(202),
+  PrisonIncentiveLevelNotGloballyActive(203),
+  PrisonIncentiveLevelDefaultRequired(204),
+}
+
 @Schema(description = "Error response")
 data class ErrorResponse(
   @Schema(description = "HTTP status code", example = "500", required = true)
@@ -258,10 +279,10 @@ data class ErrorResponse(
 ) {
   constructor(
     status: HttpStatus,
-    errorCode: Int? = null,
+    errorCode: ErrorCode? = null,
     userMessage: String? = null,
     developerMessage: String? = null,
     moreInfo: String? = null,
   ) :
-    this(status.value(), errorCode, userMessage, developerMessage, moreInfo)
+    this(status.value(), errorCode?.errorCode, userMessage, developerMessage, moreInfo)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/HmppsIncentivesApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/HmppsIncentivesApiExceptionHandler.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.incentivesapi.config
 
-import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.ValidationException
 import org.slf4j.LoggerFactory
@@ -32,7 +31,7 @@ class HmppsIncentivesApiExceptionHandler {
       .status(BAD_REQUEST)
       .body(
         ErrorResponse(
-          status = (BAD_REQUEST.value()),
+          status = BAD_REQUEST,
           userMessage = "Validation failure: $message",
           developerMessage = (e.message),
         ),
@@ -244,14 +243,13 @@ class ListOfDataNotFoundException(dataType: String, ids: Collection<Long>) :
 class DataIntegrityException(message: String) :
   Exception(message)
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
-@Schema(description = "Error Response")
+@Schema(description = "Error response")
 data class ErrorResponse(
-  @Schema(description = "Status of Error", example = "500", required = true)
+  @Schema(description = "HTTP status code", example = "500", required = true)
   val status: Int,
-  @Schema(description = "Error Code", example = "500", required = false)
+  @Schema(description = "Internal error code", example = "123", required = false)
   val errorCode: Int? = null,
-  @Schema(description = "User Message of error", example = "Bad Data", required = false)
+  @Schema(description = "User message for the error", example = "Bad Data", required = false)
   val userMessage: String? = null,
   @Schema(description = "More detailed error message", example = "This is a stack trace", required = false)
   val developerMessage: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/HmppsIncentivesApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/HmppsIncentivesApiExceptionHandler.kt
@@ -256,6 +256,12 @@ class DataIntegrityException(message: String) :
 class ValidationExceptionWithErrorCode(message: String, val errorCode: ErrorCode, val moreInfo: String? = null) :
   ValidationException(message)
 
+/**
+ * Codes that can be used by api clients to uniquely discriminate between error types,
+ * instead of relying on non-constant text descriptions.
+ *
+ * NB: Once defined, the values must not be changed
+ */
 enum class ErrorCode(val errorCode: Int) {
   IncentiveLevelActiveIfRequired(100),
   IncentiveLevelActiveIfActiveInPrison(101),
@@ -273,13 +279,13 @@ enum class ErrorCode(val errorCode: Int) {
 data class ErrorResponse(
   @Schema(description = "HTTP status code", example = "500", required = true)
   val status: Int,
-  @Schema(description = "Internal error code", example = "123", required = false)
+  @Schema(description = "When present, uniquely identifies the type of error making it easier for clients to discriminate without relying on error description; see `uk.gov.justice.digital.hmpps.incentivesapi.config.ErrorResponse` enumeration in hmpps-incentives-api", example = "123", required = false)
   val errorCode: Int? = null,
-  @Schema(description = "User message for the error", example = "Bad Data", required = false)
+  @Schema(description = "User message for the error", example = "No incentive level found for code `ABC`", required = false)
   val userMessage: String? = null,
-  @Schema(description = "More detailed error message", example = "This is a stack trace", required = false)
+  @Schema(description = "More detailed error message", example = "[Details, sometimes a stack trace]", required = false)
   val developerMessage: String? = null,
-  @Schema(description = "More information about the error", example = "More info", required = false)
+  @Schema(description = "More information about the error", example = "[Rarely used, error-specific]", required = false)
   val moreInfo: String? = null,
 ) {
   constructor(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonIncentiveLevelRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonIncentiveLevelRepository.kt
@@ -107,6 +107,7 @@ interface PrisonIncentiveLevelRepository : CoroutineCrudRepository<PrisonIncenti
     SELECT prison_id
     FROM prison_incentive_level
     WHERE active IS TRUE AND level_code = :levelCode
+    ORDER BY prison_id
     """,
   )
   fun findPrisonIdsWithActiveLevel(levelCode: String): Flow<String>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResource.kt
@@ -193,7 +193,7 @@ class IncentiveLevelResource(
   @Operation(
     summary = "Updates an incentive level",
     description = "Payload must include all required fields. A level marked as required must also be active. " +
-      "Deactivating a level is only possible if it is not active in any prison. " +
+      "Deactivating a level is only possible if it is not active in any prison (moreInfo field will contain comma-separated prison ids). " +
       "Deactivated incentive levels remain in the same position with respect to the others." +
       "\n\nRequires role: MAINTAIN_INCENTIVE_LEVELS with write scope" +
       "\n\nRaises HMPPS domain event: \"incentives.level.changed\"",
@@ -244,7 +244,7 @@ class IncentiveLevelResource(
   @Operation(
     summary = "Updates an incentive level",
     description = "Partial updates are allowed. A level marked as required must also be active. " +
-      "Deactivating a level is only possible if it is not active in any prison. " +
+      "Deactivating a level is only possible if it is not active in any prison (moreInfo field will contain comma-separated prison ids). " +
       "Deactivated incentive levels remain in the same position with respect to the others." +
       "\n\nRequires role: MAINTAIN_INCENTIVE_LEVELS with write scope" +
       "\n\nRaises HMPPS domain event: \"incentives.level.changed\"",
@@ -304,7 +304,7 @@ class IncentiveLevelResource(
   @Operation(
     summary = "Deactivates an incentive level",
     description = "A required level cannot be deactivated, needs to be updated first to be not required. " +
-      "Deactivating a level is only possible if it is not active in any prison. " +
+      "Deactivating a level is only possible if it is not active in any prison (moreInfo field will contain comma-separated prison ids). " +
       "Deactivated incentive levels remain in the same position with respect to the others." +
       "\n\nRequires role: MAINTAIN_INCENTIVE_LEVELS with write scope" +
       "\n\nRaises HMPPS domain event: \"incentives.level.changed\"",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveLevelService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveLevelService.kt
@@ -1,13 +1,14 @@
 package uk.gov.justice.digital.hmpps.incentivesapi.service
 
-import jakarta.validation.ValidationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.incentivesapi.config.ErrorCode
 import uk.gov.justice.digital.hmpps.incentivesapi.config.FeatureFlagsService
 import uk.gov.justice.digital.hmpps.incentivesapi.config.NoDataWithCodeFoundException
+import uk.gov.justice.digital.hmpps.incentivesapi.config.ValidationExceptionWithErrorCode
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.IepLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.toIncentivesServiceDto
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.IncentiveLevel
@@ -71,10 +72,16 @@ class IncentiveLevelService(
   @Transactional
   suspend fun createIncentiveLevel(dto: IncentiveLevelDTO): IncentiveLevelDTO {
     if (!dto.active && dto.required) {
-      throw ValidationException("A level must be active if it is required")
+      throw ValidationExceptionWithErrorCode(
+        "A level must be active if it is required",
+        ErrorCode.IncentiveLevelActiveIfRequired,
+      )
     }
     if (incentiveLevelRepository.existsById(dto.code)) {
-      throw ValidationException("Incentive level with code ${dto.code} already exists")
+      throw ValidationExceptionWithErrorCode(
+        "Incentive level with code ${dto.code} already exists",
+        ErrorCode.IncentiveLevelCodeNotUnique,
+      )
     }
 
     val highestSequence = incentiveLevelRepository.findMaxSequence() ?: 0
@@ -98,11 +105,17 @@ class IncentiveLevelService(
         val incentiveLevel = originalIncentiveLevel.withUpdate(update)
 
         if (!incentiveLevel.active && incentiveLevel.required) {
-          throw ValidationException("A level must be active if it is required")
+          throw ValidationExceptionWithErrorCode(
+            "A level must be active if it is required",
+            ErrorCode.IncentiveLevelActiveIfRequired,
+          )
         }
         if (originalIncentiveLevel.active && !incentiveLevel.active) {
           if (prisonIncentiveLevelService.getPrisonIdsWithActivePrisonIncentiveLevel(incentiveLevel.code).isNotEmpty()) {
-            throw ValidationException("A level must remain active if it is active in some prison")
+            throw ValidationExceptionWithErrorCode(
+              "A level must remain active if it is active in some prison",
+              ErrorCode.IncentiveLevelActiveIfActiveInPrison,
+            )
           }
         }
 
@@ -130,7 +143,10 @@ class IncentiveLevelService(
     }
     if (allIncentiveLevels.isNotEmpty()) {
       val missing = allIncentiveLevels.keys.joinToString("`, `", prefix = "`", postfix = "`")
-      throw ValidationException("All incentive levels required when setting order. Missing: $missing")
+      throw ValidationExceptionWithErrorCode(
+        "All incentive levels required when setting order. Missing: $missing",
+        ErrorCode.IncentiveLevelReorderNeedsFullSet,
+      )
     }
 
     val incentiveLevelsWithNewSequences = allIncentiveLevelsInDesiredOrder.mapIndexed { index, incentiveLevel ->

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveLevelService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveLevelService.kt
@@ -111,10 +111,12 @@ class IncentiveLevelService(
           )
         }
         if (originalIncentiveLevel.active && !incentiveLevel.active) {
-          if (prisonIncentiveLevelService.getPrisonIdsWithActivePrisonIncentiveLevel(incentiveLevel.code).isNotEmpty()) {
+          val prisonIds = prisonIncentiveLevelService.getPrisonIdsWithActivePrisonIncentiveLevel(incentiveLevel.code)
+          if (prisonIds.isNotEmpty()) {
             throw ValidationExceptionWithErrorCode(
               "A level must remain active if it is active in some prison",
               ErrorCode.IncentiveLevelActiveIfActiveInPrison,
+              moreInfo = prisonIds.joinToString(","),
             )
           }
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/helper/ErrorResponseHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/helper/ErrorResponseHelper.kt
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.springframework.http.HttpStatus
 import org.springframework.test.web.reactive.server.WebTestClient
 
-fun <T : WebTestClient.ResponseSpec> T.expectErrorResponse(status: HttpStatus, vararg messages: String): T {
+fun <T : WebTestClient.ResponseSpec> T.expectErrorResponse(status: HttpStatus, vararg messages: String, errorCode: Int? = null): T {
   expectStatus().isEqualTo(status)
 
   with(expectBody()) {
@@ -13,6 +13,12 @@ fun <T : WebTestClient.ResponseSpec> T.expectErrorResponse(status: HttpStatus, v
     val userMessage = jsonPath("$.userMessage")
     for (message in messages) {
       userMessage.value<String> { assertThat(it).contains(message) }
+    }
+
+    if (errorCode != null) {
+      jsonPath("$.errorCode").isEqualTo(errorCode)
+    } else {
+      jsonPath("$.errorCode").doesNotExist()
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/helper/ErrorResponseHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/helper/ErrorResponseHelper.kt
@@ -3,11 +3,12 @@ package uk.gov.justice.digital.hmpps.incentivesapi.helper
 import org.assertj.core.api.Assertions.assertThat
 import org.springframework.http.HttpStatus
 import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.incentivesapi.config.ErrorCode
 
 fun <T : WebTestClient.ResponseSpec> T.expectErrorResponse(
   status: HttpStatus,
   vararg messages: String,
-  errorCode: Int? = null,
+  errorCode: ErrorCode? = null,
   moreInfo: String? = null,
 ): T {
   expectStatus().isEqualTo(status)
@@ -21,7 +22,7 @@ fun <T : WebTestClient.ResponseSpec> T.expectErrorResponse(
     }
 
     if (errorCode != null) {
-      jsonPath("$.errorCode").isEqualTo(errorCode)
+      jsonPath("$.errorCode").isEqualTo(errorCode.errorCode)
     } else {
       jsonPath("$.errorCode").doesNotExist()
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/helper/ErrorResponseHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/helper/ErrorResponseHelper.kt
@@ -4,7 +4,12 @@ import org.assertj.core.api.Assertions.assertThat
 import org.springframework.http.HttpStatus
 import org.springframework.test.web.reactive.server.WebTestClient
 
-fun <T : WebTestClient.ResponseSpec> T.expectErrorResponse(status: HttpStatus, vararg messages: String, errorCode: Int? = null): T {
+fun <T : WebTestClient.ResponseSpec> T.expectErrorResponse(
+  status: HttpStatus,
+  vararg messages: String,
+  errorCode: Int? = null,
+  moreInfo: String? = null,
+): T {
   expectStatus().isEqualTo(status)
 
   with(expectBody()) {
@@ -19,6 +24,12 @@ fun <T : WebTestClient.ResponseSpec> T.expectErrorResponse(status: HttpStatus, v
       jsonPath("$.errorCode").isEqualTo(errorCode)
     } else {
       jsonPath("$.errorCode").doesNotExist()
+    }
+
+    if (moreInfo != null) {
+      jsonPath("$.moreInfo").isEqualTo(moreInfo)
+    } else {
+      jsonPath("$.moreInfo").doesNotExist()
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonerIepLevelRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonerIepLevelRepositoryTest.kt
@@ -169,7 +169,7 @@ class PrisonerIepLevelRepositoryTest : TestBase() {
   }
 
   @Test
-  fun `counts prisoners on a level`(): Unit = runBlocking {
+  fun `checks if there are prisoners on a level`(): Unit = runBlocking {
     repository.save(
       PrisonerIepLevel(
         iepCode = "BAS",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResourceTest.kt
@@ -13,6 +13,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Primary
 import org.springframework.http.HttpStatus
 import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.incentivesapi.config.ErrorCode
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.PrisonIncentiveLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.helper.expectErrorResponse
 import uk.gov.justice.digital.hmpps.incentivesapi.integration.IncentiveLevelResourceTestBase
@@ -329,7 +330,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectErrorResponse(
           HttpStatus.BAD_REQUEST,
           "Incentive level with code STD already exists",
-          errorCode = 102,
+          errorCode = ErrorCode.IncentiveLevelCodeNotUnique,
         )
 
       runBlocking {
@@ -569,7 +570,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectErrorResponse(
           HttpStatus.BAD_REQUEST,
           "All incentive levels required when setting order. Missing: `ENT`",
-          errorCode = 103,
+          errorCode = ErrorCode.IncentiveLevelReorderNeedsFullSet,
         )
 
       runBlocking {
@@ -1085,7 +1086,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectErrorResponse(
           HttpStatus.BAD_REQUEST,
           "A level must be active if it is required",
-          errorCode = 100,
+          errorCode = ErrorCode.IncentiveLevelActiveIfRequired,
         )
 
       runBlocking {
@@ -1214,7 +1215,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectErrorResponse(
           HttpStatus.BAD_REQUEST,
           "A level must be active if it is required",
-          errorCode = 100,
+          errorCode = ErrorCode.IncentiveLevelActiveIfRequired,
         )
 
       runBlocking {
@@ -1249,7 +1250,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectErrorResponse(
           HttpStatus.BAD_REQUEST,
           "A level must remain active if it is active in some prison",
-          errorCode = 101,
+          errorCode = ErrorCode.IncentiveLevelActiveIfActiveInPrison,
           moreInfo = "BAI,MDI",
         )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResourceTest.kt
@@ -131,7 +131,10 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .uri("/incentive/levels/bas")
         .headers(setAuthorisation())
         .exchange()
-        .expectErrorResponse(HttpStatus.NOT_FOUND, "No incentive level found for code `bas`")
+        .expectErrorResponse(
+          HttpStatus.NOT_FOUND,
+          "No incentive level found for code `bas`",
+        )
     }
   }
 
@@ -263,7 +266,10 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.FORBIDDEN, "Forbidden")
+        .expectErrorResponse(
+          HttpStatus.FORBIDDEN,
+          "Forbidden",
+        )
 
       runBlocking {
         assertThat(incentiveLevelRepository.count()).isEqualTo(6)
@@ -320,7 +326,11 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Incentive level with code STD already exists")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "Incentive level with code STD already exists",
+          errorCode = 102,
+        )
 
       runBlocking {
         assertThat(incentiveLevelRepository.count()).isEqualTo(6)
@@ -356,7 +366,10 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .header("Content-Type", "application/json")
         .bodyValue(body)
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Invalid request format")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "Invalid request format",
+        )
 
       runBlocking {
         assertThat(incentiveLevelRepository.count()).isEqualTo(6)
@@ -394,7 +407,10 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .header("Content-Type", "application/json")
         .bodyValue(body)
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Invalid parameters")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "Invalid parameters",
+        )
 
       runBlocking {
         assertThat(incentiveLevelRepository.count()).isEqualTo(6)
@@ -464,7 +480,10 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.FORBIDDEN, "Forbidden")
+        .expectErrorResponse(
+          HttpStatus.FORBIDDEN,
+          "Forbidden",
+        )
 
       runBlocking {
         val incentiveLevelCodes = incentiveLevelRepository.findAllByOrderBySequence().map { it.code }.toList()
@@ -488,7 +507,10 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.NOT_FOUND, "No incentive level found for code `EN4`")
+        .expectErrorResponse(
+          HttpStatus.NOT_FOUND,
+          "No incentive level found for code `EN4`",
+        )
 
       runBlocking {
         val incentiveLevels = incentiveLevelRepository.findAllByOrderBySequence().toList()
@@ -516,7 +538,10 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "must have size of at least 2")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "must have size of at least 2",
+        )
 
       runBlocking {
         val incentiveLevels = incentiveLevelRepository.findAllByOrderBySequence().toList()
@@ -541,7 +566,11 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "All incentive levels required when setting order. Missing: `ENT`")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "All incentive levels required when setting order. Missing: `ENT`",
+          errorCode = 103,
+        )
 
       runBlocking {
         val incentiveLevels = incentiveLevelRepository.findAllByOrderBySequence().toList()
@@ -659,7 +688,10 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.FORBIDDEN, "Forbidden")
+        .expectErrorResponse(
+          HttpStatus.FORBIDDEN,
+          "Forbidden",
+        )
 
       runBlocking {
         val incentiveLevel = incentiveLevelRepository.findById("STD")
@@ -683,7 +715,10 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.NOT_FOUND, "No incentive level found for code `std`")
+        .expectErrorResponse(
+          HttpStatus.NOT_FOUND,
+          "No incentive level found for code `std`",
+        )
 
       runBlocking {
         var incentiveLevel = incentiveLevelRepository.findById("std")
@@ -710,7 +745,10 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Incentive level codes must match in URL and payload")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "Incentive level codes must match in URL and payload",
+        )
 
       runBlocking {
         var incentiveLevel = incentiveLevelRepository.findById("STD")
@@ -749,7 +787,10 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .header("Content-Type", "application/json")
         .bodyValue(body)
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Invalid request format")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "Invalid request format",
+        )
 
       runBlocking {
         val incentiveLevel = incentiveLevelRepository.findById("STD")
@@ -781,7 +822,10 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .header("Content-Type", "application/json")
         .bodyValue(body)
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Invalid parameters")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "Invalid parameters",
+        )
 
       runBlocking {
         var incentiveLevel = incentiveLevelRepository.findById("STD")
@@ -901,7 +945,10 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.FORBIDDEN, "Forbidden")
+        .expectErrorResponse(
+          HttpStatus.FORBIDDEN,
+          "Forbidden",
+        )
 
       runBlocking {
         val incentiveLevel = incentiveLevelRepository.findById("STD")
@@ -925,7 +972,10 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.NOT_FOUND, "No incentive level found for code `std`")
+        .expectErrorResponse(
+          HttpStatus.NOT_FOUND,
+          "No incentive level found for code `std`",
+        )
 
       runBlocking {
         var incentiveLevel = incentiveLevelRepository.findById("std")
@@ -1004,7 +1054,10 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .header("Content-Type", "application/json")
         .bodyValue(body)
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Invalid parameters")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "Invalid parameters",
+        )
 
       runBlocking {
         val incentiveLevel = incentiveLevelRepository.findById("STD")
@@ -1029,7 +1082,11 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "A level must be active if it is required")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "A level must be active if it is required",
+          errorCode = 100,
+        )
 
       runBlocking {
         val incentiveLevel = incentiveLevelRepository.findById("ENT")
@@ -1111,7 +1168,10 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .uri("/incentive/levels/STD")
         .headers(setAuthorisation())
         .exchange()
-        .expectErrorResponse(HttpStatus.FORBIDDEN, "Forbidden")
+        .expectErrorResponse(
+          HttpStatus.FORBIDDEN,
+          "Forbidden",
+        )
 
       runBlocking {
         val incentiveLevel = incentiveLevelRepository.findById("STD")
@@ -1128,7 +1188,10 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .uri("/incentive/levels/std")
         .withCentralAuthorisation()
         .exchange()
-        .expectErrorResponse(HttpStatus.NOT_FOUND, "No incentive level found for code `std`")
+        .expectErrorResponse(
+          HttpStatus.NOT_FOUND,
+          "No incentive level found for code `std`",
+        )
 
       runBlocking {
         var incentiveLevel = incentiveLevelRepository.findById("std")
@@ -1148,7 +1211,11 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .uri("/incentive/levels/STD")
         .withCentralAuthorisation()
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "A level must be active if it is required")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "A level must be active if it is required",
+          errorCode = 100,
+        )
 
       runBlocking {
         val incentiveLevel = incentiveLevelRepository.findById("STD")
@@ -1179,7 +1246,11 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .uri("/incentive/levels/EN2")
         .withCentralAuthorisation()
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "A level must remain active if it is active in some prison")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "A level must remain active if it is active in some prison",
+          errorCode = 101,
+        )
 
       runBlocking {
         val incentiveLevel = incentiveLevelRepository.findById("EN2")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResourceTest.kt
@@ -1250,6 +1250,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           HttpStatus.BAD_REQUEST,
           "A level must remain active if it is active in some prison",
           errorCode = 101,
+          moreInfo = "BAI,MDI",
         )
 
       runBlocking {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/PrisonIncentiveLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/PrisonIncentiveLevelResourceTest.kt
@@ -175,7 +175,10 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .uri("/incentive/prison-levels/BAI/level/EN4")
         .headers(setAuthorisation())
         .exchange()
-        .expectErrorResponse(HttpStatus.NOT_FOUND, "No prison incentive level found for code `EN4`")
+        .expectErrorResponse(
+          HttpStatus.NOT_FOUND,
+          "No prison incentive level found for code `EN4`",
+        )
     }
   }
 
@@ -338,7 +341,10 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.FORBIDDEN, "Forbidden")
+        .expectErrorResponse(
+          HttpStatus.FORBIDDEN,
+          "Forbidden",
+        )
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("MDI", "STD")
@@ -368,7 +374,10 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.NOT_FOUND, "No incentive level found for code `std`")
+        .expectErrorResponse(
+          HttpStatus.NOT_FOUND,
+          "No incentive level found for code `std`",
+        )
 
       runBlocking {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
@@ -395,7 +404,10 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Incentive level codes must match in URL and payload")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "Incentive level codes must match in URL and payload",
+        )
 
       runBlocking {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
@@ -422,7 +434,10 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Prison ids must match in URL and payload")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "Prison ids must match in URL and payload",
+        )
 
       runBlocking {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
@@ -447,7 +462,10 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Invalid request format")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "Invalid request format",
+        )
 
       runBlocking {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
@@ -474,7 +492,10 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Invalid parameters")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "Invalid parameters",
+        )
 
       runBlocking {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
@@ -533,7 +554,11 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "There must be an active default level for admission in a prison")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "There must be an active default level for admission in a prison",
+          errorCode = 204,
+        )
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("BAI", "STD")
@@ -569,7 +594,11 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "There must be an active default level for admission in a prison")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "There must be an active default level for admission in a prison",
+          errorCode = 204,
+        )
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("BAI", "BAS")
@@ -603,7 +632,11 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "A level cannot be made active and when it is globally inactive")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "A level cannot be made active and when it is globally inactive",
+          errorCode = 203,
+        )
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("BAI", "ENT")
@@ -631,7 +664,11 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "A level cannot be made inactive and when it is globally required")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "A level cannot be made inactive and when it is globally required",
+          errorCode = 200,
+        )
 
       runBlocking {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
@@ -662,7 +699,11 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "A level must remain active if there are prisoners on it currently")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "A level must remain active if there are prisoners on it currently",
+          errorCode = 202,
+        )
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("WRI", "EN2")
@@ -820,7 +861,10 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.FORBIDDEN, "Forbidden")
+        .expectErrorResponse(
+          HttpStatus.FORBIDDEN,
+          "Forbidden",
+        )
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("BAI", "BAS")
@@ -847,7 +891,10 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.NOT_FOUND, "No incentive level found for code `std`")
+        .expectErrorResponse(
+          HttpStatus.NOT_FOUND,
+          "No incentive level found for code `std`",
+        )
 
       runBlocking {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
@@ -874,7 +921,10 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Invalid parameters")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "Invalid parameters",
+        )
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("WRI", "ENH")
@@ -907,6 +957,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectErrorResponse(
           HttpStatus.BAD_REQUEST,
           "A level cannot be made inactive and still be the default for admission",
+          errorCode = 201,
         )
 
       runBlocking {
@@ -942,7 +993,11 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "A level cannot be made inactive and still be the default for admission")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "A level cannot be made inactive and still be the default for admission",
+          errorCode = 201,
+        )
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("MDI", "STD")
@@ -972,7 +1027,11 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "There must be an active default level for admission in a prison")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "There must be an active default level for admission in a prison",
+          errorCode = 204,
+        )
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("BAI", "STD")
@@ -1006,7 +1065,11 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "There must be an active default level for admission in a prison")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "There must be an active default level for admission in a prison",
+          errorCode = 204,
+        )
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("BAI", "BAS")
@@ -1038,7 +1101,11 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "A level cannot be made active and when it is globally inactive")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "A level cannot be made active and when it is globally inactive",
+          errorCode = 203,
+        )
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("BAI", "ENT")
@@ -1067,7 +1134,11 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "A level cannot be made inactive and when it is globally required")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "A level cannot be made inactive and when it is globally required",
+          errorCode = 200,
+        )
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("BAI", "BAS")
@@ -1098,7 +1169,11 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "A level must remain active if there are prisoners on it currently")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "A level must remain active if there are prisoners on it currently",
+          errorCode = 202,
+        )
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("WRI", "EN2")
@@ -1174,7 +1249,10 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .headers(setAuthorisation())
         .header("Content-Type", "application/json")
         .exchange()
-        .expectErrorResponse(HttpStatus.FORBIDDEN, "Forbidden")
+        .expectErrorResponse(
+          HttpStatus.FORBIDDEN,
+          "Forbidden",
+        )
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("WRI", "ENH")
@@ -1192,7 +1270,10 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .withLocalAuthorisation()
         .header("Content-Type", "application/json")
         .exchange()
-        .expectErrorResponse(HttpStatus.NOT_FOUND, "No incentive level found for code `bas`")
+        .expectErrorResponse(
+          HttpStatus.NOT_FOUND,
+          "No incentive level found for code `bas`",
+        )
 
       runBlocking {
         assertThat(prisonIncentiveLevelRepository.count()).isZero
@@ -1219,6 +1300,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectErrorResponse(
           HttpStatus.BAD_REQUEST,
           "A level cannot be made inactive and still be the default for admission",
+          errorCode = 201,
         )
 
       runBlocking {
@@ -1244,6 +1326,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectErrorResponse(
           HttpStatus.BAD_REQUEST,
           "A level cannot be made inactive and when it is globally required",
+          errorCode = 200,
         )
 
       runBlocking {
@@ -1267,7 +1350,11 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .withLocalAuthorisation()
         .header("Content-Type", "application/json")
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "A level must remain active if there are prisoners on it currently")
+        .expectErrorResponse(
+          HttpStatus.BAD_REQUEST,
+          "A level must remain active if there are prisoners on it currently",
+          errorCode = 202,
+        )
 
       runBlocking {
         val prisonIncentiveLevel = prisonIncentiveLevelRepository.findFirstByPrisonIdAndLevelCode("MDI", "EN2")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/PrisonIncentiveLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/PrisonIncentiveLevelResourceTest.kt
@@ -16,6 +16,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Primary
 import org.springframework.http.HttpStatus
 import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.incentivesapi.config.ErrorCode
 import uk.gov.justice.digital.hmpps.incentivesapi.helper.expectErrorResponse
 import uk.gov.justice.digital.hmpps.incentivesapi.integration.IncentiveLevelResourceTestBase
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.PrisonerIepLevel
@@ -557,7 +558,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectErrorResponse(
           HttpStatus.BAD_REQUEST,
           "There must be an active default level for admission in a prison",
-          errorCode = 204,
+          errorCode = ErrorCode.PrisonIncentiveLevelDefaultRequired,
         )
 
       runBlocking {
@@ -597,7 +598,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectErrorResponse(
           HttpStatus.BAD_REQUEST,
           "There must be an active default level for admission in a prison",
-          errorCode = 204,
+          errorCode = ErrorCode.PrisonIncentiveLevelDefaultRequired,
         )
 
       runBlocking {
@@ -635,7 +636,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectErrorResponse(
           HttpStatus.BAD_REQUEST,
           "A level cannot be made active and when it is globally inactive",
-          errorCode = 203,
+          errorCode = ErrorCode.PrisonIncentiveLevelNotGloballyActive,
         )
 
       runBlocking {
@@ -667,7 +668,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectErrorResponse(
           HttpStatus.BAD_REQUEST,
           "A level cannot be made inactive and when it is globally required",
-          errorCode = 200,
+          errorCode = ErrorCode.PrisonIncentiveLevelActiveIfRequired,
         )
 
       runBlocking {
@@ -702,7 +703,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectErrorResponse(
           HttpStatus.BAD_REQUEST,
           "A level must remain active if there are prisoners on it currently",
-          errorCode = 202,
+          errorCode = ErrorCode.PrisonIncentiveLevelActiveIfPrisonersExist,
         )
 
       runBlocking {
@@ -957,7 +958,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectErrorResponse(
           HttpStatus.BAD_REQUEST,
           "A level cannot be made inactive and still be the default for admission",
-          errorCode = 201,
+          errorCode = ErrorCode.PrisonIncentiveLevelActiveIfDefault,
         )
 
       runBlocking {
@@ -996,7 +997,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectErrorResponse(
           HttpStatus.BAD_REQUEST,
           "A level cannot be made inactive and still be the default for admission",
-          errorCode = 201,
+          errorCode = ErrorCode.PrisonIncentiveLevelActiveIfDefault,
         )
 
       runBlocking {
@@ -1030,7 +1031,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectErrorResponse(
           HttpStatus.BAD_REQUEST,
           "There must be an active default level for admission in a prison",
-          errorCode = 204,
+          errorCode = ErrorCode.PrisonIncentiveLevelDefaultRequired,
         )
 
       runBlocking {
@@ -1068,7 +1069,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectErrorResponse(
           HttpStatus.BAD_REQUEST,
           "There must be an active default level for admission in a prison",
-          errorCode = 204,
+          errorCode = ErrorCode.PrisonIncentiveLevelDefaultRequired,
         )
 
       runBlocking {
@@ -1104,7 +1105,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectErrorResponse(
           HttpStatus.BAD_REQUEST,
           "A level cannot be made active and when it is globally inactive",
-          errorCode = 203,
+          errorCode = ErrorCode.PrisonIncentiveLevelNotGloballyActive,
         )
 
       runBlocking {
@@ -1137,7 +1138,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectErrorResponse(
           HttpStatus.BAD_REQUEST,
           "A level cannot be made inactive and when it is globally required",
-          errorCode = 200,
+          errorCode = ErrorCode.PrisonIncentiveLevelActiveIfRequired,
         )
 
       runBlocking {
@@ -1172,7 +1173,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectErrorResponse(
           HttpStatus.BAD_REQUEST,
           "A level must remain active if there are prisoners on it currently",
-          errorCode = 202,
+          errorCode = ErrorCode.PrisonIncentiveLevelActiveIfPrisonersExist,
         )
 
       runBlocking {
@@ -1300,7 +1301,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectErrorResponse(
           HttpStatus.BAD_REQUEST,
           "A level cannot be made inactive and still be the default for admission",
-          errorCode = 201,
+          errorCode = ErrorCode.PrisonIncentiveLevelActiveIfDefault,
         )
 
       runBlocking {
@@ -1326,7 +1327,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectErrorResponse(
           HttpStatus.BAD_REQUEST,
           "A level cannot be made inactive and when it is globally required",
-          errorCode = 200,
+          errorCode = ErrorCode.PrisonIncentiveLevelActiveIfRequired,
         )
 
       runBlocking {
@@ -1353,7 +1354,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .expectErrorResponse(
           HttpStatus.BAD_REQUEST,
           "A level must remain active if there are prisoners on it currently",
-          errorCode = 202,
+          errorCode = ErrorCode.PrisonIncentiveLevelActiveIfPrisonersExist,
         )
 
       runBlocking {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/util/ErrorCodeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/util/ErrorCodeTest.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.incentivesapi.util
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.incentivesapi.config.ErrorCode
+
+class ErrorCodeTest {
+  @Test
+  fun `error codes should all be unique`() {
+    val errorCodes = ErrorCode.values()
+    val uniqueErrorCodes = errorCodes.map { it.errorCode }.toSet().size
+    assertThat(errorCodes).hasSize(uniqueErrorCodes)
+  }
+}


### PR DESCRIPTION
Error responses could always have contained an integer `errorCode` but it was not used in practice. For clients of the api to be able to _precisely_ know the error that occurred, it's better to use an enum / constant code rather than rely on text included in the message.

Similarly, the `moreInfo` field hasn't been used yet: Trying to remove an incentive level globally will now return an error with prisons that currently have it active.

Depends on (and won't merge with) #425