### PR TITLE
More useful logging when no default level for a prison

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/PrisonIncentiveLevel.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/PrisonIncentiveLevel.kt
@@ -105,8 +105,8 @@ data class PrisonIncentiveLevel(
   )
 }
 
-fun List<PrisonIncentiveLevel>.findDefaultOnAdmission() = find(PrisonIncentiveLevel::defaultOnAdmission)
-  ?: throw DataIntegrityException("No default level for new admissions")
+fun List<PrisonIncentiveLevel>.findDefaultOnAdmission(prisonId: String) = find(PrisonIncentiveLevel::defaultOnAdmission)
+  ?: throw DataIntegrityException("No default level for new admissions (prisonId = '$prisonId')")
 
 /**
  * Update payload for PrisonIncentiveLevel

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NearestPrisonIncentiveLevelService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/NearestPrisonIncentiveLevelService.kt
@@ -16,7 +16,7 @@ class NearestPrisonIncentiveLevelService(
    */
   suspend fun findNearestHighestLevel(prisonId: String, levelCode: String): String {
     val prisonLevels = prisonIncentiveLevelService.getActivePrisonIncentiveLevels(prisonId)
-    val defaultLevelCode = prisonLevels.findDefaultOnAdmission().levelCode
+    val defaultLevelCode = prisonLevels.findDefaultOnAdmission(prisonId).levelCode
     val levelCodesAvailableInPrison = prisonLevels.filter(PrisonIncentiveLevel::active)
       .map(PrisonIncentiveLevel::levelCode)
       .toSet()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIncentiveReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIncentiveReviewService.kt
@@ -152,7 +152,7 @@ class PrisonerIncentiveReviewService(
 
   private suspend fun getIncentiveLevelForReviewType(prisonerInfo: PrisonerBasicInfo, reviewType: ReviewType): String {
     val prisonIncentiveLevels = prisonIncentiveLevelService.getActivePrisonIncentiveLevels(prisonerInfo.prisonId)
-    val defaultLevelCode = prisonIncentiveLevels.findDefaultOnAdmission().levelCode
+    val defaultLevelCode = prisonIncentiveLevels.findDefaultOnAdmission(prisonerInfo.prisonId).levelCode
 
     return when (reviewType) {
       ReviewType.INITIAL, ReviewType.READMISSION -> {


### PR DESCRIPTION
All prisons should have a default Incentive level, and when this is not the case this is a misconfiguration and needs to be corrected.

It is an exceptional situation and indeed not being able to determine the default Incentive level throws an exception.

Unfortunately the exception message says doesn't tell **which** prison is causing this exception. This makes the error message more useful so that we can investigate these sort of things, tweaked message:

```
No default level for new admissions (prisonId = '$prisonId')")
```