### PR TITLE
IR-1713 Emit incentives changed event after merge / booking moved

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIncentiveReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIncentiveReviewService.kt
@@ -26,8 +26,10 @@ import uk.gov.justice.digital.hmpps.incentivesapi.dto.daysSinceReviewCalc
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.findDefaultOnAdmission
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.IncentiveReview
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.IncentiveReviewRepository
+import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.NextReviewDateRepository
 import uk.gov.justice.hmpps.kotlin.auth.HmppsReactiveAuthenticationHolder
 import java.time.Clock
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
@@ -44,6 +46,7 @@ class PrisonerIncentiveReviewService(
   private val clock: Clock,
   private val nextReviewDateGetterService: NextReviewDateGetterService,
   private val nextReviewDateUpdaterService: NextReviewDateUpdaterService,
+  private val nextReviewDateRepository: NextReviewDateRepository,
   private val incentiveStoreService: IncentiveStoreService,
   private val transactionalOperator: TransactionalOperator,
 ) {
@@ -260,21 +263,40 @@ class PrisonerIncentiveReviewService(
     return newIepReview
   }
 
-  private suspend fun currentReviewFor(prisonerNumber: String): IncentiveReview? =
-    incentiveReviewRepository.findAllByPrisonerNumberOrderByReviewTimeDesc(prisonerNumber)
-      .firstOrNull { it.current }
+  /**
+   * Snapshot of the fields prisoner-search caches for a prisoner's current incentive: the level,
+   * the review date/time and the next review date. Used to detect whether a merge or booking move
+   * has changed what downstream consumers display.
+   */
+  private data class CurrentReviewSnapshot(
+    val review: IncentiveReview,
+    val nextReviewDate: LocalDate?,
+  )
+
+  private suspend fun currentReviewSnapshotFor(prisonerNumber: String): CurrentReviewSnapshot? {
+    val current = incentiveReviewRepository.findAllByPrisonerNumberOrderByReviewTimeDesc(prisonerNumber)
+      .firstOrNull { it.current } ?: return null
+    // Read the persisted next review date directly rather than via NextReviewDateGetterService,
+    // which would (re)compute and persist it — an unwanted side effect when only snapshotting.
+    val nextReviewDate = nextReviewDateRepository.findById(current.bookingId)?.nextReviewDate
+    return CurrentReviewSnapshot(current, nextReviewDate)
+  }
 
   /**
    * Publishes an [IncentivesDomainEventType.IEP_REVIEW_UPDATED] domain event when a prisoner's
-   * current incentive review has changed (e.g. after a merge or booking move), so downstream
-   * consumers such as prisoner-search can refresh. No event is published if the current review
-   * is unchanged.
+   * current incentive snapshot has changed (e.g. after a merge or booking move), so downstream
+   * consumers such as prisoner-search can refresh. The snapshot covers the level, the review
+   * date/time and the next review date — the fields prisoner-search caches. No event is published
+   * if all three are unchanged.
    */
-  private suspend fun publishIfCurrentReviewChanged(prisonerNumber: String, before: IncentiveReview?) {
-    val after = currentReviewFor(prisonerNumber)
-    val changed = before?.id != after?.id || before?.levelCode != after?.levelCode
-    if (changed && after != null) {
-      val detail = after.toIncentiveReviewDetail(incentiveLevelService.getAllIncentiveLevelsMapByCode())
+  private suspend fun publishIfCurrentReviewChanged(prisonerNumber: String, before: CurrentReviewSnapshot?) {
+    val after = currentReviewSnapshotFor(prisonerNumber) ?: return
+    val changed = before == null ||
+      before.review.levelCode != after.review.levelCode ||
+      before.review.reviewTime != after.review.reviewTime ||
+      before.nextReviewDate != after.nextReviewDate
+    if (changed) {
+      val detail = after.review.toIncentiveReviewDetail(incentiveLevelService.getAllIncentiveLevelsMapByCode())
       publishReviewDomainEvent(detail, IncentivesDomainEventType.IEP_REVIEW_UPDATED)
     }
   }
@@ -317,7 +339,7 @@ class PrisonerIncentiveReviewService(
     val remainingPrisonerNumber = prisonerMergeEvent.additionalInformation.nomsNumber!!
     log.info("Processing merge event: Prisoner Number Merge $removedPrisonerNumber -> $remainingPrisonerNumber")
 
-    val survivorBefore = currentReviewFor(remainingPrisonerNumber)
+    val survivorBefore = currentReviewSnapshotFor(remainingPrisonerNumber)
 
     val activeReviews = incentiveReviewRepository.findAllByPrisonerNumberOrderByReviewTimeDesc(removedPrisonerNumber)
       .map { review -> review.copy(prisonerNumber = remainingPrisonerNumber) }
@@ -354,8 +376,8 @@ class PrisonerIncentiveReviewService(
     val remainingPrisonerNumber = bookingMovedEvent.additionalInformation.movedToNomsNumber
     log.info("Moving incentive reviews for booking $bookingId from $removedPrisonerNumber to $remainingPrisonerNumber")
 
-    val movedFromBefore = currentReviewFor(removedPrisonerNumber)
-    val movedToBefore = currentReviewFor(remainingPrisonerNumber)
+    val movedFromBefore = currentReviewSnapshotFor(removedPrisonerNumber)
+    val movedToBefore = currentReviewSnapshotFor(remainingPrisonerNumber)
 
     incentiveReviewRepository.saveAll(
       incentiveReviewRepository.findAllByBookingIdOrderByReviewTimeDesc(bookingId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIncentiveReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIncentiveReviewService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.incentivesapi.service
 import jakarta.validation.ValidationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.count
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.toList
@@ -259,6 +260,25 @@ class PrisonerIncentiveReviewService(
     return newIepReview
   }
 
+  private suspend fun currentReviewFor(prisonerNumber: String): IncentiveReview? =
+    incentiveReviewRepository.findAllByPrisonerNumberOrderByReviewTimeDesc(prisonerNumber)
+      .firstOrNull { it.current }
+
+  /**
+   * Publishes an [IncentivesDomainEventType.IEP_REVIEW_UPDATED] domain event when a prisoner's
+   * current incentive review has changed (e.g. after a merge or booking move), so downstream
+   * consumers such as prisoner-search can refresh. No event is published if the current review
+   * is unchanged.
+   */
+  private suspend fun publishIfCurrentReviewChanged(prisonerNumber: String, before: IncentiveReview?) {
+    val after = currentReviewFor(prisonerNumber)
+    val changed = before?.id != after?.id || before?.levelCode != after?.levelCode
+    if (changed && after != null) {
+      val detail = after.toIncentiveReviewDetail(incentiveLevelService.getAllIncentiveLevelsMapByCode())
+      publishReviewDomainEvent(detail, IncentivesDomainEventType.IEP_REVIEW_UPDATED)
+    }
+  }
+
   private suspend fun publishReviewDomainEvent(
     incentiveReviewDetail: IncentiveReviewDetail,
     eventType: IncentivesDomainEventType,
@@ -297,6 +317,8 @@ class PrisonerIncentiveReviewService(
     val remainingPrisonerNumber = prisonerMergeEvent.additionalInformation.nomsNumber!!
     log.info("Processing merge event: Prisoner Number Merge $removedPrisonerNumber -> $remainingPrisonerNumber")
 
+    val survivorBefore = currentReviewFor(remainingPrisonerNumber)
+
     val activeReviews = incentiveReviewRepository.findAllByPrisonerNumberOrderByReviewTimeDesc(removedPrisonerNumber)
       .map { review -> review.copy(prisonerNumber = remainingPrisonerNumber) }
 
@@ -319,6 +341,7 @@ class PrisonerIncentiveReviewService(
         message,
         SYSTEM_USERNAME,
       )
+      publishIfCurrentReviewChanged(remainingPrisonerNumber, survivorBefore)
     } else {
       log.info("No incentive records found for $removedPrisonerNumber, no records updated")
     }
@@ -330,12 +353,19 @@ class PrisonerIncentiveReviewService(
     val removedPrisonerNumber = bookingMovedEvent.additionalInformation.movedFromNomsNumber
     val remainingPrisonerNumber = bookingMovedEvent.additionalInformation.movedToNomsNumber
     log.info("Moving incentive reviews for booking $bookingId from $removedPrisonerNumber to $remainingPrisonerNumber")
+
+    val movedFromBefore = currentReviewFor(removedPrisonerNumber)
+    val movedToBefore = currentReviewFor(remainingPrisonerNumber)
+
     incentiveReviewRepository.saveAll(
       incentiveReviewRepository.findAllByBookingIdOrderByReviewTimeDesc(bookingId)
         .toList()
         .filter { it.prisonerNumber == removedPrisonerNumber }
         .onEach { it.prisonerNumber = remainingPrisonerNumber },
     ).collect {}
+
+    publishIfCurrentReviewChanged(removedPrisonerNumber, movedFromBefore)
+    publishIfCurrentReviewChanged(remainingPrisonerNumber, movedToBefore)
   }
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/service/PrisonOffenderEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/service/PrisonOffenderEventListenerIntTest.kt
@@ -14,6 +14,8 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.beans.factory.annotation.Autowired
 import software.amazon.awssdk.services.sns.model.PublishResponse
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.PrisonerAlert
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
 import uk.gov.justice.digital.hmpps.incentivesapi.integration.SqsIntegrationTestBase
@@ -24,6 +26,7 @@ import uk.gov.justice.digital.hmpps.incentivesapi.service.AdditionalInformation
 import uk.gov.justice.digital.hmpps.incentivesapi.service.AdditionalInformationBookingMoved
 import uk.gov.justice.digital.hmpps.incentivesapi.service.HMPPSBookingMovedDomainEvent
 import uk.gov.justice.digital.hmpps.incentivesapi.service.HMPPSDomainEvent
+import uk.gov.justice.digital.hmpps.incentivesapi.service.HMPPSMessage
 import uk.gov.justice.digital.hmpps.incentivesapi.util.flow.toMap
 import uk.gov.justice.hmpps.sqs.publish
 import java.time.Duration
@@ -170,6 +173,11 @@ class PrisonOffenderEventListenerIntTest : SqsIntegrationTestBase() {
       prisonerSearchMockServer.getCountFor("/prisoner/$prisonerNumber")
     } matches
       { it == 1 }
+
+    // The survivor's current incentive changed from Standard to Basic, so an iep-review.updated
+    // event is emitted for the survivor so consumers (e.g. prisoner-search) refresh
+    val updatedEvent = awaitDomainEventOfType("incentives.iep-review.updated")
+    assertThat(updatedEvent.additionalInformation?.nomsNumber).isEqualTo(prisonerNumber)
   }
 
   @Test
@@ -313,6 +321,35 @@ class PrisonOffenderEventListenerIntTest : SqsIntegrationTestBase() {
 
     assertThat(nextReviewDateRepository.findById(bookingId)?.nextReviewDate)
       .isEqualTo(lastReviewTime.plusDays(28).toLocalDate())
+  }
+
+  /**
+   * Drains the test domain-events queue (which may carry several event types, e.g.
+   * next-review-date-changed) until an event of [eventType] is observed, then returns it.
+   */
+  private fun awaitDomainEventOfType(eventType: String): HMPPSDomainEvent {
+    val sqsClient = testDomainEventQueue.sqsClient
+    val collected = mutableListOf<HMPPSDomainEvent>()
+    awaitAtMost30Secs untilCallTo {
+      sqsClient.receiveMessage(
+        ReceiveMessageRequest.builder()
+          .queueUrl(testDomainEventQueue.queueUrl)
+          .maxNumberOfMessages(10)
+          .waitTimeSeconds(1)
+          .build(),
+      ).get().messages().forEach { sqsMessage ->
+        val (message) = objectMapper.readValue(sqsMessage.body(), HMPPSMessage::class.java)
+        collected += objectMapper.readValue(message, HMPPSDomainEvent::class.java)
+        sqsClient.deleteMessage(
+          DeleteMessageRequest.builder()
+            .queueUrl(testDomainEventQueue.queueUrl)
+            .receiptHandle(sqsMessage.receiptHandle())
+            .build(),
+        )
+      }
+      collected.firstOrNull { it.eventType == eventType }
+    } matches { it != null }
+    return collected.first { it.eventType == eventType }
   }
 
   private fun publishPrisonerReceivedMessage(reason: String) = publishDomainEventMessage(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIncentiveReviewServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIncentiveReviewServiceTest.kt
@@ -12,7 +12,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
@@ -85,6 +87,11 @@ class PrisonerIncentiveReviewServiceTest {
     // Fixes tests which do not explicitly mock findAllByBookingIdInAndCurrentIsTrueOrderByReviewTimeDesc
     // while other tests may override the call to the repo
     whenever(incentiveReviewRepository.findAllByBookingIdInAndCurrentIsTrueOrderByReviewTimeDesc(any()))
+      .thenReturn(emptyFlow())
+
+    // Default for the before/after current-review lookups in merge / booking-moved handling.
+    // Tests that exercise a change in current incentive override this for specific prisoner numbers.
+    whenever(incentiveReviewRepository.findAllByPrisonerNumberOrderByReviewTimeDesc(any()))
       .thenReturn(emptyFlow())
 
     whenever(incentiveLevelService.getAllIncentiveLevelsMapByCode()).thenReturn(incentiveLevels)
@@ -471,7 +478,111 @@ class PrisonerIncentiveReviewServiceTest {
           olderReview.copy(prisonerNumber = "A1244AB"),
         ),
       )
+
+      // Current incentive unchanged (no current-review stubs) so no iep-review.updated event
+      verify(snsService, never()).publishDomainEvent(
+        eventType = eq(IncentivesDomainEventType.IEP_REVIEW_UPDATED),
+        description = any(),
+        occurredAt = any(),
+        additionalInformation = any(),
+      )
     }
+
+    @Test
+    fun `merge publishes iep-review-updated when survivor's current incentive changes`(): Unit = runBlocking {
+      val survivorCurrentBefore = IncentiveReview(
+        id = 3L,
+        prisonerNumber = "A1244AB",
+        bookingId = 1234567L,
+        prisonId = "LEI",
+        reviewedBy = "TEST_STAFF1",
+        levelCode = "STD",
+        current = true,
+        reviewTime = LocalDateTime.now(clock).minusDays(100),
+      )
+      // The removed prisoner's current (Enhanced) review, which the survivor takes on after the merge
+      val survivorCurrentAfter = IncentiveReview(
+        id = 100L,
+        prisonerNumber = "A1244AB",
+        bookingId = 999999L,
+        prisonId = "LEI",
+        reviewedBy = "TEST_STAFF1",
+        levelCode = "ENH",
+        current = true,
+        reviewTime = LocalDateTime.now(clock).minusDays(1),
+      )
+
+      whenever(prisonerSearchService.getPrisonerInfo("A1244AB"))
+        .thenReturn(mockPrisoner(bookingId = 1234567, prisonerNumber = "A1244AB"))
+      whenever(incentiveReviewRepository.findAllByPrisonerNumberOrderByReviewTimeDesc("A8765SS"))
+        .thenReturn(flowOf(survivorCurrentAfter.copy(prisonerNumber = "A8765SS")))
+      // before lookup, then the merge logic's read of the survivor's reviews, then the after lookup
+      whenever(incentiveReviewRepository.findAllByPrisonerNumberOrderByReviewTimeDesc("A1244AB"))
+        .thenReturn(
+          flowOf(survivorCurrentBefore),
+          flowOf(survivorCurrentBefore),
+          flowOf(survivorCurrentAfter),
+        )
+
+      prisonerIncentiveReviewService.processOffenderEvent(prisonerMergedEvent())
+
+      verify(snsService, times(1)).publishDomainEvent(
+        eventType = IncentivesDomainEventType.IEP_REVIEW_UPDATED,
+        description = "An IEP review has been updated",
+        occurredAt = survivorCurrentAfter.reviewTime,
+        additionalInformation = AdditionalInformation(
+          id = 100L,
+          nomsNumber = "A1244AB",
+        ),
+      )
+    }
+
+    @Test
+    fun `booking moved publishes iep-review-updated when moved-to prisoner's current incentive changes`(): Unit =
+      runBlocking {
+        val movedReview = IncentiveReview(
+          id = 10L,
+          prisonerNumber = "A8765SS",
+          bookingId = 1234567L,
+          prisonId = "LEI",
+          reviewedBy = "TEST_STAFF1",
+          levelCode = "ENH",
+          current = true,
+          reviewTime = LocalDateTime.now(clock).minusDays(1),
+        )
+        val movedToBefore = IncentiveReview(
+          id = 5L,
+          prisonerNumber = "A1244AB",
+          bookingId = 222222L,
+          prisonId = "LEI",
+          reviewedBy = "TEST_STAFF1",
+          levelCode = "STD",
+          current = true,
+          reviewTime = LocalDateTime.now(clock).minusDays(5),
+        )
+        val movedToAfter = movedReview.copy(prisonerNumber = "A1244AB")
+
+        whenever(incentiveReviewRepository.findAllByBookingIdOrderByReviewTimeDesc(1234567))
+          .thenReturn(flowOf(movedReview))
+        whenever(incentiveReviewRepository.saveAll(any<List<IncentiveReview>>()))
+          .thenReturn(flowOf())
+        // moved-from prisoner: unchanged current (default empty stub leaves it null before & after)
+        // moved-to prisoner: before lookup then after lookup
+        whenever(incentiveReviewRepository.findAllByPrisonerNumberOrderByReviewTimeDesc("A1244AB"))
+          .thenReturn(flowOf(movedToBefore), flowOf(movedToAfter))
+
+        prisonerIncentiveReviewService.processBookingMovedEvent(bookingMovedEvent())
+
+        verify(snsService, times(1)).publishDomainEvent(
+          eventType = IncentivesDomainEventType.IEP_REVIEW_UPDATED,
+          description = "An IEP review has been updated",
+          occurredAt = movedToAfter.reviewTime,
+          additionalInformation = AdditionalInformation(
+            id = 10L,
+            nomsNumber = "A1244AB",
+          ),
+        )
+      }
 
     @Test
     fun `do not create review if prisoner number is null`(): Unit = runBlocking {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIncentiveReviewServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIncentiveReviewServiceTest.kt
@@ -31,10 +31,13 @@ import uk.gov.justice.digital.hmpps.incentivesapi.dto.PrisonIncentiveLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.PrisonerAlert
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.IncentiveReview
+import uk.gov.justice.digital.hmpps.incentivesapi.jpa.NextReviewDate
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.IncentiveReviewRepository
+import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.NextReviewDateRepository
 import uk.gov.justice.hmpps.kotlin.auth.HmppsReactiveAuthenticationHolder
 import java.time.Clock
 import java.time.Instant
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
@@ -51,6 +54,7 @@ class PrisonerIncentiveReviewServiceTest {
   private val auditService: AuditService = mock()
   private val nextReviewDateGetterService: NextReviewDateGetterService = mock()
   private val nextReviewDateUpdaterService: NextReviewDateUpdaterService = mock()
+  private val nextReviewDateRepository: NextReviewDateRepository = mock()
   private val incentiveStoreService: IncentiveStoreService = mock()
   private val transactionalOperator = TransactionalOperator.create(
     object : ReactiveTransactionManager {
@@ -78,6 +82,7 @@ class PrisonerIncentiveReviewServiceTest {
     clock,
     nextReviewDateGetterService,
     nextReviewDateUpdaterService,
+    nextReviewDateRepository,
     incentiveStoreService,
     transactionalOperator,
   )
@@ -93,6 +98,11 @@ class PrisonerIncentiveReviewServiceTest {
     // Tests that exercise a change in current incentive override this for specific prisoner numbers.
     whenever(incentiveReviewRepository.findAllByPrisonerNumberOrderByReviewTimeDesc(any()))
       .thenReturn(emptyFlow())
+
+    // Default next review date for the snapshot lookups; tests that exercise a next-review-date
+    // change override this with consecutive return values.
+    whenever(nextReviewDateRepository.findById(any()))
+      .thenReturn(NextReviewDate(bookingId = 0L, nextReviewDate = LocalDate.parse("2023-01-01")))
 
     whenever(incentiveLevelService.getAllIncentiveLevelsMapByCode()).thenReturn(incentiveLevels)
   }
@@ -536,6 +546,89 @@ class PrisonerIncentiveReviewServiceTest {
         ),
       )
     }
+
+    @Test
+    fun `merge publishes iep-review-updated when only the survivor's next review date changes`(): Unit = runBlocking {
+      // Same current review row before and after the merge (same level and review time), but the
+      // merge brings in extra history that shifts the computed next review date.
+      val survivorCurrent = IncentiveReview(
+        id = 3L,
+        prisonerNumber = "A1244AB",
+        bookingId = 1234567L,
+        prisonId = "LEI",
+        reviewedBy = "TEST_STAFF1",
+        levelCode = "STD",
+        current = true,
+        reviewTime = LocalDateTime.now(clock).minusDays(100),
+      )
+
+      whenever(prisonerSearchService.getPrisonerInfo("A1244AB"))
+        .thenReturn(mockPrisoner(bookingId = 1234567, prisonerNumber = "A1244AB"))
+      // Removed prisoner has reviews so the merge actually updates records
+      whenever(incentiveReviewRepository.findAllByPrisonerNumberOrderByReviewTimeDesc("A8765SS"))
+        .thenReturn(flowOf(survivorCurrent.copy(id = 50L, prisonerNumber = "A8765SS", bookingId = 999999L)))
+      // before lookup, the merge logic's read, then the after lookup — all the same current review
+      whenever(incentiveReviewRepository.findAllByPrisonerNumberOrderByReviewTimeDesc("A1244AB"))
+        .thenReturn(
+          flowOf(survivorCurrent),
+          flowOf(survivorCurrent),
+          flowOf(survivorCurrent),
+        )
+      // Next review date for the survivor's booking changes as a result of the merge
+      whenever(nextReviewDateRepository.findById(1234567L))
+        .thenReturn(
+          NextReviewDate(bookingId = 1234567L, nextReviewDate = LocalDate.parse("2023-01-01")),
+          NextReviewDate(bookingId = 1234567L, nextReviewDate = LocalDate.parse("2024-06-01")),
+        )
+
+      prisonerIncentiveReviewService.processOffenderEvent(prisonerMergedEvent())
+
+      verify(snsService, times(1)).publishDomainEvent(
+        eventType = IncentivesDomainEventType.IEP_REVIEW_UPDATED,
+        description = "An IEP review has been updated",
+        occurredAt = survivorCurrent.reviewTime,
+        additionalInformation = AdditionalInformation(
+          id = 3L,
+          nomsNumber = "A1244AB",
+        ),
+      )
+    }
+
+    @Test
+    fun `merge does not publish iep-review-updated when level, review time and next review date are unchanged`(): Unit =
+      runBlocking {
+        val survivorCurrent = IncentiveReview(
+          id = 3L,
+          prisonerNumber = "A1244AB",
+          bookingId = 1234567L,
+          prisonId = "LEI",
+          reviewedBy = "TEST_STAFF1",
+          levelCode = "STD",
+          current = true,
+          reviewTime = LocalDateTime.now(clock).minusDays(100),
+        )
+
+        whenever(prisonerSearchService.getPrisonerInfo("A1244AB"))
+          .thenReturn(mockPrisoner(bookingId = 1234567, prisonerNumber = "A1244AB"))
+        whenever(incentiveReviewRepository.findAllByPrisonerNumberOrderByReviewTimeDesc("A8765SS"))
+          .thenReturn(flowOf(survivorCurrent.copy(id = 50L, prisonerNumber = "A8765SS", bookingId = 999999L)))
+        whenever(incentiveReviewRepository.findAllByPrisonerNumberOrderByReviewTimeDesc("A1244AB"))
+          .thenReturn(
+            flowOf(survivorCurrent),
+            flowOf(survivorCurrent),
+            flowOf(survivorCurrent),
+          )
+        // Next review date unchanged (default stub returns the same date for every call)
+
+        prisonerIncentiveReviewService.processOffenderEvent(prisonerMergedEvent())
+
+        verify(snsService, never()).publishDomainEvent(
+          eventType = eq(IncentivesDomainEventType.IEP_REVIEW_UPDATED),
+          description = any(),
+          occurredAt = any(),
+          additionalInformation = any(),
+        )
+      }
 
     @Test
     fun `booking moved publishes iep-review-updated when moved-to prisoner's current incentive changes`(): Unit =


### PR DESCRIPTION
## Problem

prisoner-search ends up with **stale incentive data after a prisoner merge or a
`booking.moved`**, because the incentives API silently rewrote incentive-review ownership
without telling anyone:

- The **merge** handler (`mergedPrisonerDetails`) reassigned the removed prisoner's reviews to
  the surviving prisoner and only sent an audit message — no domain event signalling the level
  changed.
- The **booking.moved** handler (`processBookingMovedEvent`) moved a booking's reviews from one
  NOMS number to another by writing directly through the repository — it emitted nothing at all.

So when the surviving prisoner takes on the deleted prisoner's incentive (or a booking move
changes who holds a current review), consumers never learn the current incentive changed.

## Change

After handling a merge or `booking.moved`, publish an `incentives.iep-review.updated` domain
event **only when the affected prisoner's current incentive review actually changed** (a
different current review row or a different level).

- Reuses the existing `IncentivesDomainEventType.IEP_REVIEW_UPDATED` — already declared in code
  and already documented in `async-api.yml`, so no contract/schema change and consumers can
  already subscribe.
- **Merge:** notifies the surviving prisoner.
- **booking.moved:** notifies the moved-from and moved-to prisoners independently.
- The event carries `additionalInformation = { id, nomsNumber }` (new current review id +
  prisoner number), matching the existing inserted/updated review events; consumers re-fetch by
  NOMS number.

Two small private helpers were added (`currentReviewFor`, `publishIfCurrentReviewChanged`)
reusing the existing `publishReviewDomainEvent`.

## Tests

- Unit (`PrisonerIncentiveReviewServiceTest`): merge that changes the survivor's current level
  emits the event; booking.moved where the moved-to prisoner's current level changes emits the
  event; unchanged booking.moved emits nothing.
- Integration (`PrisonOffenderEventListenerIntTest`): the merge test now asserts an
  `incentives.iep-review.updated` message reaches the test domain-events queue carrying the
  survivor's NOMS number.

`./gradlew build` passes (tests + ktlint).
