### PR TITLE
INC-1398 Simplify OAuth2 client removal by standardizing to system username.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/ClientCachingOAuth2AuthorizedClientService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/config/ClientCachingOAuth2AuthorizedClientService.kt
@@ -35,8 +35,7 @@ class ClientCachingOAuth2AuthorizedClientService(
     return Mono.justOrEmpty(clientRegistrationId)
       .flatMap { id -> clientRegistrationRepository.findByRegistrationId(id) }
       .doOnNext { registration ->
-        val principal = principalName ?: SYSTEM_USERNAME
-        authorizedClients.remove(OAuth2AuthorizedClientId(registration.registrationId, principal))
+        authorizedClients.remove(OAuth2AuthorizedClientId(registration.registrationId, SYSTEM_USERNAME))
       }
       .then()
   }


### PR DESCRIPTION
This pull request standardizes the system username used in OAuth2 client removal, simplifying the process and ensuring consistency.