### PR TITLE
Renovate: Move more generic rule last

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,16 +6,16 @@
   "packageRules": [
     {
       "matchManagers": ["gradle"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "all non major Gradle dependencies",
+      "groupSlug": "all-gradle-minor-patch"
+    },
+    {
+      "matchManagers": ["gradle"],
       "matchPackageNames": ["io.swagger.parser.v3:swagger-parser"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "swagger-parser",
       "groupSlug": "swagger-parser"
-    },
-    {
-      "matchManagers": ["gradle"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "all non major Gradle dependencies",
-      "groupSlug": "all-gradle-minor-patch"
     }
   ]
 }


### PR DESCRIPTION
When multiple rules match the last win, so the more specific rules should go last.