### PR TITLE
Remove health-kick from allow list since it is now within Cloud Platform

### DIFF
--- a/helm_deploy/hmpps-incentives-api/values.yaml
+++ b/helm_deploy/hmpps-incentives-api/values.yaml
@@ -66,8 +66,6 @@ generic-service:
     groups:
       - internal
 
-    health-kick: "35.177.252.195/32"
-
 generic-prometheus-alerts:
   targetApplication: hmpps-incentives-api
   sqsAlertsOldestThreshold: 10


### PR DESCRIPTION
Ref: [hmpps-ip-allowlists#2](https://github.com/ministryofjustice/hmpps-ip-allowlists/pull/2)