### PR TITLE
INC-1356 Update nginx ingress annotation in helm values.yaml

### DIFF
--- a/helm_deploy/hmpps-incentives-api/values.yaml
+++ b/helm_deploy/hmpps-incentives-api/values.yaml
@@ -17,7 +17,7 @@ generic-service:
     host: app-hostname.local    # override per environment
     tlsSecretName: hmpps-incentives-api-cert
     annotations:
-      nginx.ingress.kubernetes.io/configuration-snippet: |
+      nginx.ingress.kubernetes.io/server-snippet: |
         server_tokens off;
         location /queue-admin/retry-all-dlqs {
           deny all;


### PR DESCRIPTION


The nginx ingress annotation in the helm_deploy/hmpps-incentives-api/values.yaml file has been updated. The previous 'configuration-snippet' key has been replaced with 'server-snippet', reflecting a change in the server tokens and access denial settings for specific locations.
