### PR TITLE
Improve error messaging and documentation regarding incentive level name length

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IncentiveLevel.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/IncentiveLevel.kt
@@ -10,7 +10,7 @@ data class IncentiveLevel(
   @Schema(description = "Unique id for the incentive level", example = "STD", minLength = 1, maxLength = 6)
   @JsonProperty(required = true)
   val code: String,
-  @Schema(description = "Name of the incentive level", example = "Standard", minLength = 1)
+  @Schema(description = "Name of the incentive level", example = "Standard", minLength = 1, maxLength = 30)
   @JsonProperty(required = true)
   val name: String,
   @Schema(description = "Indicates that the incentive level is active; inactive levels are historic levels no longer in use", example = "true", defaultValue = "true")
@@ -35,7 +35,7 @@ data class IncentiveLevel(
  * Update payload for IncentiveLevel
  */
 data class IncentiveLevelUpdate(
-  @Schema(description = "Name of the incentive level", example = "Standard", minLength = 1, required = false)
+  @Schema(description = "Name of the incentive level", example = "Standard", minLength = 1, maxLength = 30, required = false)
   val name: String? = null,
   @Schema(description = "Indicates that the incentive level is active; inactive levels are historic levels no longer in use", example = "true", required = false)
   val active: Boolean? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResource.kt
@@ -100,7 +100,7 @@ class IncentiveLevelResource(
   ): IncentiveLevel {
     ensure {
       ("code" to incentiveLevel.code).hasLengthAtLeast(1).hasLengthAtMost(6)
-      ("name" to incentiveLevel.name).hasLengthAtLeast(1)
+      ("name" to incentiveLevel.name).hasLengthAtLeast(1).hasLengthAtMost(30)
 
       if (!incentiveLevel.active && incentiveLevel.required) {
         errors.add("A level must be active if it is required")
@@ -284,7 +284,7 @@ class IncentiveLevelResource(
   ): IncentiveLevel {
     ensure {
       update.name?.let {
-        ("name" to it).hasLengthAtLeast(1)
+        ("name" to it).hasLengthAtLeast(1).hasLengthAtMost(30)
       }
 
       update.active?.let { active ->


### PR DESCRIPTION
The database already had a hard limit of 30 characters, but the modification endpoints would have previously returned a generic 500 server error instead of a meaningful response.