### PR TITLE
Fix location lookup when retrieving reviews

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsService.kt
@@ -55,7 +55,7 @@ class IncentiveReviewsService(
     }
     val deferredLocationDescription = async {
       try {
-        prisonApiService.getLocation(cellLocationPrefix).description
+        prisonApiService.getLocation(cellLocationPrefix.removeSuffix("-")).description
       } catch (e: NotFound) {
         "Unknown location"
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsServiceTest.kt
@@ -142,7 +142,7 @@ class IncentiveReviewsServiceTest {
         prisonId = "MDI",
       ),
     )
-    whenever(prisonApiService.getLocation(any())).thenReturnLocation("MDI-2-1")
+    whenever(prisonApiService.getLocation(any())).thenReturnLocation("MDI-2")
     whenever(offenderSearchService.getOffendersAtLocation(any(), any())).thenReturn(offenders)
     val nextReviewDatesMap = mapOf(
       110001L to LocalDate.now(clock).plusYears(1),
@@ -150,9 +150,10 @@ class IncentiveReviewsServiceTest {
     )
     whenever(nextReviewDateGetterService.getMany(offenders)).thenReturn(nextReviewDatesMap)
 
-    val reviews = incentiveReviewsService.reviews("MDI", "MDI-2-1", "STD")
+    val reviews = incentiveReviewsService.reviews("MDI", "MDI-2-", "STD")
 
-    verify(offenderSearchService, times(1)).getOffendersAtLocation(any(), eq("MDI-2-1"))
+    verify(offenderSearchService, times(1)).getOffendersAtLocation(any(), eq("MDI-2-"))
+    verify(prisonApiService, times(1)).getLocation(eq("MDI-2"))
     assertThat(reviews.locationDescription).isEqualTo("A houseblock")
     val reviewCount = reviews.levels.find { level -> level.levelCode == "STD" }?.reviewCount
     assertThat(reviewCount).isEqualTo(2)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/util/ErrorCodeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/util/ErrorCodeTest.kt
@@ -7,7 +7,7 @@ import uk.gov.justice.digital.hmpps.incentivesapi.config.ErrorCode
 class ErrorCodeTest {
   @Test
   fun `error codes should all be unique`() {
-    val errorCodes = ErrorCode.values()
+    val errorCodes = ErrorCode.entries
     val uniqueErrorCodes = errorCodes.map { it.errorCode }.toSet().size
     assertThat(errorCodes).hasSize(uniqueErrorCodes)
   }


### PR DESCRIPTION
We want to be able to look up reviews for a given location by using a prefix like "MDI-1-" (including a trailing hyphen) so that other locations aren't accidentally included. Using a prefix of "MDI-1" (no trailing hyphen) would also match locations starting with "MDI-10" and that's wrong.

However, when looking up the details of a location in prison-api, trailing hyphens will not be valid so need to be removed.