### PR TITLE
IR-1808 Add endpoint to repair prisoners left on a switched-away booking

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/BookingSwitchRepair.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/dto/BookingSwitchRepair.kt
@@ -1,0 +1,57 @@
+package uk.gov.justice.digital.hmpps.incentivesapi.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "What repairing a prisoner after a booking switch did, or would do in a dry run")
+enum class BookingSwitchRepairOutcome {
+  @Schema(description = "The prisoner's current incentive level was moved back onto the reinstated booking")
+  REPAIRED,
+
+  @Schema(description = "The prisoner's reviews were already correct, so nothing was changed")
+  NOTHING_TO_DO,
+}
+
+@Schema(
+  description = "Outcome of repairing a prisoner whose incentive level was left on a booking that NOMIS has " +
+    "since switched away from",
+)
+data class BookingSwitchRepairResult(
+  @param:Schema(description = "Prisoner number", example = "A1234BC")
+  val prisonerNumber: String,
+
+  @param:Schema(
+    description = "The booking prisoner-search reports the prisoner is on — the one their level is reinstated to",
+    example = "1234567",
+  )
+  val bookingId: Long,
+
+  @param:Schema(description = "What was done")
+  val outcome: BookingSwitchRepairOutcome,
+
+  @param:Schema(description = "Whether this was a dry run, in which case nothing was written", example = "false")
+  val dryRun: Boolean,
+
+  @param:Schema(description = "The prisoner's current incentive level before the repair", example = "STD")
+  val levelCodeBefore: String?,
+
+  @param:Schema(
+    description = "The prisoner's current incentive level after the repair; for a dry run, what it would become",
+    example = "ENH",
+  )
+  val levelCodeAfter: String?,
+
+  @param:Schema(
+    description = "Ids of the reviews on the mistaken booking that are no longer current",
+    example = "[2345]",
+  )
+  val reviewIdsStoodDown: List<Long>,
+
+  @param:Schema(
+    description = "Id of the review on the reinstated booking that was made current again, if any",
+    example = "1234",
+  )
+  val reviewIdReinstated: Long?,
+
+  @param:Schema(description = "Human-readable summary, useful when nothing was changed")
+  val message: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/ManageIncentiveReviewsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/ManageIncentiveReviewsResource.kt
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.incentivesapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.BookingSwitchRepairResult
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.CreateIncentiveReviewRequest
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IncentiveReviewDetail
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IncentiveReviewSummary
@@ -211,4 +212,54 @@ class ManageIncentiveReviewsResource(
     createIncentiveReviewRequest: CreateIncentiveReviewRequest,
   ): IncentiveReviewDetail =
     prisonerIncentiveReviewService.addIncentiveReview(prisonerNumber, createIncentiveReviewRequest)
+
+  @PostMapping("/prisoner/{prisonerNumber}/repair-booking-switch")
+  @PreAuthorize("hasRole('ROLE_INCENTIVE_REVIEWS') and hasAuthority('SCOPE_write')")
+  @ResponseStatus(HttpStatus.OK)
+  @Operation(
+    summary = "Repairs a prisoner left on the wrong incentive level after NOMIS switched their booking",
+    description = "When a recall is mistakenly admitted onto a new booking and NOMIS staff correct it by " +
+      "re-admitting the prisoner onto their earlier booking, the default-level review written against the " +
+      "mistaken booking stays current and masks the level held on the reinstated booking. This does what the " +
+      "`READMISSION_SWITCH_BOOKING` event now does, for prisoners affected before it was handled or for whom " +
+      "the event was missed, and publishes `incentives.iep-review.updated` so downstream services resync. " +
+      "Safe to re-run: a prisoner who needs no repair is left untouched. " +
+      "Requires INCENTIVE_REVIEWS role and write scope.",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Repair attempted; the response body reports what was changed, if anything",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Incorrect permissions to use this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Prisoner not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  suspend fun repairAfterBookingSwitch(
+    @Schema(description = "Prisoner Number", example = "A1234AB", required = true, pattern = "^[A-Z0-9]{7}$")
+    @PathVariable
+    prisonerNumber: String,
+    @Schema(
+      description = "Report what would change without writing anything or publishing any events",
+      example = "false",
+      required = false,
+      defaultValue = "false",
+      type = "boolean",
+      pattern = "^true|false$",
+    )
+    @RequestParam(defaultValue = "false", value = "dry-run", required = false)
+    dryRun: Boolean = false,
+  ): BookingSwitchRepairResult = prisonerIncentiveReviewService.repairAfterBookingSwitch(prisonerNumber, dryRun)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIncentiveReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIncentiveReviewService.kt
@@ -15,6 +15,8 @@ import org.springframework.transaction.reactive.TransactionalOperator
 import org.springframework.transaction.reactive.executeAndAwait
 import uk.gov.justice.digital.hmpps.incentivesapi.SYSTEM_USERNAME
 import uk.gov.justice.digital.hmpps.incentivesapi.config.NoDataFoundException
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.BookingSwitchRepairOutcome
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.BookingSwitchRepairResult
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.CreateIncentiveReviewRequest
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IncentiveLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IncentiveReviewDetail
@@ -290,8 +292,11 @@ class PrisonerIncentiveReviewService(
    * date/time and the next review date — the fields prisoner-search caches. No event is published
    * if all three are unchanged.
    */
-  private suspend fun publishIfCurrentReviewChanged(prisonerNumber: String, before: CurrentReviewSnapshot?) {
-    val after = currentReviewSnapshotFor(prisonerNumber) ?: return
+  private suspend fun publishIfCurrentReviewChanged(
+    prisonerNumber: String,
+    before: CurrentReviewSnapshot?,
+  ): CurrentReviewSnapshot? {
+    val after = currentReviewSnapshotFor(prisonerNumber) ?: return null
     val changed = before == null ||
       before.review.levelCode != after.review.levelCode ||
       before.review.reviewTime != after.review.reviewTime ||
@@ -300,6 +305,7 @@ class PrisonerIncentiveReviewService(
       val detail = after.review.toIncentiveReviewDetail(incentiveLevelService.getAllIncentiveLevelsMapByCode())
       publishReviewDomainEvent(detail, IncentivesDomainEventType.IEP_REVIEW_UPDATED)
     }
+    return after
   }
 
   private suspend fun publishReviewDomainEvent(
@@ -342,7 +348,32 @@ class PrisonerIncentiveReviewService(
    * them onto their earlier booking. prisoner-search reports that as `READMISSION_SWITCH_BOOKING`
    * and, by its own definition, only when the booking the prisoner is now on is *not* their
    * highest-numbered one — so the mistaken booking always has the higher id.
+   */
+  private suspend fun reinstateReviewsAfterBookingSwitch(prisonOffenderEvent: HMPPSDomainEvent) {
+    val prisonerNumber = prisonOffenderEvent.additionalInformation?.nomsNumber ?: run {
+      log.warn("prisonerNumber null for prisonOffenderEvent: $prisonOffenderEvent")
+      return
+    }
+    reinstateReviewsAfterBookingSwitch(prisonerNumber, repairedBy = SYSTEM_USERNAME, dryRun = false)
+  }
+
+  /**
+   * Repairs a prisoner whose incentive level was left behind on a booking NOMIS has since switched
+   * away from — for those affected before [reinstateReviewsAfterBookingSwitch] was handling the
+   * event, and for any the event is missed for since.
    *
+   * The repair is the same operation the event triggers, so it also publishes
+   * `incentives.iep-review.updated`, which a database-level fix could not do. Running it against a
+   * prisoner who is already correct is a safe no-op, so it can be re-run freely.
+   */
+  suspend fun repairAfterBookingSwitch(prisonerNumber: String, dryRun: Boolean = false) =
+    reinstateReviewsAfterBookingSwitch(
+      prisonerNumber,
+      repairedBy = authenticationHolder.getPrincipal(),
+      dryRun = dryRun,
+    )
+
+  /**
    * The `NEW_ADMISSION`/`READMISSION` event for the mistaken booking will already have written a
    * default-level review against it. Because `current` is unique only per booking, that review is
    * still current and, being the most recent by review time, wins every prisoner-scoped read —
@@ -350,12 +381,11 @@ class PrisonerIncentiveReviewService(
    *
    * Reviews are only flipped, never deleted, so the prisoner's history stays intact.
    */
-  private suspend fun reinstateReviewsAfterBookingSwitch(prisonOffenderEvent: HMPPSDomainEvent) {
-    val prisonerNumber = prisonOffenderEvent.additionalInformation?.nomsNumber ?: run {
-      log.warn("prisonerNumber null for prisonOffenderEvent: $prisonOffenderEvent")
-      return
-    }
-
+  private suspend fun reinstateReviewsAfterBookingSwitch(
+    prisonerNumber: String,
+    repairedBy: String,
+    dryRun: Boolean,
+  ): BookingSwitchRepairResult {
     val correctBookingId = prisonerSearchService.getPrisonerInfo(prisonerNumber).bookingId
     val before = currentReviewSnapshotFor(prisonerNumber)
 
@@ -371,12 +401,44 @@ class PrisonerIncentiveReviewService(
     }
     // `reviews` is ordered by review time descending, so this is the latest on the correct booking
     val latestOnCorrectBooking = reviews.firstOrNull { it.bookingId == correctBookingId }
+    val reviewToReinstate = latestOnCorrectBooking?.takeUnless { it.current }
 
-    if (supersededReviews.isEmpty() && latestOnCorrectBooking?.current != false) {
-      log.info(
-        "Booking switch for $prisonerNumber: nothing to reinstate on booking $correctBookingId",
+    if (supersededReviews.isEmpty() && reviewToReinstate == null) {
+      val message = "Booking switch for $prisonerNumber: nothing to reinstate on booking $correctBookingId"
+      log.info(message)
+      return BookingSwitchRepairResult(
+        prisonerNumber = prisonerNumber,
+        bookingId = correctBookingId,
+        outcome = BookingSwitchRepairOutcome.NOTHING_TO_DO,
+        dryRun = dryRun,
+        levelCodeBefore = before?.review?.levelCode,
+        levelCodeAfter = before?.review?.levelCode,
+        reviewIdsStoodDown = emptyList(),
+        reviewIdReinstated = null,
+        message = message,
       )
-      return
+    }
+
+    val supersededIds = supersededReviews.map { it.id }
+    val message = "Reinstated incentive level on booking $correctBookingId for $prisonerNumber " +
+      "after booking switch; ${supersededReviews.size} review(s) on later bookings no longer current"
+
+    if (dryRun) {
+      log.info("Dry run — would have $message")
+      return BookingSwitchRepairResult(
+        prisonerNumber = prisonerNumber,
+        bookingId = correctBookingId,
+        outcome = BookingSwitchRepairOutcome.REPAIRED,
+        dryRun = true,
+        levelCodeBefore = before?.review?.levelCode,
+        // of the reviews left current afterwards, the newest is what a prisoner-scoped read picks
+        levelCodeAfter = reviews.firstOrNull {
+          it.id == reviewToReinstate?.id || (it.current && it.id !in supersededIds)
+        }?.levelCode,
+        reviewIdsStoodDown = supersededIds,
+        reviewIdReinstated = reviewToReinstate?.id,
+        message = "Dry run — would have $message",
+      )
     }
 
     val changes = transactionalOperator.executeAndAwait {
@@ -385,22 +447,30 @@ class PrisonerIncentiveReviewService(
       incentiveReviewRepository
         .saveAll(supersededReviews.map { it.copy(current = false, new = false) })
         .collect {}
-      latestOnCorrectBooking
-        ?.takeUnless { it.current }
-        ?.let { incentiveReviewRepository.save(it.copy(current = true, new = false)) }
+      reviewToReinstate?.let { incentiveReviewRepository.save(it.copy(current = true, new = false)) }
       nextReviewDateUpdaterService.updateWriteOnly(correctBookingId)
     }
     nextReviewDateUpdaterService.publishDomainEvents(changes)
 
-    val message = "Reinstated incentive level on booking $correctBookingId for $prisonerNumber " +
-      "after booking switch; ${supersededReviews.size} review(s) on later bookings no longer current"
     log.info(message)
-    publishIfCurrentReviewChanged(prisonerNumber, before)
+    val after = publishIfCurrentReviewChanged(prisonerNumber, before)
     auditService.sendMessage(
       AuditType.PRISONER_BOOKING_SWITCHED,
       prisonerNumber,
       message,
-      SYSTEM_USERNAME,
+      repairedBy,
+    )
+
+    return BookingSwitchRepairResult(
+      prisonerNumber = prisonerNumber,
+      bookingId = correctBookingId,
+      outcome = BookingSwitchRepairOutcome.REPAIRED,
+      dryRun = false,
+      levelCodeBefore = before?.review?.levelCode,
+      levelCodeAfter = after?.review?.levelCode,
+      reviewIdsStoodDown = supersededIds,
+      reviewIdReinstated = reviewToReinstate?.id,
+      message = message,
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/ManageIncentiveReviewsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/ManageIncentiveReviewsResourceTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.incentivesapi.resource
 
 import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -10,6 +11,7 @@ import org.springframework.test.json.JsonCompareMode
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.CreateIncentiveReviewRequest
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.ReviewType
 import uk.gov.justice.digital.hmpps.incentivesapi.integration.IncentiveLevelResourceTestBase
+import uk.gov.justice.digital.hmpps.incentivesapi.jpa.IncentiveReview
 import uk.gov.justice.digital.hmpps.incentivesapi.jpa.repository.IncentiveReviewRepository
 import java.time.LocalDate.now
 import java.time.LocalDateTime
@@ -181,5 +183,154 @@ class ManageIncentiveReviewsResourceTest : IncentiveLevelResourceTestBase() {
         """,
         JsonCompareMode.LENIENT,
       )
+  }
+
+  /**
+   * The prisoner was mistakenly admitted on a new (higher) booking, where this service recorded the
+   * prison's default level, and NOMIS staff have since put them back on the earlier booking where
+   * they hold Enhanced. The repair endpoint corrects prisoners this happened to before the
+   * `READMISSION_SWITCH_BOOKING` event was handled, and any the event is missed for since.
+   */
+  private val repairPrisonerNumber = "A1244AB"
+  private val reinstatedBookingId = 1294100L
+  private val mistakenBookingId = 1294200L
+
+  private suspend fun givenPrisonerNeedingRepair(): Pair<Long, Long> {
+    prisonerSearchMockServer.stubGetPrisonerInfoByPrisonerNumber(reinstatedBookingId, repairPrisonerNumber)
+    prisonApiMockServer.stubGetPrisonerExtraInfo(reinstatedBookingId, repairPrisonerNumber)
+
+    val reinstatedReview = repository.save(
+      IncentiveReview(
+        bookingId = reinstatedBookingId,
+        prisonerNumber = repairPrisonerNumber,
+        prisonId = "LEI",
+        reviewedBy = "TEST_STAFF1",
+        levelCode = "ENH",
+        current = true,
+        reviewTime = LocalDateTime.now(clock).minusDays(100),
+      ),
+    )
+    val mistakenReview = repository.save(
+      IncentiveReview(
+        bookingId = mistakenBookingId,
+        prisonerNumber = repairPrisonerNumber,
+        prisonId = "MDI",
+        reviewedBy = "INCENTIVES_API",
+        levelCode = "STD",
+        current = true,
+        reviewType = ReviewType.INITIAL,
+        reviewTime = LocalDateTime.now(clock).minusDays(1),
+      ),
+    )
+    return reinstatedReview.id to mistakenReview.id
+  }
+
+  @Test
+  fun `repair after booking switch requires the write scope`() {
+    webTestClient.post().uri("/incentive-reviews/prisoner/$repairPrisonerNumber/repair-booking-switch")
+      .headers(setAuthorisation(roles = listOf("ROLE_INCENTIVE_REVIEWS"), scopes = listOf("read")))
+      .exchange()
+      .expectStatus().isForbidden
+  }
+
+  @Test
+  fun `repair after booking switch requires authorisation`() {
+    webTestClient.post().uri("/incentive-reviews/prisoner/$repairPrisonerNumber/repair-booking-switch")
+      .exchange()
+      .expectStatus().isUnauthorized
+  }
+
+  @Test
+  fun `repair after booking switch moves the current level back onto the reinstated booking`(): Unit = runBlocking {
+    // Given
+    val (reinstatedReviewId, mistakenReviewId) = givenPrisonerNeedingRepair()
+
+    // When
+    webTestClient.post().uri("/incentive-reviews/prisoner/$repairPrisonerNumber/repair-booking-switch")
+      .headers(setAuthorisation(roles = listOf("ROLE_INCENTIVE_REVIEWS"), scopes = listOf("read", "write")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody().json(
+        // language=json
+        """
+        {
+          "prisonerNumber": "$repairPrisonerNumber",
+          "bookingId": $reinstatedBookingId,
+          "outcome": "REPAIRED",
+          "dryRun": false,
+          "levelCodeBefore": "STD",
+          "levelCodeAfter": "ENH",
+          "reviewIdsStoodDown": [$mistakenReviewId]
+        }
+        """,
+        JsonCompareMode.LENIENT,
+      )
+
+    // Then
+    assertThat(repository.findById(mistakenReviewId)?.current).isFalse()
+    assertThat(repository.findById(reinstatedReviewId)?.current).isTrue()
+  }
+
+  @Test
+  fun `repair after booking switch is a safe no-op when the prisoner is already correct`(): Unit = runBlocking {
+    // Given - so the repair can be re-run over a list without checking each prisoner first
+    val (reinstatedReviewId, mistakenReviewId) = givenPrisonerNeedingRepair()
+    val uri = "/incentive-reviews/prisoner/$repairPrisonerNumber/repair-booking-switch"
+    webTestClient.post().uri(uri)
+      .headers(setAuthorisation(roles = listOf("ROLE_INCENTIVE_REVIEWS"), scopes = listOf("read", "write")))
+      .exchange()
+      .expectStatus().isOk
+
+    // When - repaired a second time
+    webTestClient.post().uri(uri)
+      .headers(setAuthorisation(roles = listOf("ROLE_INCENTIVE_REVIEWS"), scopes = listOf("read", "write")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody().json(
+        // language=json
+        """
+        {
+          "outcome": "NOTHING_TO_DO",
+          "levelCodeBefore": "ENH",
+          "levelCodeAfter": "ENH",
+          "reviewIdsStoodDown": [],
+          "reviewIdReinstated": null
+        }
+        """,
+        JsonCompareMode.LENIENT,
+      )
+
+    // Then
+    assertThat(repository.findById(mistakenReviewId)?.current).isFalse()
+    assertThat(repository.findById(reinstatedReviewId)?.current).isTrue()
+  }
+
+  @Test
+  fun `repair after booking switch dry run reports the change without making it`(): Unit = runBlocking {
+    // Given
+    val (reinstatedReviewId, mistakenReviewId) = givenPrisonerNeedingRepair()
+
+    // When
+    webTestClient.post().uri("/incentive-reviews/prisoner/$repairPrisonerNumber/repair-booking-switch?dry-run=true")
+      .headers(setAuthorisation(roles = listOf("ROLE_INCENTIVE_REVIEWS"), scopes = listOf("read", "write")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody().json(
+        // language=json
+        """
+        {
+          "outcome": "REPAIRED",
+          "dryRun": true,
+          "levelCodeBefore": "STD",
+          "levelCodeAfter": "ENH",
+          "reviewIdsStoodDown": [$mistakenReviewId]
+        }
+        """,
+        JsonCompareMode.LENIENT,
+      )
+
+    // Then - the reviews are untouched
+    assertThat(repository.findById(mistakenReviewId)?.current).isTrue()
+    assertThat(repository.findById(reinstatedReviewId)?.current).isTrue()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIncentiveReviewServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIncentiveReviewServiceTest.kt
@@ -24,6 +24,7 @@ import org.springframework.transaction.ReactiveTransactionManager
 import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.reactive.TransactionalOperator
 import reactor.core.publisher.Mono
+import uk.gov.justice.digital.hmpps.incentivesapi.dto.BookingSwitchRepairOutcome
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.CreateIncentiveReviewRequest
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IncentiveLevel
 import uk.gov.justice.digital.hmpps.incentivesapi.dto.IncentiveReviewDetail
@@ -105,6 +106,50 @@ class PrisonerIncentiveReviewServiceTest {
       .thenReturn(NextReviewDate(bookingId = 0L, nextReviewDate = LocalDate.parse("2023-01-01")))
 
     whenever(incentiveLevelService.getAllIncentiveLevelsMapByCode()).thenReturn(incentiveLevels)
+  }
+
+  /**
+   * A mistaken new booking is corrected in NOMIS by releasing the prisoner and re-admitting them
+   * onto their earlier booking, so the reinstated booking always has the *lower* id. Shared by the
+   * event-driven correction and the repair endpoint, which are the same operation.
+   */
+  private val switchPrisonerNumber = "A1244AB"
+  private val reinstatedBookingId = 1000000L
+  private val mistakenBookingId = 2000000L
+
+  private val reviewOnReinstatedBooking = IncentiveReview(
+    id = 1L,
+    prisonerNumber = switchPrisonerNumber,
+    bookingId = reinstatedBookingId,
+    prisonId = "LEI",
+    reviewedBy = "TEST_STAFF1",
+    levelCode = "ENH",
+    current = true,
+    reviewTime = LocalDateTime.now(clock).minusDays(100),
+  )
+
+  private val reviewOnMistakenBooking = IncentiveReview(
+    id = 2L,
+    prisonerNumber = switchPrisonerNumber,
+    bookingId = mistakenBookingId,
+    prisonId = "MDI",
+    reviewedBy = "INCENTIVES_API",
+    levelCode = "STD",
+    current = true,
+    reviewType = ReviewType.INITIAL,
+    reviewTime = LocalDateTime.now(clock).minusDays(1),
+  )
+
+  private suspend fun stubBookingSwitch(vararg reviews: IncentiveReview) {
+    whenever(prisonerSearchService.getPrisonerInfo(switchPrisonerNumber))
+      .thenReturn(mockPrisoner(bookingId = reinstatedBookingId, prisonerNumber = switchPrisonerNumber))
+    // before snapshot, the handler's own read, then the after snapshot
+    whenever(incentiveReviewRepository.findAllByPrisonerNumberOrderByReviewTimeDesc(switchPrisonerNumber))
+      .thenReturn(flowOf(*reviews), flowOf(*reviews), flowOf(*reviews))
+    whenever(incentiveReviewRepository.saveAll(any<List<IncentiveReview>>())).thenReturn(flowOf())
+    whenever(incentiveReviewRepository.save(any())).thenAnswer { i -> i.arguments[0] }
+    whenever(nextReviewDateUpdaterService.updateWriteOnly(reinstatedBookingId))
+      .thenReturn(NextReviewDateChanges(emptyMap(), emptyList(), emptyMap()))
   }
 
   @DisplayName("add incentive review")
@@ -677,49 +722,6 @@ class PrisonerIncentiveReviewServiceTest {
         )
       }
 
-    /**
-     * A mistaken new booking is corrected in NOMIS by releasing the prisoner and re-admitting them
-     * onto their earlier booking, so the reinstated booking always has the *lower* id.
-     */
-    private val switchPrisonerNumber = "A1244AB"
-    private val reinstatedBookingId = 1000000L
-    private val mistakenBookingId = 2000000L
-
-    private val reviewOnReinstatedBooking = IncentiveReview(
-      id = 1L,
-      prisonerNumber = switchPrisonerNumber,
-      bookingId = reinstatedBookingId,
-      prisonId = "LEI",
-      reviewedBy = "TEST_STAFF1",
-      levelCode = "ENH",
-      current = true,
-      reviewTime = LocalDateTime.now(clock).minusDays(100),
-    )
-
-    private val reviewOnMistakenBooking = IncentiveReview(
-      id = 2L,
-      prisonerNumber = switchPrisonerNumber,
-      bookingId = mistakenBookingId,
-      prisonId = "MDI",
-      reviewedBy = "INCENTIVES_API",
-      levelCode = "STD",
-      current = true,
-      reviewType = ReviewType.INITIAL,
-      reviewTime = LocalDateTime.now(clock).minusDays(1),
-    )
-
-    private suspend fun stubBookingSwitch(vararg reviews: IncentiveReview) {
-      whenever(prisonerSearchService.getPrisonerInfo(switchPrisonerNumber))
-        .thenReturn(mockPrisoner(bookingId = reinstatedBookingId, prisonerNumber = switchPrisonerNumber))
-      // before snapshot, the handler's own read, then the after snapshot
-      whenever(incentiveReviewRepository.findAllByPrisonerNumberOrderByReviewTimeDesc(switchPrisonerNumber))
-        .thenReturn(flowOf(*reviews), flowOf(*reviews), flowOf(*reviews))
-      whenever(incentiveReviewRepository.saveAll(any<List<IncentiveReview>>())).thenReturn(flowOf())
-      whenever(incentiveReviewRepository.save(any())).thenAnswer { i -> i.arguments[0] }
-      whenever(nextReviewDateUpdaterService.updateWriteOnly(reinstatedBookingId))
-        .thenReturn(NextReviewDateChanges(emptyMap(), emptyList(), emptyMap()))
-    }
-
     @Test
     fun `booking switch stands down the review written against the mistaken later booking`(): Unit = runBlocking {
       // Given - the prisoner is back on their earlier booking, but the review this service wrote
@@ -905,6 +907,135 @@ class PrisonerIncentiveReviewServiceTest {
 
       // Then
       verifyNoInteractions(incentiveReviewRepository)
+    }
+  }
+
+  @DisplayName("repair after booking switch")
+  @Nested
+  inner class RepairAfterBookingSwitch {
+
+    @BeforeEach
+    fun setUp(): Unit = runBlocking {
+      whenever(authenticationHolder.getPrincipal()).thenReturn("REPAIR_USER")
+    }
+
+    @Test
+    fun `repairs a prisoner left on the level from a booking NOMIS has switched away from`(): Unit = runBlocking {
+      // Given - the same state the event handler corrects, but for a prisoner whose event was
+      // missed or who was affected before the event was handled at all
+      val notCurrentOnReinstatedBooking = reviewOnReinstatedBooking.copy(current = false)
+      whenever(prisonerSearchService.getPrisonerInfo(switchPrisonerNumber))
+        .thenReturn(mockPrisoner(bookingId = reinstatedBookingId, prisonerNumber = switchPrisonerNumber))
+      whenever(incentiveReviewRepository.saveAll(any<List<IncentiveReview>>())).thenReturn(flowOf())
+      whenever(incentiveReviewRepository.save(any())).thenAnswer { i -> i.arguments[0] }
+      whenever(nextReviewDateUpdaterService.updateWriteOnly(reinstatedBookingId))
+        .thenReturn(NextReviewDateChanges(emptyMap(), emptyList(), emptyMap()))
+      // before snapshot, the repair's own read, then the after snapshot
+      whenever(incentiveReviewRepository.findAllByPrisonerNumberOrderByReviewTimeDesc(switchPrisonerNumber))
+        .thenReturn(
+          flowOf(reviewOnMistakenBooking, notCurrentOnReinstatedBooking),
+          flowOf(reviewOnMistakenBooking, notCurrentOnReinstatedBooking),
+          flowOf(reviewOnReinstatedBooking),
+        )
+
+      // When
+      val result = prisonerIncentiveReviewService.repairAfterBookingSwitch(switchPrisonerNumber)
+
+      // Then
+      assertThat(result.outcome).isEqualTo(BookingSwitchRepairOutcome.REPAIRED)
+      assertThat(result.dryRun).isFalse()
+      assertThat(result.bookingId).isEqualTo(reinstatedBookingId)
+      assertThat(result.levelCodeBefore).isEqualTo("STD")
+      assertThat(result.levelCodeAfter).isEqualTo("ENH")
+      assertThat(result.reviewIdsStoodDown).isEqualTo(listOf(reviewOnMistakenBooking.id))
+      assertThat(result.reviewIdReinstated).isEqualTo(reviewOnReinstatedBooking.id)
+
+      @Suppress("UnusedFlow")
+      verify(incentiveReviewRepository).saveAll(listOf(reviewOnMistakenBooking.copy(current = false, new = false)))
+      verify(incentiveReviewRepository).save(notCurrentOnReinstatedBooking.copy(current = true, new = false))
+      verify(nextReviewDateUpdaterService, times(1)).updateWriteOnly(reinstatedBookingId)
+    }
+
+    @Test
+    fun `repair publishes iep-review-updated so downstream services resync`(): Unit = runBlocking {
+      // Given - a database-level fix could not do this, which is why the repair is an endpoint
+      whenever(prisonerSearchService.getPrisonerInfo(switchPrisonerNumber))
+        .thenReturn(mockPrisoner(bookingId = reinstatedBookingId, prisonerNumber = switchPrisonerNumber))
+      whenever(incentiveReviewRepository.saveAll(any<List<IncentiveReview>>())).thenReturn(flowOf())
+      whenever(nextReviewDateUpdaterService.updateWriteOnly(reinstatedBookingId))
+        .thenReturn(NextReviewDateChanges(emptyMap(), emptyList(), emptyMap()))
+      whenever(incentiveReviewRepository.findAllByPrisonerNumberOrderByReviewTimeDesc(switchPrisonerNumber))
+        .thenReturn(
+          flowOf(reviewOnMistakenBooking, reviewOnReinstatedBooking),
+          flowOf(reviewOnMistakenBooking, reviewOnReinstatedBooking),
+          flowOf(reviewOnReinstatedBooking),
+        )
+
+      // When
+      prisonerIncentiveReviewService.repairAfterBookingSwitch(switchPrisonerNumber)
+
+      // Then
+      verify(snsService, times(1)).publishDomainEvent(
+        eventType = IncentivesDomainEventType.IEP_REVIEW_UPDATED,
+        description = "An IEP review has been updated",
+        occurredAt = reviewOnReinstatedBooking.reviewTime,
+        additionalInformation = AdditionalInformation(
+          id = reviewOnReinstatedBooking.id,
+          nomsNumber = switchPrisonerNumber,
+        ),
+      )
+      // audited against the caller rather than the service, since a person asked for this
+      verify(auditService, times(1)).sendMessage(
+        eq(AuditType.PRISONER_BOOKING_SWITCHED),
+        eq(switchPrisonerNumber),
+        any(),
+        eq("REPAIR_USER"),
+      )
+    }
+
+    @Test
+    fun `dry run reports the repair without writing anything or publishing events`(): Unit = runBlocking {
+      // Given
+      stubBookingSwitch(reviewOnMistakenBooking, reviewOnReinstatedBooking)
+
+      // When
+      val result = prisonerIncentiveReviewService.repairAfterBookingSwitch(switchPrisonerNumber, dryRun = true)
+
+      // Then
+      assertThat(result.outcome).isEqualTo(BookingSwitchRepairOutcome.REPAIRED)
+      assertThat(result.dryRun).isTrue()
+      assertThat(result.levelCodeBefore).isEqualTo("STD")
+      assertThat(result.levelCodeAfter).isEqualTo("ENH")
+      assertThat(result.reviewIdsStoodDown).isEqualTo(listOf(reviewOnMistakenBooking.id))
+
+      @Suppress("UnusedFlow")
+      verify(incentiveReviewRepository, never()).saveAll(any<List<IncentiveReview>>())
+      verify(incentiveReviewRepository, never()).save(any())
+      verify(nextReviewDateUpdaterService, never()).updateWriteOnly(any())
+      verifyNoInteractions(snsService)
+      verifyNoInteractions(auditService)
+    }
+
+    @Test
+    fun `repairing a prisoner who is already correct is a safe no-op`(): Unit = runBlocking {
+      // Given - so the repair can be re-run over the whole list without checking first
+      stubBookingSwitch(reviewOnReinstatedBooking)
+
+      // When
+      val result = prisonerIncentiveReviewService.repairAfterBookingSwitch(switchPrisonerNumber)
+
+      // Then
+      assertThat(result.outcome).isEqualTo(BookingSwitchRepairOutcome.NOTHING_TO_DO)
+      assertThat(result.levelCodeBefore).isEqualTo("ENH")
+      assertThat(result.levelCodeAfter).isEqualTo("ENH")
+      assertThat(result.reviewIdsStoodDown).isEmpty()
+      assertThat(result.reviewIdReinstated).isNull()
+
+      @Suppress("UnusedFlow")
+      verify(incentiveReviewRepository, never()).saveAll(any<List<IncentiveReview>>())
+      verify(incentiveReviewRepository, never()).save(any())
+      verifyNoInteractions(snsService)
+      verifyNoInteractions(auditService)
     }
   }
 


### PR DESCRIPTION
[IR-1808](https://dsdmoj.atlassian.net/browse/IR-1808)

Follows #786.

## Why

#786 handles the `READMISSION_SWITCH_BOOKING` event so the problem stops recurring. It does nothing for the prisoners already affected.

The incentives reconciliation report in hmpps-prisoner-to-nomis-update still shows **21 mismatches** as at 03/08/2026, **four of them new** since the 27/07 run — the problem was still actively producing new cases while #786 was being written. (Five others self-resolved in the same week, presumably because a real review touched them.)

## Change

```
POST /incentive-reviews/prisoner/{prisonerNumber}/repair-booking-switch[?dry-run=true]
```

`ROLE_INCENTIVE_REVIEWS` + write scope. It runs the same correction the event triggers — the event handler's body is extracted into a shared method rather than reimplemented, so the two cannot drift apart.

The response reports what changed, so a run can be checked against NOMIS afterwards:

```json
{ "prisonerNumber": "A9436AA", "bookingId": 3064398, "outcome": "REPAIRED",
  "dryRun": false, "levelCodeBefore": "STD", "levelCodeAfter": "ENH",
  "reviewIdsStoodDown": [2345], "reviewIdReinstated": 1234 }
```

- `?dry-run=true` returns the same body without writing or publishing anything.
- Repairing a prisoner who is already correct returns `NOTHING_TO_DO` and touches nothing, so the list is safe to re-run.
- Audited as the calling user rather than `INCENTIVES_API`, since a person asked for it.

## Why an endpoint rather than a Flyway migration

The original plan on the ticket was `V1_35__fix_readmission_switch_booking.sql` with review IDs derived from production. A migration writes to the database without emitting domain events, so prisoner-search would have carried on serving the stale level until something else touched each prisoner — and the ticket carried an open question about replaying prisoner-search's `PUT /events/prisoner/received/{prisonerNumber}` admin endpoint to work around that.

Going through the service instead means the repair publishes `incentives.iep-review.updated` itself. That closes the open question, and avoids hard-coding production review IDs into a migration that would match nothing in dev or preprod. The migration approach is dropped.

Worth noting for the sync side: hmpps-prisoner-to-nomis-update subscribes only to `incentives.iep-review.inserted` (`IncentivesDomainEventListener.kt:35`), not `updated`, so the repair will **not** write anything back into NOMIS. That is the desired behaviour — NOMIS is already correct; it is DPS that is wrong.

## Running it

Dry-run the full list first. Anything returning `NOTHING_TO_DO` is mismatching for some other reason and needs investigating separately rather than being assumed fixed. Then re-run without `dry-run` and confirm against the next reconciliation report.

## Testing

- 4 unit tests in `PrisonerIncentiveReviewServiceTest` — repair, event publication and audit actor, dry run, and the already-correct no-op.
- 5 tests in `ManageIncentiveReviewsResourceTest` — 401, 403 without write scope, the repair end to end, idempotency on a second call, and dry run leaving the rows untouched.
- `./gradlew build` green — 309 tests.


[IR-1808]: https://dsdmoj.atlassian.net/browse/IR-1808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