### PR TITLE
INC-1199: Tweak to exception handling

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/HmppsIncentivesApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/HmppsIncentivesApiExceptionHandler.kt
@@ -20,7 +20,6 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import org.springframework.web.server.ServerWebInputException
 import org.springframework.web.server.UnsupportedMediaTypeStatusException
 import uk.gov.justice.digital.hmpps.incentivesapi.service.IncentiveReviewNotFoundException
-import uk.gov.justice.digital.hmpps.incentivesapi.util.ParameterValidationException
 
 @RestControllerAdvice
 class HmppsIncentivesApiExceptionHandler {
@@ -63,20 +62,6 @@ class HmppsIncentivesApiExceptionHandler {
         ErrorResponse(
           status = BAD_REQUEST,
           userMessage = "Validation failure: ${e.message}",
-          developerMessage = e.message,
-        ),
-      )
-  }
-
-  @ExceptionHandler(ParameterValidationException::class)
-  fun handleParameterValidationException(e: ParameterValidationException): ResponseEntity<ErrorResponse> {
-    log.info("Invalid parameters: {}", e.errors)
-    return ResponseEntity
-      .status(BAD_REQUEST)
-      .body(
-        ErrorResponse(
-          status = BAD_REQUEST,
-          userMessage = e.message,
           developerMessage = e.message,
         ),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/HmppsIncentivesApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/HmppsIncentivesApiExceptionHandler.kt
@@ -53,6 +53,8 @@ class HmppsIncentivesApiExceptionHandler {
       )
   }
 
+  // Validation exceptions including `ParameterValidationException`
+  // thrown by `ensure` blocks when field validations fail
   @ExceptionHandler(ValidationException::class)
   fun handleValidationException(e: ValidationException): ResponseEntity<ErrorResponse> {
     log.info("Validation exception: {}", e.message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/HmppsIncentivesApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/HmppsIncentivesApiExceptionHandler.kt
@@ -216,16 +216,23 @@ class HmppsIncentivesApiExceptionHandler {
       )
   }
 
+  // Exception thrown when the request body is missing a required field
+  // or provided value doesn't match valid enum values
+  //
+  // NOTE: This exception covers a number of possible bad inputs,
+  // e.g. missing fields, values of the wrong type, values not
+  // matching the ones available in an enum, etc...
   @ExceptionHandler(ServerWebInputException::class)
   fun handleServerWebInputException(e: ServerWebInputException): ResponseEntity<ErrorResponse> {
-    log.error("Parameter conversion exception: {}", e.message)
+    val developerMessage = "Invalid request format: ${e.cause}"
+    log.error(developerMessage)
     return ResponseEntity
       .status(BAD_REQUEST)
       .body(
         ErrorResponse(
           status = BAD_REQUEST,
-          userMessage = "Parameter conversion failure: ${e.message}",
-          developerMessage = e.message,
+          userMessage = "Invalid request format, e.g. request is missing a required field or one of the fields has an invalid value",
+          developerMessage = developerMessage,
         ),
       )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/HmppsIncentivesApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/HmppsIncentivesApiExceptionHandler.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.ValidationException
 import org.slf4j.LoggerFactory
-import org.springframework.beans.TypeMismatchException
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.FORBIDDEN
@@ -233,20 +232,6 @@ class HmppsIncentivesApiExceptionHandler {
           status = BAD_REQUEST,
           userMessage = "Invalid request format, e.g. request is missing a required field or one of the fields has an invalid value",
           developerMessage = developerMessage,
-        ),
-      )
-  }
-
-  @ExceptionHandler(TypeMismatchException::class)
-  fun handleTypeMismatchException(e: TypeMismatchException): ResponseEntity<ErrorResponse> {
-    log.error("Parameter conversion exception: {}", e.message)
-    return ResponseEntity
-      .status(BAD_REQUEST)
-      .body(
-        ErrorResponse(
-          status = BAD_REQUEST,
-          userMessage = "Parameter conversion failure: ${e.message}",
-          developerMessage = e.message,
         ),
       )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/HmppsIncentivesApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/HmppsIncentivesApiExceptionHandler.kt
@@ -53,8 +53,10 @@ class HmppsIncentivesApiExceptionHandler {
       )
   }
 
-  // Validation exceptions including `ParameterValidationException`
-  // thrown by `ensure` blocks when field validations fail
+  /**
+   * Validation exceptions including `ParameterValidationException`
+   * thrown by `ensure` blocks when field validations fail
+   */
   @ExceptionHandler(ValidationException::class)
   fun handleValidationException(e: ValidationException): ResponseEntity<ErrorResponse> {
     log.info("Validation exception: {}", e.message)
@@ -202,12 +204,14 @@ class HmppsIncentivesApiExceptionHandler {
       )
   }
 
-  // Exception thrown when the request body is missing a required field
-  // or provided value doesn't match valid enum values
-  //
-  // NOTE: This exception covers a number of possible bad inputs,
-  // e.g. missing fields, values of the wrong type, values not
-  // matching the ones available in an enum, etc...
+  /**
+   * Exception thrown when the request body is missing a required field
+   * or provided value doesn't match valid enum values
+   *
+   * NOTE: This exception covers a number of possible bad inputs,
+   * e.g. missing fields, values of the wrong type, values not
+   * matching the ones available in an enum, etc...
+   */
   @ExceptionHandler(ServerWebInputException::class)
   fun handleServerWebInputException(e: ServerWebInputException): ResponseEntity<ErrorResponse> {
     val developerMessage = "Invalid request format: ${e.cause}"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepReviewsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IepReviewsResourceTest.kt
@@ -5,8 +5,10 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IepReview
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
+import uk.gov.justice.digital.hmpps.incentivesapi.helper.expectErrorResponse
 import uk.gov.justice.digital.hmpps.incentivesapi.integration.IncentiveLevelResourceTestBase
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.PrisonerIepLevelRepository
 import java.time.LocalDate.now
@@ -46,7 +48,7 @@ class IepReviewsResourceTest : IncentiveLevelResourceTestBase() {
     webTestClient.get().uri("/iep/reviews/booking/undefined")
       .headers(setAuthorisation())
       .exchange()
-      .expectStatus().isBadRequest
+      .expectErrorResponse(HttpStatus.BAD_REQUEST, "Invalid request format")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResourceTest.kt
@@ -356,7 +356,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .header("Content-Type", "application/json")
         .bodyValue(body)
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Parameter conversion failure")
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Invalid request format")
 
       runBlocking {
         assertThat(incentiveLevelRepository.count()).isEqualTo(6)
@@ -749,7 +749,7 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         .header("Content-Type", "application/json")
         .bodyValue(body)
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Parameter conversion failure")
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Invalid request format")
 
       runBlocking {
         val incentiveLevel = incentiveLevelRepository.findById("STD")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResourceTest.kt
@@ -134,7 +134,7 @@ class IncentiveReviewsResourceTest : IncentiveLevelResourceTestBase() {
         .uri("/incentives-reviews/prison/MDI/location/MDI-1/level/STD?sort=PRISON")
         .headers(setAuthorisation(roles = listOf("ROLE_INCENTIVES")))
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Parameter conversion failure: 400 BAD_REQUEST \"Type mismatch.\"")
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Invalid request format")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/PrisonIncentiveLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/PrisonIncentiveLevelResourceTest.kt
@@ -447,7 +447,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           """,
         )
         .exchange()
-        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Parameter conversion failure")
+        .expectErrorResponse(HttpStatus.BAD_REQUEST, "Invalid request format")
 
       runBlocking {
         assertThat(prisonIncentiveLevelRepository.count()).isZero


### PR DESCRIPTION
NOTE: There is no "bubbling up" of exceptions problem AFAICT, the  `ServerWebInputException` is thrown automatically by Spring (when the request format is incorrect) and this is happening before any of our code (e.g. resource method) could be reached, therefore we don't have much control over this (but also it doesn't matter as the user gets a `400 Bad Request` anyway)

- improved handler for `ServerWebInputException`
  - document what's covering
  - response's user message is simpler and explain what could have been wrong in the request (before this could contain something like `Failed to read HTTP message` which is misleading and almost sound like a networking problem)
  - response's developer message and log includes the exception cause which contains useful information about what caused the problem (this would say something like "couldn't instantiate IncentiveLevel because code was missing and therefore null" which is very useful to understand the nature of the problem)
- removed handler for `TypeMismatchException`, this was added to handle things like `undefined` being passed as a path parameter for a long (e.g. `bookingId`)
  - however handler for `ServerWebInputException` cover this case (and others too) so this can be removed (and we can alway revert the commit if we realise there is still a need for this)
- document that `ValidationException` handler also covers `ParameterValidationException`
  - `ValidationException` is the parent class of `ParameterValidationException`, a custom exception thrown by `ensure {}` blocks when some field have invalid values