### PR TITLE
INC-1398 Add OAuth2 client caching mechanism and configuration to optimize authorized client management.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/ClientCachingOAuth2AuthorizedClientService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/ClientCachingOAuth2AuthorizedClientService.kt
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.hmpps.incentivesapi.config
+
+import org.springframework.security.core.Authentication
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientId
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
+import uk.gov.justice.digital.hmpps.incentivesapi.SYSTEM_USERNAME
+import java.util.concurrent.ConcurrentHashMap
+
+class ClientCachingOAuth2AuthorizedClientService(
+  private val clientRegistrationRepository: ClientRegistrationRepository,
+) : OAuth2AuthorizedClientService {
+  private val authorizedClients: MutableMap<OAuth2AuthorizedClientId, OAuth2AuthorizedClient> = ConcurrentHashMap()
+
+  override fun <T : OAuth2AuthorizedClient?> loadAuthorizedClient(
+    clientRegistrationId: String,
+    principalName: String,
+  ): T? = clientRegistrationRepository.findByRegistrationId(clientRegistrationId)?.let {
+    @Suppress("UNCHECKED_CAST")
+    authorizedClients[OAuth2AuthorizedClientId(clientRegistrationId, SYSTEM_USERNAME)] as T
+  }
+
+  override fun saveAuthorizedClient(authorizedClient: OAuth2AuthorizedClient, principal: Authentication) {
+    authorizedClients[
+      OAuth2AuthorizedClientId(authorizedClient.clientRegistration.registrationId, SYSTEM_USERNAME),
+    ] = authorizedClient
+  }
+
+  override fun removeAuthorizedClient(clientRegistrationId: String, principalName: String) {
+    clientRegistrationRepository.findByRegistrationId(clientRegistrationId)?.apply {
+      authorizedClients.remove(OAuth2AuthorizedClientId(clientRegistrationId, SYSTEM_USERNAME))
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/ClientCachingOAuth2AuthorizedClientService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/ClientCachingOAuth2AuthorizedClientService.kt
@@ -3,33 +3,41 @@ package uk.gov.justice.digital.hmpps.incentivesapi.config
 import org.springframework.security.core.Authentication
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientId
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
-import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
+import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientService
+import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository
+import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.incentivesapi.SYSTEM_USERNAME
 import java.util.concurrent.ConcurrentHashMap
 
 class ClientCachingOAuth2AuthorizedClientService(
-  private val clientRegistrationRepository: ClientRegistrationRepository,
-) : OAuth2AuthorizedClientService {
+  private val clientRegistrationRepository: ReactiveClientRegistrationRepository,
+) : ReactiveOAuth2AuthorizedClientService {
   private val authorizedClients: MutableMap<OAuth2AuthorizedClientId, OAuth2AuthorizedClient> = ConcurrentHashMap()
 
   override fun <T : OAuth2AuthorizedClient?> loadAuthorizedClient(
-    clientRegistrationId: String,
-    principalName: String,
-  ): T? = clientRegistrationRepository.findByRegistrationId(clientRegistrationId)?.let {
-    @Suppress("UNCHECKED_CAST")
-    authorizedClients[OAuth2AuthorizedClientId(clientRegistrationId, SYSTEM_USERNAME)] as T
-  }
+    clientRegistrationId: String?,
+    principalName: String?,
+  ): Mono<T?> = Mono.justOrEmpty(clientRegistrationId)
+    .flatMap { id -> clientRegistrationRepository.findByRegistrationId(id) }
+    .mapNotNull { clientRegistration ->
+      @Suppress("UNCHECKED_CAST")
+      authorizedClients[OAuth2AuthorizedClientId(clientRegistration.registrationId, SYSTEM_USERNAME)] as? T
+    }
 
-  override fun saveAuthorizedClient(authorizedClient: OAuth2AuthorizedClient, principal: Authentication) {
+  override fun saveAuthorizedClient(authorizedClient: OAuth2AuthorizedClient, principal: Authentication?): Mono<Void> {
     authorizedClients[
       OAuth2AuthorizedClientId(authorizedClient.clientRegistration.registrationId, SYSTEM_USERNAME),
     ] = authorizedClient
+    return Mono.empty()
   }
 
-  override fun removeAuthorizedClient(clientRegistrationId: String, principalName: String) {
-    clientRegistrationRepository.findByRegistrationId(clientRegistrationId)?.apply {
-      authorizedClients.remove(OAuth2AuthorizedClientId(clientRegistrationId, SYSTEM_USERNAME))
-    }
+  override fun removeAuthorizedClient(clientRegistrationId: String?, principalName: String?): Mono<Void> {
+    return Mono.justOrEmpty(clientRegistrationId)
+      .flatMap { id -> clientRegistrationRepository.findByRegistrationId(id) }
+      .doOnNext { registration ->
+        val principal = principalName ?: SYSTEM_USERNAME
+        authorizedClients.remove(OAuth2AuthorizedClientId(registration.registrationId, principal))
+      }
+      .then()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/OAuth2ClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/OAuth2ClientConfiguration.kt
@@ -2,21 +2,21 @@ package uk.gov.justice.digital.hmpps.incentivesapi.config
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder
-import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
+import org.springframework.security.oauth2.client.AuthorizedClientServiceReactiveOAuth2AuthorizedClientManager
+import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientManager
+import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientProviderBuilder
+import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository
 
 @Configuration
 class OAuth2ClientConfiguration {
 
   @Bean
   fun authorizedClientManager(
-    clientRegistrationRepository: ClientRegistrationRepository,
-  ): OAuth2AuthorizedClientManager {
-    val authorizedClientProvider = OAuth2AuthorizedClientProviderBuilder.builder().clientCredentials().build()
+    clientRegistrationRepository: ReactiveClientRegistrationRepository,
+  ): ReactiveOAuth2AuthorizedClientManager {
+    val authorizedClientProvider = ReactiveOAuth2AuthorizedClientProviderBuilder.builder().clientCredentials().build()
     val authorizedClientManager =
-      AuthorizedClientServiceOAuth2AuthorizedClientManager(
+      AuthorizedClientServiceReactiveOAuth2AuthorizedClientManager(
         clientRegistrationRepository,
         ClientCachingOAuth2AuthorizedClientService(clientRegistrationRepository),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/OAuth2ClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/OAuth2ClientConfiguration.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.incentivesapi.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
+
+@Configuration
+class OAuth2ClientConfiguration {
+
+  @Bean
+  fun authorizedClientManager(
+    clientRegistrationRepository: ClientRegistrationRepository,
+  ): OAuth2AuthorizedClientManager {
+    val authorizedClientProvider = OAuth2AuthorizedClientProviderBuilder.builder().clientCredentials().build()
+    val authorizedClientManager =
+      AuthorizedClientServiceOAuth2AuthorizedClientManager(
+        clientRegistrationRepository,
+        ClientCachingOAuth2AuthorizedClientService(clientRegistrationRepository),
+      )
+    authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider)
+    return authorizedClientManager
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/wiremock/HmppsAuthMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/wiremock/HmppsAuthMockServer.kt
@@ -24,7 +24,8 @@ class HmppsAuthMockServer : WireMockServer(WIREMOCK_PORT) {
               """
                 {
                   "token_type": "bearer",
-                  "access_token": "ABCDE"
+                  "access_token": "ABCDE",
+                  "expires_in": 3600
                 }
               """,
             ),


### PR DESCRIPTION
Improves the management of authorized clients by introducing a caching mechanism. This enhancement aims to optimize performance and reduce unnecessary duplication when handling OAuth2 client operations.