### PR TITLE
INC-1276: Add api endpoint to reset levels in a prison

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/PrisonIncentiveLevelResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/PrisonIncentiveLevelResource.kt
@@ -243,15 +243,53 @@ class PrisonIncentiveLevelResource(
       ?: throw NoDataWithCodeFoundException("incentive level", levelCode)
   }
 
+  @PutMapping("{prisonId}/reset")
+  @PreAuthorize("hasRole('MAINTAIN_PRISON_IEP_LEVELS') and hasAuthority('SCOPE_write')")
+  @Operation(
+    summary = "Reset all incentive levels for a prison",
+    description = "Activates the required set of levels, ensuring that Standard is the default level for admission. " +
+      "This can be used when a new prison is opened. " +
+      "Any levels that are already active will remain active and associated information remains unchanged. " +
+      "Returns all incentive levels in this prison including those that were already active. " +
+      "\n\nRequires role: MAINTAIN_PRISON_IEP_LEVELS with write scope" +
+      "\n\nRaises HMPPS domain events: \"incentives.prison-level.changed\"",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Prison incentive levels reset",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Incorrect permissions to use this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  suspend fun resetPrisonIncentiveLevels(
+    @Schema(description = "Prison id", example = "MDI", required = true, minLength = 3, maxLength = 6)
+    @PathVariable
+    prisonId: String,
+    @RequestBody
+    body: Unit, // no payload is needed
+  ): List<PrisonIncentiveLevel> {
+    prisonIncentiveLevelService.resetPrisonIncentiveLevels(prisonId)
+    return prisonIncentiveLevelService.getAllPrisonIncentiveLevels(prisonId)
+  }
+
   @DeleteMapping("{prisonId}")
   @PreAuthorize("hasRole('MAINTAIN_PRISON_IEP_LEVELS') and hasAuthority('SCOPE_write')")
   @Operation(
     summary = "Deactivate all incentive levels for a prison",
     description = "This can be used when a prison closes. " +
-      "Returns all incentive levels in this prison include those that were already inactive. " +
+      "Returns all incentive levels in this prison including those that were already inactive. " +
       "Deactivating a level is only possible if there are no prisoners currently on it." +
       "\n\nRequires role: MAINTAIN_PRISON_IEP_LEVELS with write scope" +
-      "\n\nRaises HMPPS domain event: \"incentives.prison-level.changed\"",
+      "\n\nRaises HMPPS domain events: \"incentives.prison-level.changed\"",
     responses = [
       ApiResponse(
         responseCode = "200",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonIncentiveLevelService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonIncentiveLevelService.kt
@@ -228,7 +228,7 @@ class PrisonIncentiveLevelService(
     prisonId: String,
     levelCode: String,
   ): PrisonIncentiveLevel {
-    val fallbackSpendLimits = spendLimitPolicy.getOrDefault(levelCode, spendLimitPolicy["ENH"]!!)
+    val fallback = prisonIncentiveLevelPolicies.getOrDefault(levelCode, prisonIncentiveLevelPolicies["ENH"]!!)
 
     return PrisonIncentiveLevel(
       levelCode = levelCode,
@@ -237,16 +237,18 @@ class PrisonIncentiveLevelService(
       defaultOnAdmission = defaultOnAdmission ?: false,
 
       remandTransferLimitInPence = remandTransferLimitInPence
-        ?: fallbackSpendLimits.remandTransferLimitInPence,
+        ?: fallback.remandTransferLimitInPence,
       remandSpendLimitInPence = remandSpendLimitInPence
-        ?: fallbackSpendLimits.remandSpendLimitInPence,
+        ?: fallback.remandSpendLimitInPence,
       convictedTransferLimitInPence = convictedTransferLimitInPence
-        ?: fallbackSpendLimits.convictedTransferLimitInPence,
+        ?: fallback.convictedTransferLimitInPence,
       convictedSpendLimitInPence = convictedSpendLimitInPence
-        ?: fallbackSpendLimits.convictedSpendLimitInPence,
+        ?: fallback.convictedSpendLimitInPence,
 
-      visitOrders = visitOrders ?: 2,
-      privilegedVisitOrders = privilegedVisitOrders ?: 1,
+      visitOrders = visitOrders
+        ?: fallback.visitOrders,
+      privilegedVisitOrders = privilegedVisitOrders
+        ?: fallback.privilegedVisitOrders,
 
       new = true,
       whenUpdated = LocalDateTime.now(clock),
@@ -257,15 +259,18 @@ class PrisonIncentiveLevelService(
     map { it.toDTO() }.toList()
 }
 
-private data class SpendLimits(
+private data class Policy(
   val remandTransferLimitInPence: Int,
   val remandSpendLimitInPence: Int,
   val convictedTransferLimitInPence: Int,
   val convictedSpendLimitInPence: Int,
+
+  val visitOrders: Int,
+  val privilegedVisitOrders: Int,
 )
 
-private val spendLimitPolicy = mapOf(
-  "BAS" to SpendLimits(27_50, 275_00, 5_50, 55_00),
-  "STD" to SpendLimits(60_50, 605_00, 19_80, 198_00),
-  "ENH" to SpendLimits(66_00, 660_00, 33_00, 330_00),
+private val prisonIncentiveLevelPolicies = mapOf(
+  "BAS" to Policy(27_50, 275_00, 5_50, 55_00, 2, 1),
+  "STD" to Policy(60_50, 605_00, 19_80, 198_00, 2, 1),
+  "ENH" to Policy(66_00, 660_00, 33_00, 330_00, 2, 1),
 )


### PR DESCRIPTION
This is useful when setting up a new prison. If in future there are domain events raised when a prison is created, incentives-api could listen for them and automatically set up the prison.

It can also be used to ensure that a prison has the required set of levels active and that Standard is the default for admission.