### PR TITLE
Fixed "matchPackageNames" to include whole package name

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "packageRules": [
     {
       "matchManagers": ["gradle"],
-      "matchPackageNames": ["swagger-parser"],
+      "matchPackageNames": ["io.swagger.parser.v3:swagger-parser"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "swagger-parser",
       "groupSlug": "swagger-parser"


### PR DESCRIPTION
From Renovate perspective this is the whole `group:name`, e.g. `"io.swagger.parser.v3:swagger-parser"`.