### PR TITLE
INC-1371 (part 2): Get location description from Locations API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,16 @@ services:
     volumes:
       - ./prisoner-search-data:/home/wiremock
 
+  locations-inside-prison:
+    image: wiremock/wiremock:2.35.0
+    networks:
+      - hmpps
+    container_name: locations-inside-prison
+    ports:
+      - "8085:8080"
+    volumes:
+      - ./locations-inside-prison-data:/home/wiremock
+
   prison-api:
     image: quay.io/hmpps/prison-api:latest
     networks:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -14,6 +14,7 @@ generic-service:
     API_BASE_URL_OAUTH: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
     API_BASE_URL_PRISON: https://prison-api-dev.prison.service.justice.gov.uk
     API_BASE_URL_OFFENDER_SEARCH: https://prisoner-search-dev.prison.service.justice.gov.uk
+    API_BASE_URL_LOCATIONS: https://locations-inside-prison-api-dev.hmpps.service.justice.gov.uk
     # First weekday of the month at 10:00am - Offender Search API is turned off during non-working hours in dev/preprod
     TASK_UPDATE_KPIS_CRON: "0 0 10 1W * *"
 

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -12,6 +12,7 @@ generic-service:
     API_BASE_URL_OAUTH: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
     API_BASE_URL_PRISON: https://prison-api-preprod.prison.service.justice.gov.uk
     API_BASE_URL_OFFENDER_SEARCH: https://prisoner-search-preprod.prison.service.justice.gov.uk
+    API_BASE_URL_LOCATIONS: https://locations-inside-prison-api-preprod.hmpps.service.justice.gov.uk
     # First weekday of the month at 10:00am - Offender Search API is turned off during non-working hours in dev/preprod
     TASK_UPDATE_KPIS_CRON: "0 0 10 1W * *"
 

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -7,6 +7,7 @@ generic-service:
     API_BASE_URL_OAUTH: https://sign-in.hmpps.service.justice.gov.uk/auth
     API_BASE_URL_PRISON: https://prison-api.prison.service.justice.gov.uk
     API_BASE_URL_OFFENDER_SEARCH: https://prisoner-search.prison.service.justice.gov.uk
+    API_BASE_URL_LOCATIONS: https://locations-inside-prison-api.hmpps.service.justice.gov.uk
 
   postgresDatabaseRestore:
     enabled: true

