### PR TITLE
Move `prod` and `preprod` to use the same shared IP address allow lists

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@7
+  hmpps: ministryofjustice/hmpps@7.5
 
 parameters:
   alerts-slack-channel:

--- a/helm_deploy/hmpps-incentives-api/values.yaml
+++ b/helm_deploy/hmpps-incentives-api/values.yaml
@@ -63,14 +63,10 @@ generic-service:
       HMPPS_SQS_QUEUES_INCENTIVES_DLQ_NAME: "sqs_queue_name"
 
   allowlist:
-    office: "217.33.148.210/32"
+    groups:
+      - internal
+
     health-kick: "35.177.252.195/32"
-    mojvpn: "81.134.202.29/32"
-    petty-france-wifi: "213.121.161.112/28"
-    global-protect: "35.176.93.186/32"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
 
 generic-prometheus-alerts:
   targetApplication: hmpps-incentives-api


### PR DESCRIPTION
… keeping `dev` unrestricted.

Don’t merge until [ui#649](https://github.com/ministryofjustice/hmpps-incentives-ui/pull/649) is tested.