### PR TITLE
INC-1235: Stop non-prod instances during non-working hours

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -4,6 +4,9 @@
 generic-service:
   replicaCount: 2
 
+  scheduledDowntime:
+    enabled: true
+
   ingress:
     host: incentives-api-dev.hmpps.service.justice.gov.uk
   allowlist: null

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -4,6 +4,9 @@
 generic-service:
   replicaCount: 2
 
+  scheduledDowntime:
+    enabled: true
+
   ingress:
     host: incentives-api-preprod.hmpps.service.justice.gov.uk
 


### PR DESCRIPTION
Enable 'scheduled downtime' feature of generic-service helm chart: https://github.com/ministryofjustice/hmpps-helm-charts/tree/main/charts/generic-service#scheduled-downtime

> To enable this feature, you first need to add a `scheduled-downtime-serviceaccount`
> Service Account to your namespace, with permissions to scale your deployment.

The required kubernetes `ServiceAccount` is already there:
- `dev`: https://github.com/ministryofjustice/cloud-platform-environments/blob/b534875bb2347de40543ceabc3d5ce102b6514fd/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-dev/resources/scheduled-downtime.tf
- `preprod`: https://github.com/ministryofjustice/cloud-platform-environments/blob/b534875bb2347de40543ceabc3d5ce102b6514fd/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-incentives-preprod/resources/scheduled-downtime.tf

```sh
$ kubectl -n hmpps-incentives-dev get sa scheduled-downtime-serviceaccount
NAME                                SECRETS   AGE
scheduled-downtime-serviceaccount   2         190d
```

```sh
$ kubectl -n hmpps-incentives-preprod get sa scheduled-downtime-serviceaccount
NAME                                SECRETS   AGE
scheduled-downtime-serviceaccount   2         190d
```