### PR TITLE
INC-1234: Send audit events for other levels changed when one becomes the new default

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonIncentiveLevelRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonIncentiveLevelRepository.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository
 
 import kotlinx.coroutines.flow.Flow
-import org.springframework.data.r2dbc.repository.Modifying
 import org.springframework.data.r2dbc.repository.Query
 import org.springframework.data.repository.kotlin.CoroutineCrudRepository
 import org.springframework.stereotype.Repository
@@ -74,16 +73,16 @@ interface PrisonIncentiveLevelRepository : CoroutineCrudRepository<PrisonIncenti
    * Sets levels other than the one privided to be non-default for this prison
    * Used to ensure there is only one default level for admission in a prison
    */
-  @Modifying
   @Query(
     // language=postgresql
     """
     UPDATE prison_incentive_level
     SET default_on_admission = FALSE
-    WHERE prison_id = :prisonId AND NOT level_code = :levelCode
+    WHERE prison_id = :prisonId AND NOT level_code = :levelCode AND default_on_admission IS TRUE
+    RETURNING level_code
     """,
   )
-  suspend fun setOtherLevelsNotDefaultForAdmission(prisonId: String, levelCode: String): Int?
+  fun setOtherLevelsNotDefaultForAdmission(prisonId: String, levelCode: String): Flow<String>
 
   /**
    * All prisons that have active level configurations, effectively a way to find all active prisons

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonIncentiveLevelRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonIncentiveLevelRepository.kt
@@ -71,6 +71,7 @@ interface PrisonIncentiveLevelRepository : CoroutineCrudRepository<PrisonIncenti
 
   /**
    * Sets levels other than the one privided to be non-default for this prison
+   * Returns the level codes that changed; there should only be zero or one if the data was consistent
    * Used to ensure there is only one default level for admission in a prison
    */
   @Query(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonIncentiveLevelService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonIncentiveLevelService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.incentivesapi.service
 
 import jakarta.validation.ValidationException
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
 import org.springframework.stereotype.Service
@@ -128,7 +129,7 @@ class PrisonIncentiveLevelService(
       }
 
       if (prisonIncentiveLevel.defaultOnAdmission) {
-        prisonIncentiveLevelRepository.setOtherLevelsNotDefaultForAdmission(prisonId, levelCode)
+        prisonIncentiveLevelRepository.setOtherLevelsNotDefaultForAdmission(prisonId, levelCode).collect()
       } else {
         val currentDefaultLevelCode =
           prisonIncentiveLevelRepository.findFirstByPrisonIdAndActiveIsTrueAndDefaultIsTrue(prisonId)?.levelCode

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonIncentiveLevelRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/jpa/repository/PrisonIncentiveLevelRepositoryTest.kt
@@ -242,6 +242,17 @@ class PrisonIncentiveLevelRepositoryTest : TestBase() {
   }
 
   @Test
+  fun `sets other levels to be non-default`(): Unit = runBlocking {
+    generateDefaultData()
+
+    var previouslyDefaultLevelCode = repository.setOtherLevelsNotDefaultForAdmission("MDI", "ENH").toSet()
+    assertThat(previouslyDefaultLevelCode).isEqualTo(setOf("STD"))
+
+    previouslyDefaultLevelCode = repository.setOtherLevelsNotDefaultForAdmission("MDI", "ENH").toSet()
+    assertThat(previouslyDefaultLevelCode).isEqualTo(emptySet<String>())
+  }
+
+  @Test
   fun `find prisons that have active levels`(): Unit = runBlocking {
     generateDefaultData()
     // Generate inactive prisons that will not be returned:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveLevelResourceTest.kt
@@ -237,6 +237,10 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
       val domainEvents = getPublishedDomainEvents()
       val auditMessages = getSentAuditMessages()
 
+      val expectedEventCount = 3
+      assertThat(domainEvents).hasSize(expectedEventCount)
+      assertThat(auditMessages).hasSize(expectedEventCount)
+
       val expectedIncentiveLevelCreateCount = 1
       assertThat(domainEvents.count { it.eventType == "incentives.level.changed" }).isEqualTo(expectedIncentiveLevelCreateCount)
       assertThat(auditMessages.count { it.what == "INCENTIVE_LEVEL_ADDED" }).isEqualTo(expectedIncentiveLevelCreateCount)
@@ -659,6 +663,10 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
       val domainEvents = getPublishedDomainEvents()
       val auditMessages = getSentAuditMessages()
 
+      val expectedEventCount = 3
+      assertThat(domainEvents).hasSize(expectedEventCount)
+      assertThat(auditMessages).hasSize(expectedEventCount)
+
       val expectedIncentiveLevelCreateCount = 1
       assertThat(domainEvents.count { it.eventType == "incentives.level.changed" }).isEqualTo(expectedIncentiveLevelCreateCount)
       assertThat(auditMessages.count { it.what == "INCENTIVE_LEVEL_UPDATED" }).isEqualTo(expectedIncentiveLevelCreateCount)
@@ -915,6 +923,10 @@ class IncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
 
       val domainEvents = getPublishedDomainEvents()
       val auditMessages = getSentAuditMessages()
+
+      val expectedEventCount = 3
+      assertThat(domainEvents).hasSize(expectedEventCount)
+      assertThat(auditMessages).hasSize(expectedEventCount)
 
       val expectedIncentiveLevelCreateCount = 1
       assertThat(domainEvents.count { it.eventType == "incentives.level.changed" }).isEqualTo(expectedIncentiveLevelCreateCount)


### PR DESCRIPTION
Previously, only the level that was being directly edited had events published for the change. Now, if another level becomes non-default-for-admissions, it will also publish audit events.