### PR TITLE
Document that some endpoints may return a 404

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/ManageIncentiveReviewsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/ManageIncentiveReviewsResource.kt
@@ -56,6 +56,11 @@ class ManageIncentiveReviewsResource(
         description = "Incorrect permissions to use this endpoint",
         content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
       ),
+      ApiResponse(
+        responseCode = "404",
+        description = "No incentive reviews found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
     ],
   )
   suspend fun getPrisonerIncentiveLevelHistory(
@@ -104,6 +109,11 @@ class ManageIncentiveReviewsResource(
         description = "Incorrect permissions to use this endpoint",
         content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
       ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Incentive review not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
     ],
   )
   suspend fun getIncentiveReviewById(
@@ -141,6 +151,11 @@ class ManageIncentiveReviewsResource(
       ApiResponse(
         responseCode = "403",
         description = "Incorrect permissions to use this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "No incentive reviews found",
         content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
       ),
     ],


### PR DESCRIPTION
Although it's an edge case and all prisoners should have at least one Incentive review, we have seen some cases in `dev` where incorrect data leads to some prisoners without any Incentive review record causing a `404 Not Found`.

This may be caused by some of the manual testing happening, e.g. some prisoners being admitted and instantly being released leading to the `NEW_ADMISSION` domain event not being processed correctly (because `OUT` is not an actual prison and it doesn't have a "default incentive level").

It may also be caused by historical bad data or possibly a `dev` prison being misconfigured and lacking a "default incentive level".

Whatever the case is, these endpoint can return a `404 Not Found` when a given prisoner has no Incentive review records and a `IncentiveReviewSummary`/ `IncentiveReviewDetail` can't be constructed. This is now documented.