### PR TITLE
INC-1265: Add api endpoint that deactivates all incentive levels in a prison

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/PrisonIncentiveLevelResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/PrisonIncentiveLevelResource.kt
@@ -243,6 +243,44 @@ class PrisonIncentiveLevelResource(
       ?: throw NoDataWithCodeFoundException("incentive level", levelCode)
   }
 
+  @DeleteMapping("{prisonId}")
+  @PreAuthorize("hasRole('MAINTAIN_PRISON_IEP_LEVELS') and hasAuthority('SCOPE_write')")
+  @Operation(
+    summary = "Deactivate all incentive levels for a prison",
+    description = "This can be used when a prison closes. " +
+      "Deactivating a level is only possible if there are no prisoners currently on it." +
+      "\n\nRequires role: MAINTAIN_PRISON_IEP_LEVELS with write scope" +
+      "\n\nRaises HMPPS domain event: \"incentives.prison-level.changed\"",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Prison incentive levels deactivated",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "There are prisoners on some incentive level at this prison",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Incorrect permissions to use this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  suspend fun deactivateAllPrisonIncentiveLevels(
+    @Schema(description = "Prison id", example = "MDI", required = true, minLength = 3, maxLength = 6)
+    @PathVariable
+    prisonId: String,
+  ): List<PrisonIncentiveLevel> {
+    return prisonIncentiveLevelService.deactivateAllPrisonIncentiveLevels(prisonId)
+  }
+
   @DeleteMapping("{prisonId}/level/{levelCode}")
   @PreAuthorize("hasRole('MAINTAIN_PRISON_IEP_LEVELS') and hasAuthority('SCOPE_write')")
   @Operation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonIncentiveLevelAuditedService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonIncentiveLevelAuditedService.kt
@@ -38,6 +38,13 @@ class PrisonIncentiveLevelAuditedService(
       }
   }
 
+  override suspend fun deactivateAllPrisonIncentiveLevels(prisonId: String): List<PrisonIncentiveLevelDTO> {
+    return super.deactivateAllPrisonIncentiveLevels(prisonId)
+      .onEach {
+        auditAndPublishPrisonLevelChangeEvent(it)
+      }
+  }
+
   private suspend fun auditAndPublishPrisonLevelChangeEvent(prisonIncentiveLevel: PrisonIncentiveLevelDTO) {
     auditService.sendMessage(
       AuditType.PRISON_INCENTIVE_LEVEL_UPDATED,


### PR DESCRIPTION
This is needed when a prison is closed and to tidy up ancient prison incentive level information from long-closed prisons.