### PR TITLE
INC-1335: Send alerts to dev channel

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -19,7 +19,7 @@ generic-service:
     TASK_UPDATE_KPIS_CRON: "0 0 10 1W * *"
 
 generic-prometheus-alerts:
-  alertSeverity: digital-prison-service-dev
+  alertSeverity: hmpps-incentives-dev
   businessHoursOnly: true
   rdsAlertsDatabases:
     cloud-platform-c75ed66addfe4c30: "incentives api"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -17,7 +17,7 @@ generic-service:
     TASK_UPDATE_KPIS_CRON: "0 0 10 1W * *"
 
 generic-prometheus-alerts:
-  alertSeverity: digital-prison-service-dev
+  alertSeverity: hmpps-incentives-preprod
   businessHoursOnly: true
   rdsAlertsDatabases:
     cloud-platform-6b3b723b359a69e2: "incentives api"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -24,7 +24,7 @@ generic-service:
         DB_HOST_PREPROD: "rds_instance_address"
 
 generic-prometheus-alerts:
-  alertSeverity: digital-prison-service
+  alertSeverity: hmpps-incentives-prod
   rdsAlertsDatabases:
     cloud-platform-4da80b91054a19d6: "incentives api"
   sqsAlertsQueueNames:


### PR DESCRIPTION
Send alerts to our Slack dev channel (`#incentives_dev`) instead of `#dps_alers`/`#dps_alerts_non_prod`.