### PR TITLE
Avoid calling `runBlocking` from within coroutines as recommended in documentation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NextReviewDateUpdaterService.kt
@@ -1,8 +1,6 @@
 package uk.gov.justice.digital.hmpps.incentivesapi.service
 
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.IncentiveReview
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.NextReviewDate
@@ -93,24 +91,22 @@ class NextReviewDateUpdaterService(
     return nextReviewDatesAfterUpdate
   }
 
-  private suspend fun publishDomainEvents(
+  private fun publishDomainEvents(
     bookingIdsChanged: List<Long>,
     offendersMap: Map<Long, PrisonerInfoForNextReviewDate>,
     nextReviewDatesMap: Map<Long, LocalDate>,
-  ) = runBlocking {
+  ) {
     bookingIdsChanged.forEach { bookingId ->
-      launch {
-        snsService.publishDomainEvent(
-          eventType = IncentivesDomainEventType.PRISONER_NEXT_REVIEW_DATE_CHANGED,
-          description = "A prisoner's next incentive review date has changed",
-          occurredAt = LocalDateTime.now(clock),
-          additionalInformation = AdditionalInformation(
-            id = bookingId,
-            nomsNumber = offendersMap[bookingId]!!.prisonerNumber,
-            nextReviewDate = nextReviewDatesMap[bookingId],
-          ),
-        )
-      }
+      snsService.publishDomainEvent(
+        eventType = IncentivesDomainEventType.PRISONER_NEXT_REVIEW_DATE_CHANGED,
+        description = "A prisoner's next incentive review date has changed",
+        occurredAt = LocalDateTime.now(clock),
+        additionalInformation = AdditionalInformation(
+          id = bookingId,
+          nomsNumber = offendersMap[bookingId]!!.prisonerNumber,
+          nextReviewDate = nextReviewDatesMap[bookingId],
+        ),
+      )
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/task/UpdateKpis.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/task/UpdateKpis.kt
@@ -28,13 +28,13 @@ class UpdateKpis(
     lockAtLeastFor = defaultLockAtLeastFor,
     lockAtMostFor = defaultLockAtMostFor,
   )
-  fun updateKpis() {
+  fun updateKpis(): Unit = runBlocking {
     val day = LocalDate.now()
 
-    val kpiExists = runBlocking { kpiRepository.existsById(day) }
+    val kpiExists = kpiRepository.existsById(day)
     if (kpiExists) {
       LOG.debug("KPI for $day already exists, skipping...")
-      return
+      return@runBlocking
     }
 
     LOG.debug("Updating KPIs for $day...")
@@ -48,16 +48,14 @@ class UpdateKpis(
     LOG.info("KPIs for $day. Prisoners overdue = $numberOfPrisonersOverdue")
 
     // Store the result in the DB table
-    runBlocking {
-      kpiRepository.save(
-        Kpi(
-          day = day,
-          overdueReviews = numberOfPrisonersOverdue,
-          previousMonthReviewsConducted = reviewsConductedPrisonersReviewed.reviewsConducted,
-          previousMonthPrisonersReviewed = reviewsConductedPrisonersReviewed.prisonersReviewed,
-        ),
-      )
-    }
+    kpiRepository.save(
+      Kpi(
+        day = day,
+        overdueReviews = numberOfPrisonersOverdue,
+        previousMonthReviewsConducted = reviewsConductedPrisonersReviewed.reviewsConducted,
+        previousMonthPrisonersReviewed = reviewsConductedPrisonersReviewed.prisonersReviewed,
+      ),
+    )
 
     LOG.debug("KPIs updated for $day")
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/KpiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/KpiServiceTest.kt
@@ -129,7 +129,7 @@ class KpiServiceTest {
     }
 
     @Test
-    fun `getNumberOfPrisonersOverdue() returns the correct number of overdue prisoners`() {
+    fun `getNumberOfPrisonersOverdue() returns the correct number of overdue prisoners`(): Unit = runBlocking {
       assertThat(kpiService.getNumberOfPrisonersOverdue()).isEqualTo(2)
     }
   }


### PR DESCRIPTION
Ref: https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/run-blocking.html

`runBlocking` blocks the current thread, but since coroutines share a small pool of threads (perhaps even 1 thread??) it means that this one cannot be used to progress any other coroutines. This could feasibly lead to a deadlock or, at the very least, defeats the purpose of coroutines.