### PR TITLE
INC-1335: Use same version of java for Veracode scanning as required by HMPPS plugins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,6 +206,7 @@ workflows:
           context:
             - hmpps-common-vars
       - hmpps/veracode_pipeline_scan:
+          jdk_tag: << pipeline.parameters.java-version >>
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:
             - hmpps-common-vars


### PR DESCRIPTION
Ref [hmpps-template-kotlin#209](https://github.com/ministryofjustice/hmpps-template-kotlin/pull/209)