### PR TITLE
INC-1269: Increase test coverage for the case of a prison being re-activated

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonIncentiveLevelService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonIncentiveLevelService.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.incentivesapi.service
 
 import jakarta.validation.ValidationException
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
 import org.springframework.stereotype.Service

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/PrisonIncentiveLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/PrisonIncentiveLevelResourceTest.kt
@@ -906,6 +906,84 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
       }
 
       @Test
+      fun `partially updates prison incentive levels if all being activated one-by-one`() {
+        makePrisonIncentiveLevel("MDI", "BAS")
+        makePrisonIncentiveLevel("MDI", "STD") // Standard was the default for admission before deactivation
+        makePrisonIncentiveLevel("MDI", "ENH")
+        runBlocking {
+          prisonIncentiveLevelRepository.saveAll(
+            prisonIncentiveLevelRepository.findAllByPrisonId("MDI").map {
+              it.copy(active = false)
+            }.toList(),
+          ).collect()
+        }
+
+        // NB: the previously-default level must be activated first to conform to business rules
+        for (levelCode in listOf("STD", "BAS", "ENH")) {
+          webTestClient.patch()
+            .uri("/incentive/prison-levels/MDI/level/$levelCode")
+            .withLocalAuthorisation()
+            .header("Content-Type", "application/json")
+            .bodyValue(
+              // language=json
+              """
+              {
+                "active": true
+              }
+              """,
+            )
+            .exchange()
+            .expectStatus().isOk
+        }
+
+        runBlocking {
+          val prisonIncentiveLevels = prisonIncentiveLevelRepository.findAll().toList()
+          assertThat(prisonIncentiveLevels).allMatch { it.active }
+          val defaultLevelCodes = prisonIncentiveLevels.filter { it.defaultOnAdmission }.map { it.levelCode }
+          assertThat(defaultLevelCodes).isEqualTo(listOf("STD"))
+        }
+      }
+
+      @Test
+      fun `partially updates prison incentive levels if all being activated one-by-one when the previous default was not Standard`() {
+        makePrisonIncentiveLevel("MDI", "BAS")
+        makePrisonIncentiveLevel("MDI", "STD")
+        makePrisonIncentiveLevel("MDI", "ENH") // Enhanced was the default for admission before deactivation
+        runBlocking {
+          prisonIncentiveLevelRepository.saveAll(
+            prisonIncentiveLevelRepository.findAllByPrisonId("MDI").map {
+              it.copy(active = false, defaultOnAdmission = it.levelCode == "ENH")
+            }.toList(),
+          ).collect()
+        }
+
+        // NB: the previously-default level must be activated first to conform to business rules
+        for (levelCode in listOf("ENH", "BAS", "STD")) {
+          webTestClient.patch()
+            .uri("/incentive/prison-levels/MDI/level/$levelCode")
+            .withLocalAuthorisation()
+            .header("Content-Type", "application/json")
+            .bodyValue(
+              // language=json
+              """
+              {
+                "active": true
+              }
+              """,
+            )
+            .exchange()
+            .expectStatus().isOk
+        }
+
+        runBlocking {
+          val prisonIncentiveLevels = prisonIncentiveLevelRepository.findAll().toList()
+          assertThat(prisonIncentiveLevels).allMatch { it.active }
+          val defaultLevelCodes = prisonIncentiveLevels.filter { it.defaultOnAdmission }.map { it.levelCode }
+          assertThat(defaultLevelCodes).isEqualTo(listOf("ENH"))
+        }
+      }
+
+      @Test
       fun `requires correct role to partially update a prison incentive level`() {
         makePrisonIncentiveLevel("BAI", "BAS")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/PrisonIncentiveLevelResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/PrisonIncentiveLevelResourceTest.kt
@@ -758,7 +758,10 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
         assertNoDomainEventSent()
         assertNoAuditMessageSent()
       }
+    }
 
+    @Nested
+    inner class `partially update level` {
       @Test
       fun `partially updates a prison incentive level when one exists`() {
         makePrisonIncentiveLevel("BAI", "BAS")
@@ -901,10 +904,7 @@ class PrisonIncentiveLevelResourceTest : IncentiveLevelResourceTestBase() {
           ),
         )
       }
-    }
 
-    @Nested
-    inner class `partially update level` {
       @Test
       fun `requires correct role to partially update a prison incentive level`() {
         makePrisonIncentiveLevel("BAI", "BAS")


### PR DESCRIPTION
When a prison is closed, it's prison incentive levels should be deactivated. This tests the situation where the same prison is later reopened.
NB: the first level that is activated must be a default according to business rules, but furthermore it must also have been the level that was _previously_ the default.

If a prison had these levels:
• BAS active
• STD active
• ENH active and default
and is closed, then it ends up with:
• BAS inactive
• STD inactive
• ENH inactive and default

To reactivate the whole prison the actions needed are:

1) activate ENH resulting in 
• BAS inactive
• STD inactive
• ENH active and default

2) activate all other required levels (BAS & STD) resulting in 
• BAS active
• STD active
• ENH active and default

only _then_ can the default level be changed if necessary.

Changing the default level for a prison when the current default is inactive is not always possible. Changing the default level necessarily requires a side effect of making the previous level no longer default. If that previous level was globally required, it will restrict updating it as inactive.

Relates to [ui#519](https://github.com/ministryofjustice/hmpps-incentives-ui/pull/519) which will now try activating the previously default level first.