### PR TITLE
INC-1356 Update UUID for queue names and simplify queue tests

### DIFF
--- a/src/main/resources/application-localstack.yml
+++ b/src/main/resources/application-localstack.yml
@@ -5,10 +5,10 @@ hmpps.sqs:
     audit:
       queueName: ${random.uuid}
     incentives:
-      queueName: incentives-event-queue
-      dlqName: incentives-event-dlq
+      queueName: ${random.uuid}
+      dlqName: ${random.uuid}
       subscribeTopicId: domainevents
       subscribeFilter: '{"eventType":[ "prison-offender-events.prisoner.merged", "prisoner-offender-search.prisoner.received", "prisoner-offender-search.prisoner.alerts-updated" ] }'
   topics:
     domainevents:
-      arn: arn:aws:sns:eu-west-2:000000000000:11111111-2222-3333-4444-555555555555
+      arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/SqsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/SqsIntegrationTestBase.kt
@@ -42,6 +42,7 @@ class SqsIntegrationTestBase : IntegrationTestBase() {
 
   protected val auditQueue by lazy { hmppsQueueService.findByQueueId("audit") as HmppsQueue }
   protected val incentivesQueue by lazy { hmppsQueueService.findByQueueId("incentives") as HmppsQueue }
+  protected val testDomainEventQueue by lazy { hmppsQueueService.findByQueueId("test") as HmppsQueue }
 
   fun HmppsSqsProperties.domaineventsTopicConfig() =
     topics["domainevents"]
@@ -51,8 +52,10 @@ class SqsIntegrationTestBase : IntegrationTestBase() {
   fun cleanQueue() {
     auditQueue.sqsClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(auditQueue.queueUrl).build())
     incentivesQueue.sqsClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(incentivesQueue.queueUrl).build())
+    testDomainEventQueue.sqsClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(testDomainEventQueue.queueUrl).build())
     await untilCallTo { auditQueue.sqsClient.countMessagesOnQueue(auditQueue.queueUrl).get() } matches { it == 0 }
     await untilCallTo { incentivesQueue.sqsClient.countMessagesOnQueue(incentivesQueue.queueUrl).get() } matches { it == 0 }
+    await untilCallTo { testDomainEventQueue.sqsClient.countMessagesOnQueue(testDomainEventQueue.queueUrl).get() } matches { it == 0 }
   }
 
   companion object {

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -41,13 +41,17 @@ hmpps.sqs:
     audit:
       queueName: ${random.uuid}
     incentives:
-      queueName: incentives-event-queue
-      dlqName: incentives-event-dlq
+      queueName: ${random.uuid}
+      dlqName: ${random.uuid}
       subscribeTopicId: domainevents
       subscribeFilter: '{"eventType":[ "prison-offender-events.prisoner.merged", "prisoner-offender-search.prisoner.received", "prisoner-offender-search.prisoner.alerts-updated" ] }'
+    test:
+      queueName: ${random.uuid}
+      dlqName: ${random.uuid}
+      subscribeTopicId: domainevents
+      subscribeFilter: '{"eventType":[ {"prefix": "incentives."} ] }'
+
   topics:
     domainevents:
-      arn: arn:aws:sns:eu-west-2:000000000000:11111111-2222-3333-4444-555555555555
+      arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}
 
-feature:
-  incentives-reference-data-source-of-truth: true


### PR DESCRIPTION
This update changes hard-coded queue names and ARNs in YAML files to generated UUIDs, improving flexibility for testing and development. Furthermore, the complexity of tests in IncentiveLevelResourceTestBase has been reduced by removing extra setup steps for domain events subscription, thanks to adding "test" queue in the SqsIntegrationTestBase and the application-test.yml files.