--- a/locations-inside-prison-data/mappings/health.json
+++ b/locations-inside-prison-data/mappings/health.json
@@ -1,0 +1,15 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/health/ping"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "status": "UP"
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/locations-inside-prison-data/mappings/location-MDI-1.json
+++ b/locations-inside-prison-data/mappings/location-MDI-1.json
@@ -1,0 +1,19 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/locations/key/MDI-1"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "id": "2475f250-434a-4257-afe7-b911f1773a4d",
+      "key": "MDI-1",
+      "prisonId": "MDI",
+      "localName": "Houseblock 1",
+      "pathHierarchy": "MDI-1"
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/locations-inside-prison-data/mappings/location-not-found.json
+++ b/locations-inside-prison-data/mappings/location-not-found.json
@@ -1,0 +1,14 @@
+{
+  "priority": 10,
+  "request": {
+    "method": "GET",
+    "urlPattern": "/locations/key/.*"
+  },
+  "response": {
+    "status": 404,
+    "jsonBody": { "status": "NOT_FOUND", "message": "Location not found" },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/WebClientConfiguration.kt
@@ -17,6 +17,7 @@ class WebClientConfiguration(
   @Value("\${api.base.url.oauth}") val authBaseUri: String,
   @Value("\${api.base.url.prison}") private val prisonRootUri: String,
   @Value("\${api.base.url.offender-search}") private val offenderSearchUri: String,
+  @Value("\${api.base.url.locations}") private val locationsUri: String,
   @Value("\${api.timeout:2m}") val healthTimeout: Duration,
 ) {
 
@@ -39,6 +40,13 @@ class WebClientConfiguration(
 
   @Bean
   fun prisonHealthWebClient(builder: WebClient.Builder): WebClient = builder.reactiveHealthWebClient(prisonRootUri, healthTimeout)
+
+  @Bean
+  fun locationsWebClient(reactiveAuthorizedClientManager: ReactiveOAuth2AuthorizedClientManager, builder: WebClient.Builder): WebClient =
+    builder.reactiveAuthorisedWebClient(reactiveAuthorizedClientManager, registrationId = SYSTEM_USERNAME, url = locationsUri, healthTimeout)
+
+  @Bean
+  fun locationsHealthWebClient(builder: WebClient.Builder): WebClient = builder.reactiveHealthWebClient(locationsUri, healthTimeout)
 
   @Bean
   fun offenderSearchHealthWebClient(builder: WebClient.Builder): WebClient = builder.reactiveHealthWebClient(offenderSearchUri, healthTimeout)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/prisonapi/PrisonAPI.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/prisonapi/PrisonAPI.kt
@@ -63,11 +63,3 @@ data class BookingFromDatePair(
   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
   val fromDate: LocalDateTime,
 )
-
-data class PrisonLocation(
-  val agencyId: String,
-  val locationPrefix: String,
-  val description: String,
-  val locationType: String,
-  val userDescription: String?,
-)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/health/HealthPingCheck.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/health/HealthPingCheck.kt
@@ -13,3 +13,6 @@ class PrisonHealthPing(@Qualifier("prisonHealthWebClient") webClient: WebClient)
 
 @Component("offenderSearch")
 class OffenderSearchHealthPing(@Qualifier("offenderSearchHealthWebClient") webClient: WebClient) : ReactiveHealthPingCheck(webClient)
+
+@Component("locations")
+class LocationsHealthPing(@Qualifier("locationsHealthWebClient") webClient: WebClient) : ReactiveHealthPingCheck(webClient)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/IncentiveReviewsService.kt
@@ -25,7 +25,7 @@ import uk.gov.justice.digital.hmpps.incentivesapi.dto.IncentiveReview as Incenti
 @Service
 class IncentiveReviewsService(
   private val offenderSearchService: OffenderSearchService,
-  private val prisonApiService: PrisonApiService,
+  private val locationsService: LocationsService,
   private val prisonIncentiveLevelService: PrisonIncentiveLevelAuditedService,
   private val incentiveReviewRepository: IncentiveReviewRepository,
   private val nextReviewDateGetterService: NextReviewDateGetterService,
@@ -55,7 +55,10 @@ class IncentiveReviewsService(
     }
     val deferredLocationDescription = async {
       try {
-        prisonApiService.getLocation(cellLocationPrefix.removeSuffix("-")).description
+        val locationKey = cellLocationPrefix.removeSuffix("-")
+        val location = locationsService.getByKey(locationKey)
+
+        location.localName ?: location.pathHierarchy
       } catch (e: NotFound) {
         "Unknown location"
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/LocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/LocationsService.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.incentivesapi.service
+
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.awaitBody
+
+@Service
+class LocationsService(private val locationsWebClient: WebClient) {
+  /**
+   * Get a location by it's key, e.g. `MDI-1`.
+   * Requires role VIEW_LOCATIONS
+   */
+  suspend fun getByKey(key: String): Location {
+    return locationsWebClient.get()
+      .uri("/locations/key/$key")
+      .retrieve()
+      .awaitBody()
+  }
+}
+
+data class Location(
+  val id: String,
+  val key: String,
+  val prisonId: String,
+  val localName: String?,
+  val pathHierarchy: String,
+  // Other fields omitted
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonApiService.kt
@@ -8,7 +8,6 @@ import org.springframework.web.reactive.function.client.bodyToFlow
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.BookingFromDatePair
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.CaseNoteUsageTypesRequest
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.Prison
-import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.PrisonLocation
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.PrisonerCaseNoteByTypeSubType
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.PrisonerExtraInfo
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.prisonapi.PrisonerInfo
@@ -35,12 +34,6 @@ class PrisonApiService(
       )
       .retrieve()
       .bodyToFlow()
-
-  suspend fun getLocation(locationId: String): PrisonLocation =
-    prisonWebClient.get()
-      .uri("/api/locations/code/$locationId")
-      .retrieve()
-      .awaitBody()
 
   suspend fun getPrisonerInfo(prisonerNumber: String, useClientCredentials: Boolean = false): PrisonerInfo {
     return getClient(useClientCredentials)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -7,6 +7,7 @@ api:
       oauth: http://localhost:9090/auth
       prison: http://localhost:8082
       offender-search: http://localhost:8083
+      locations: http://localhost:8085
 
 management.endpoint:
   health.cache.time-to-live: 0

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/IntegrationTestBase.kt
@@ -10,6 +10,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.incentivesapi.helper.TestBase
 import uk.gov.justice.digital.hmpps.incentivesapi.integration.wiremock.HmppsAuthMockServer
+import uk.gov.justice.digital.hmpps.incentivesapi.integration.wiremock.LocationsMockServer
 import uk.gov.justice.digital.hmpps.incentivesapi.integration.wiremock.OffenderSearchMockServer
 import uk.gov.justice.digital.hmpps.incentivesapi.integration.wiremock.PrisonApiMockServer
 import uk.gov.justice.hmpps.test.kotlin.auth.JwtAuthorisationHelper
@@ -34,6 +35,9 @@ abstract class IntegrationTestBase : TestBase() {
     @JvmField
     val offenderSearchMockServer = OffenderSearchMockServer()
 
+    @JvmField
+    val locationsMockServer = LocationsMockServer()
+
     @BeforeAll
     @JvmStatic
     fun startMocks() {
@@ -42,11 +46,13 @@ abstract class IntegrationTestBase : TestBase() {
 
       prisonApiMockServer.start()
       offenderSearchMockServer.start()
+      locationsMockServer.start()
     }
 
     @AfterAll
     @JvmStatic
     fun stopMocks() {
+      locationsMockServer.stop()
       offenderSearchMockServer.stop()
       prisonApiMockServer.stop()
       hmppsAuthMockServer.stop()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/health/HealthCheckTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/health/HealthCheckTest.kt
@@ -53,5 +53,6 @@ class HealthCheckTest : SqsIntegrationTestBase() {
     hmppsAuthMockServer.stubHealthPing(status)
     prisonApiMockServer.stubHealthPing(status)
     offenderSearchMockServer.stubHealthPing(status)
+    locationsMockServer.stubHealthPing(status)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/wiremock/LocationsMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/wiremock/LocationsMockServer.kt
@@ -33,7 +33,7 @@ class LocationsMockServer : WireMockServer(WIREMOCK_PORT) {
                   "key": "$key",
                   "prisonId": "MDI",
                   "localName": "Houseblock 1",
-                  "pathHierarchy": "$key",
+                  "pathHierarchy": "$key"
                 }
             """,
           ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/wiremock/LocationsMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/wiremock/LocationsMockServer.kt
@@ -1,0 +1,43 @@
+package uk.gov.justice.digital.hmpps.incentivesapi.integration.wiremock
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+
+class LocationsMockServer : WireMockServer(WIREMOCK_PORT) {
+  companion object {
+    private const val WIREMOCK_PORT = 8095
+  }
+
+  fun stubHealthPing(status: Int) {
+    stubFor(
+      get("/health/ping").willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withBody(if (status == 200) "pong" else "some error")
+          .withStatus(status),
+      ),
+    )
+  }
+
+  fun stubGetByKey(key: String) {
+    stubFor(
+      get("/locations/key/$key").willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withBody(
+            // language=json
+            """
+                {
+                  "id": "2475f250-434a-4257-afe7-b911f1773a4d",
+                  "key": "$key",
+                  "prisonId": "MDI",
+                  "localName": "Houseblock 1",
+                  "pathHierarchy": "$key",
+                }
+            """,
+          ),
+      ),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/IncentiveReviewsResourceTest.kt
@@ -31,6 +31,7 @@ class IncentiveReviewsResourceTest : IncentiveLevelResourceTestBase() {
 
   @BeforeEach
   fun setUp(): Unit = runBlocking {
+    locationsMockServer.resetAll()
     offenderSearchMockServer.resetAll()
     prisonApiMockServer.resetAll()
 
@@ -102,7 +103,7 @@ class IncentiveReviewsResourceTest : IncentiveLevelResourceTestBase() {
     @Test
     fun `when prisonId is incorrect`() {
       offenderSearchMockServer.stubFindOffenders("Moorland")
-      prisonApiMockServer.stubLocation("MDI-1")
+      locationsMockServer.stubGetByKey("MDI-1")
 
       webTestClient.get()
         .uri("/incentives-reviews/prison/Moorland/location/MDI-1/level/STD")
@@ -114,7 +115,7 @@ class IncentiveReviewsResourceTest : IncentiveLevelResourceTestBase() {
     @Test
     fun `when level code is incorrect`() {
       offenderSearchMockServer.stubFindOffenders("Moorland")
-      prisonApiMockServer.stubLocation("MDI-1")
+      locationsMockServer.stubGetByKey("MDI-1")
 
       webTestClient.get()
         .uri("/incentives-reviews/prison/MDI/location/MDI-1/level/s")
@@ -126,7 +127,7 @@ class IncentiveReviewsResourceTest : IncentiveLevelResourceTestBase() {
     @Test
     fun `when sorting is incorrect`() {
       offenderSearchMockServer.stubFindOffenders("MDI")
-      prisonApiMockServer.stubLocation("MDI-1")
+      locationsMockServer.stubGetByKey("MDI-1")
 
       webTestClient.get()
         .uri("/incentives-reviews/prison/MDI/location/MDI-1/level/STD?sort=PRISON")
@@ -138,7 +139,7 @@ class IncentiveReviewsResourceTest : IncentiveLevelResourceTestBase() {
     @Test
     fun `when page is incorrect`() {
       offenderSearchMockServer.stubFindOffenders("MDI")
-      prisonApiMockServer.stubLocation("MDI-1")
+      locationsMockServer.stubGetByKey("MDI-1")
 
       webTestClient.get()
         .uri("/incentives-reviews/prison/MDI/location/MDI-1/level/STD?page=-1")
@@ -150,7 +151,7 @@ class IncentiveReviewsResourceTest : IncentiveLevelResourceTestBase() {
     @Test
     fun `when page & pageSize are incorrect`() {
       offenderSearchMockServer.stubFindOffenders("MDI")
-      prisonApiMockServer.stubLocation("MDI-1")
+      locationsMockServer.stubGetByKey("MDI-1")
 
       webTestClient.get()
         .uri("/incentives-reviews/prison/MDI/location/MDI-1/level/STD?page=-1&pageSize=0")
@@ -166,7 +167,7 @@ class IncentiveReviewsResourceTest : IncentiveLevelResourceTestBase() {
   @Test
   fun `loads prisoner details from offender search and prison api`() {
     offenderSearchMockServer.stubFindOffenders("MDI")
-    prisonApiMockServer.stubLocation("MDI-1")
+    locationsMockServer.stubGetByKey("MDI-1")
     prisonApiMockServer.stubCaseNoteSummary()
 
     listOf("BAS", "STD", "ENH", "ENT").forEach { levelCode ->
@@ -343,7 +344,7 @@ class IncentiveReviewsResourceTest : IncentiveLevelResourceTestBase() {
   @EnumSource(IncentiveReviewSort::class)
   fun `sorts by provided parameters`(sort: IncentiveReviewSort): Unit = runBlocking {
     offenderSearchMockServer.stubFindOffenders("MDI")
-    prisonApiMockServer.stubLocation("MDI-1")
+    locationsMockServer.stubGetByKey("MDI-1")
     prisonApiMockServer.stubCaseNoteSummary()
 
     if (sort == IncentiveReviewSort.IS_NEW_TO_PRISON) {
@@ -377,7 +378,7 @@ class IncentiveReviewsResourceTest : IncentiveLevelResourceTestBase() {
     @BeforeEach
     fun setUp() {
       offenderSearchMockServer.stubFindOffenders("MDI")
-      prisonApiMockServer.stubLocation("MDI-1")
+      locationsMockServer.stubGetByKey("MDI-1")
       prisonApiMockServer.stubCaseNoteSummary()
     }
 
@@ -423,7 +424,7 @@ class IncentiveReviewsResourceTest : IncentiveLevelResourceTestBase() {
   @Test
   fun `describes error when incentive levels not available in DB`(): Unit = runBlocking {
     offenderSearchMockServer.stubFindOffenders("MDI")
-    prisonApiMockServer.stubLocation("MDI-1")
+    locationsMockServer.stubGetByKey("MDI-1")
     prisonApiMockServer.stubCaseNoteSummary()
 
     incentiveReviewRepository.deleteAll()

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -14,6 +14,7 @@ api:
       oauth: http://localhost:8090/auth
       prison: http://localhost:8093
       offender-search: http://localhost:8094
+      locations: http://localhost:8095
 
 spring:
   flyway:


### PR DESCRIPTION
⚠️ ~This PR is on a branch off [this other one](https://github.com/ministryofjustice/hmpps-incentives-api/pull/596)~ ⚠️  

The [reviews endpoint](https://incentives-api-dev.hmpps.service.justice.gov.uk/webjars/swagger-ui/index.html?configUrl=/v3/api-docs#/Incentive%20review%20summary/getReviews)'s response has a `locationDescription` field with the human description of a location (e.g. Houseblock 1). This is displayed in the UI reviews table page (this endpoint is "internal" and used only by the UI).

Before this PR this description was populated using the now deprecated `GET /api/locations/code/{locationId}` in Prison API endpoint.

The service now makes a request to the new Locations Inside Prison API. Specifically it uses the [`GET /locations/key/{key}` endpoint](https://locations-inside-prison-api-dev.hmpps.service.justice.gov.uk/swagger-ui/index.html#/Locations/getLocationByKey) which takes a location "key" (e.g. `MDI-1`) and returns information about the location.

In our case we're interested in the `localName` field. This field is optional - presumably because it's not populated for individual cells? - hence the fallback to `pathHierarchy` field.

#### Notes on permissions
- The requests to the Locations API are made using the system client rather than the user/client token. So individual users of the UI don't need any special roles (similarly to what we do when getting information from Offender Search API)
  - Previously the information about a location were retrieved using the client token. This probably explains why [upstream API sees these requests as made from the UI itself](https://docs.google.com/spreadsheets/d/1xa0MJNMreQcqONtS9alkF_5Hg3NvWSCckDIyr2KQOXA/edit?gid=0#gid=0).
- This endpoint requires the `VIEW_LOCATIONS` role. Mike kindly already added this to the `dev`/`preprod`/`prod` clients (but it may be worth triple check with someone)