### PR TITLE
IR-1808 Stand down every abandoned booking, not just the newest

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIncentiveReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIncentiveReviewService.kt
@@ -207,9 +207,18 @@ class PrisonerIncentiveReviewService(
     incentiveLevels: Map<String, IncentiveLevel>,
     withDetails: Boolean = true,
   ): IncentiveReviewSummary {
-    val iepDetails = levels.map { it.toIncentiveReviewDetail(incentiveLevels) }.toList()
+    val reviews = levels.toList()
+    val iepDetails = reviews.map { it.toIncentiveReviewDetail(incentiveLevels) }
 
-    val currentIep = iepDetails.firstOrNull() ?: throw IncentiveReviewNotFoundException("Not Found incentive reviews")
+    // Reviews arrive newest first, but the newest is not always the current one. A prisoner
+    // mistakenly admitted onto a new booking has a default-level review that is newer yet no longer
+    // current, and it must not mask the level they hold on the booking they are actually on; a
+    // backdated review is current while an older-dated one is newer. `current` is what
+    // IncentiveStoreService.saveIncentiveReview asserts, so it decides. Falling back to the newest
+    // keeps behaviour for any prisoner whose rows predate the flag being maintained.
+    val currentIep = reviews.zip(iepDetails).firstOrNull { (review, _) -> review.current }?.second
+      ?: iepDetails.firstOrNull()
+      ?: throw IncentiveReviewNotFoundException("Not Found incentive reviews")
 
     val incentiveReviewSummary = IncentiveReviewSummary(
       bookingId = currentIep.bookingId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIncentiveReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIncentiveReviewService.kt
@@ -347,7 +347,7 @@ class PrisonerIncentiveReviewService(
    * NOMIS users correct a mistakenly-created new booking by releasing the prisoner and re-admitting
    * them onto their earlier booking. prisoner-search reports that as `READMISSION_SWITCH_BOOKING`
    * and, by its own definition, only when the booking the prisoner is now on is *not* their
-   * highest-numbered one — so the mistaken booking always has the higher id.
+   * highest-numbered one — so the mistaken bookings always have higher ids.
    */
   private suspend fun reinstateReviewsAfterBookingSwitch(prisonOffenderEvent: HMPPSDomainEvent) {
     val prisonerNumber = prisonOffenderEvent.additionalInformation?.nomsNumber ?: run {
@@ -390,14 +390,17 @@ class PrisonerIncentiveReviewService(
     val before = currentReviewSnapshotFor(prisonerNumber)
 
     val reviews = incentiveReviewRepository.findAllByPrisonerNumberOrderByReviewTimeDesc(prisonerNumber).toList()
-    // The mistaken booking is the one NOMIS has just created, so it is the prisoner's newest.
-    // Restricting to the single highest booking above the reinstated one matters when a prisoner is
-    // switched back past an intermediate booking: reviews on earlier bookings are legitimate history
-    // from previous sentences, are routinely left current because nothing ever clears them, and must
-    // survive. Only reviews this service authored can be the mistaken admission.
-    val mistakenBookingId = reviews.mapNotNull { it.bookingId.takeIf { id -> id > correctBookingId } }.maxOrNull()
+    // Booking ids are sequential, so a booking above the one the prisoner is now on was created
+    // after it and is one they are not on — an admission that was abandoned. Staff sometimes get it
+    // wrong more than once before switching back, so every such booking is stood down, not just the
+    // newest. Genuine history from earlier sentences sits on *lower* bookings, is routinely left
+    // current because nothing ever clears it, and is excluded by the id comparison.
+    //
+    // Only reviews this service wrote on admission are touched. A human review on a later booking is
+    // a real decision about the prisoner and is never stood down, even though the booking was
+    // abandoned — see the note on IR-1808 about what that leaves behind.
     val supersededReviews = reviews.filter {
-      it.current && it.bookingId == mistakenBookingId && it.reviewedBy == SYSTEM_USERNAME
+      it.current && it.bookingId > correctBookingId && it.reviewedBy == SYSTEM_USERNAME
     }
     // `reviews` is ordered by review time descending, so this is the latest on the correct booking
     val latestOnCorrectBooking = reviews.firstOrNull { it.bookingId == correctBookingId }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/service/PrisonOffenderEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/integration/service/PrisonOffenderEventListenerIntTest.kt
@@ -170,6 +170,17 @@ class PrisonOffenderEventListenerIntTest : SqsIntegrationTestBase() {
     assertThat(reviews[reinstatedReview.id]?.current).isTrue()
     assertThat(reviews[reinstatedReview.id]?.levelCode).isEqualTo("ENH")
 
+    // and the prisoner reads back as Enhanced. Asserting the flags alone is not enough: the
+    // stood-down review is newer by review time, so a read that took the newest would still say
+    // Standard — which is what prisoner-search and the NOMIS reconciliation would then cache.
+    webTestClient.get().uri("/incentive-reviews/prisoner/$prisonerNumber")
+      .headers(setAuthorisation(roles = listOf("ROLE_INCENTIVE_REVIEWS"), scopes = listOf("read")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.iepCode").isEqualTo("ENH")
+      .jsonPath("$.bookingId").isEqualTo(reinstatedBookingId)
+
     // and downstream consumers are told the current incentive changed
     val domainEvent = awaitDomainEventOfType("incentives.iep-review.updated")
     assertThat(domainEvent.additionalInformation?.nomsNumber).isEqualTo(prisonerNumber)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/ManageIncentiveReviewsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/resource/ManageIncentiveReviewsResourceTest.kt
@@ -269,6 +269,27 @@ class ManageIncentiveReviewsResourceTest : IncentiveLevelResourceTestBase() {
     // Then
     assertThat(repository.findById(mistakenReviewId)?.current).isFalse()
     assertThat(repository.findById(reinstatedReviewId)?.current).isTrue()
+
+    // and — the assertion that matters — the prisoner now reads back as Enhanced. This is what
+    // prisoner-search and the NOMIS reconciliation both call, so flipping the flags is only useful
+    // insofar as it changes this. The stood-down review is newer by review time and would win a
+    // naive "newest wins" read.
+    webTestClient.get().uri("/incentive-reviews/prisoner/$repairPrisonerNumber")
+      .headers(setAuthorisation(roles = listOf("ROLE_INCENTIVE_REVIEWS"), scopes = listOf("read")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody().json(
+        // language=json
+        """
+        {
+          "id": $reinstatedReviewId,
+          "bookingId": $reinstatedBookingId,
+          "iepCode": "ENH",
+          "iepLevel": "Enhanced"
+        }
+        """,
+        JsonCompareMode.LENIENT,
+      )
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIncentiveReviewServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIncentiveReviewServiceTest.kt
@@ -790,39 +790,56 @@ class PrisonerIncentiveReviewServiceTest {
     }
 
     @Test
-    fun `booking switch only stands down the newest booking when switched back past an intermediate one`(): Unit =
+    fun `booking switch stands down every later booking when staff got the admission wrong twice`(): Unit =
       runBlocking {
-        // Given - the prisoner is switched back to the oldest of three bookings. prisoner-search
-        // only requires the reinstated booking not to be the highest, so this is possible. The
-        // intermediate booking's current review is legitimate history and must survive.
-        val intermediateBookingReview = IncentiveReview(
+        // Given - staff admitted the prisoner onto a new booking, did it again two days later, then
+        // switched back past both. Seen in production for A3812EX. Booking ids are sequential, so
+        // anything above the reinstated booking was created after it and was abandoned; standing
+        // down only the newest would leave the second admission's default level winning the read.
+        val secondMistakenBooking = IncentiveReview(
           id = 4L,
           prisonerNumber = switchPrisonerNumber,
           bookingId = 1500000L,
           prisonId = "LEI",
           reviewedBy = "INCENTIVES_API",
-          levelCode = "BAS",
+          levelCode = "STD",
           current = true,
           reviewType = ReviewType.INITIAL,
-          reviewTime = LocalDateTime.now(clock).minusDays(50),
+          reviewTime = LocalDateTime.now(clock).minusDays(3),
         )
-        stubBookingSwitch(reviewOnMistakenBooking, intermediateBookingReview, reviewOnReinstatedBooking)
+        stubBookingSwitch(reviewOnMistakenBooking, secondMistakenBooking, reviewOnReinstatedBooking)
 
         // When
         prisonerIncentiveReviewService.processOffenderEvent(prisonOffenderEvent("READMISSION_SWITCH_BOOKING"))
 
-        // Then - only the newest (mistaken) booking is stood down
+        // Then - both abandoned bookings are stood down, leaving the reinstated booking's level
         @Suppress("UnusedFlow")
         verify(incentiveReviewRepository).saveAll(
-          listOf(reviewOnMistakenBooking.copy(current = false, new = false)),
+          listOf(
+            reviewOnMistakenBooking.copy(current = false, new = false),
+            secondMistakenBooking.copy(current = false, new = false),
+          ),
         )
       }
 
     @Test
     fun `booking switch leaves a human-authored review on a later booking alone`(): Unit = runBlocking {
-      // Given - only reviews this service wrote can be the mistaken admission
+      // Given - staff reviewed the prisoner the day after the mistaken admission, against that
+      // booking, so their decision superseded the default level within it. Seen in production for
+      // A6487AY. Only reviews this service wrote on admission may be stood down, so this no-ops and
+      // the prisoner keeps a level recorded against a booking they are no longer on — deliberately,
+      // because discarding a real review is not a decision this service can make.
+      val humanReviewOnMistakenBooking = reviewOnMistakenBooking.copy(
+        id = 5L,
+        reviewedBy = "TEST_STAFF1",
+        levelCode = "BAS",
+        reviewType = ReviewType.REVIEW,
+        reviewTime = LocalDateTime.now(clock),
+      )
       stubBookingSwitch(
-        reviewOnMistakenBooking.copy(reviewedBy = "TEST_STAFF1"),
+        humanReviewOnMistakenBooking,
+        // the service's own admission review, already stood down by the human one on the same booking
+        reviewOnMistakenBooking.copy(current = false),
         reviewOnReinstatedBooking,
       )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIncentiveReviewServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/incentivesapi/service/PrisonerIncentiveReviewServiceTest.kt
@@ -256,6 +256,46 @@ class PrisonerIncentiveReviewServiceTest {
       assertThat(result.incentiveReviewDetails.size).isZero
       assertThat(result.nextReviewDate).isEqualTo(expectedNextReviewDate)
     }
+
+    @Test
+    fun `reports the current review rather than simply the newest one`(): Unit = runBlocking {
+      // Given - the newest review sits on a booking the prisoner was mistakenly admitted onto and
+      // has been stood down, so it must not mask the level held on the booking they are on
+      whenever(nextReviewDateGetterService.get(reinstatedBookingId)).thenReturn(LocalDate.parse("2023-01-01"))
+      whenever(incentiveReviewRepository.findAllByPrisonerNumberOrderByReviewTimeDesc(switchPrisonerNumber))
+        .thenReturn(
+          flowOf(reviewOnMistakenBooking.copy(current = false), reviewOnReinstatedBooking),
+          flowOf(reviewOnMistakenBooking.copy(current = false), reviewOnReinstatedBooking),
+        )
+
+      // When
+      val result = prisonerIncentiveReviewService.getPrisonerIncentiveHistory(switchPrisonerNumber)
+
+      // Then
+      assertThat(result.iepCode).isEqualTo("ENH")
+      assertThat(result.bookingId).isEqualTo(reinstatedBookingId)
+      assertThat(result.id).isEqualTo(reviewOnReinstatedBooking.id)
+      // the stood-down review is still returned in the history, just not as the current one
+      assertThat(result.incentiveReviewDetails).hasSize(2)
+    }
+
+    @Test
+    fun `falls back to the newest review when none is flagged current`(): Unit = runBlocking {
+      // Given - rows predating the flag being maintained must keep behaving as they did
+      whenever(nextReviewDateGetterService.get(mistakenBookingId)).thenReturn(LocalDate.parse("2023-01-01"))
+      whenever(incentiveReviewRepository.findAllByPrisonerNumberOrderByReviewTimeDesc(switchPrisonerNumber))
+        .thenReturn(
+          flowOf(reviewOnMistakenBooking.copy(current = false), reviewOnReinstatedBooking.copy(current = false)),
+          flowOf(reviewOnMistakenBooking.copy(current = false), reviewOnReinstatedBooking.copy(current = false)),
+        )
+
+      // When
+      val result = prisonerIncentiveReviewService.getPrisonerIncentiveHistory(switchPrisonerNumber)
+
+      // Then
+      assertThat(result.iepCode).isEqualTo("STD")
+      assertThat(result.bookingId).isEqualTo(mistakenBookingId)
+    }
   }
 
   @DisplayName("process received prisoner")


### PR DESCRIPTION
[IR-1808](https://dsdmoj.atlassian.net/browse/IR-1808)

Follows #786 and #787. Found by the dry run over the 21 affected prisoners in prod.

## The bug

The correction stood down only the **highest** booking above the one the prisoner is now on. A3812EX has two mistaken admissions two days apart:

| Booking | Level | Date | By | Type |
|---|---|---|---|---|
| 3115811 | STD | 2026-07-17 | `INCENTIVES_API` | INITIAL |
| 3115477 | STD | 2026-07-15 | `INCENTIVES_API` | INITIAL |
| 2815349 | ENH | 2024-10-29 | UQW82A | REVIEW |

Standing down only 3115811 leaves 3115477's Standard current, and 15 July 2026 still beats 29 Oct 2024, so it keeps winning the prisoner-scoped read. The dry run reported `STD -> STD` for this prisoner — the repair would have run, published an event, and left them on the wrong level.

This affects the live event handler too, not only the repair endpoint: any prisoner admitted wrongly twice is currently half-fixed when the event fires.

## Why the restriction was wrong

I originally narrowed the predicate from `bookingId > correctBookingId` to "the single highest booking", to protect a legitimate `current` review on an intermediate higher booking.

That scenario cannot occur. Booking ids are sequential, so a booking **above** the active one was created **after** it and is one the prisoner is not on — an abandoned admission by definition. Genuine history from earlier sentences sits on **lower** bookings, which the `>` comparison already excludes. The protection was against a case that does not exist, and it cost the real one.

## Change

Stand down every `current` review this service wrote on a booking above the reinstated one.

The `reviewedBy == SYSTEM_USERNAME` guard is untouched and is the actual safeguard: a human review on an abandoned booking is a real decision about the prisoner and is still never stood down.

## Tests

- Replaced the test asserting the intermediate booking survives — it encoded the wrong assumption — with one modelling A3812EX's two mistaken admissions. **Verified it fails against the old predicate** (reverted the predicate locally, ran the test, confirmed the failure, restored).
- Extended the human-authored test to model A6487AY, where staff reviewed the prisoner against the mistaken booking the day after admission, so their decision superseded the default level within that booking. That case still no-ops — deliberately, since discarding a real review is not a decision this service can make. It needs a human to decide whether that level should be re-recorded against the live booking.
- `./gradlew build` green — 309 tests.

## Rollout

The other 20 prisoners in the dry run are single-mistake cases and are unaffected by this change; they can be repaired before or after it deploys. A3812EX needs this deployed first.

---

# Second commit: the flag no reader was looking at

Found by running the repair in production. **A8165EQ still read as Standard after a successful repair** — the flags flipped, the event fired, prisoner-search called back, and got Standard.

## Why

`buildIepSummary` picked the current review like this:

```kotlin
val iepDetails = levels.map { it.toIncentiveReviewDetail(incentiveLevels) }.toList()
val currentIep = iepDetails.firstOrNull() ?: throw IncentiveReviewNotFoundException(...)
```

The newest by `reviewTime`, with no reference to `current`. Review 8209643 (STD, 2026-07-29, booking 3118450) is newer than the ENH on booking 2708499 from 2025-02-16, so standing it down changed nothing it returns.

Every consumer of the flag:

| Consumer | Scope |
|---|---|
| `currentReviewSnapshotFor` | internal — only decides whether to publish an event |
| `findAllByBookingIdInAndCurrentIsTrueOrderByReviewTimeDesc` (`IncentiveReviewsService:172`) | prison worklists — **booking**-scoped, over active bookings |
| `somePrisonerCurrentlyOnLevel` | level-deactivation guard — **booking**-scoped |

None prisoner-scoped. So `GET /incentive-reviews/prisoner/{prisonerNumber}` — which prisoner-search calls back on (`PrisonerSynchroniserService.reindexIncentive` → `getCurrentIncentive`) and which the NOMIS reconciliation compares against (`IncentivesApiService.getCurrentIncentive`) — never changed. **#786's event handler had the same problem**, so it has not been achieving anything observable in production either.

The diagnosis on the ticket was right — "prisoner-scoped reads break the tie by latest `review_time`" — but flipping `current` never changes which review is latest.

## Change

Pick the newest review still flagged `current`, falling back to the newest overall when none is, so any prisoner whose rows predate the flag being maintained behaves exactly as before.

This also settles a pre-existing disagreement on the booking-scoped path: `addIncentiveReview` accepts a past `reviewTime`, so a backdated review is `current` while an older-dated row is newer. Both paths now use `current`, which is what `saveIncentiveReview` asserts.

## Tests

The existing tests asserted the flags had swapped — that is exactly why this reached production. They now assert the endpoint output:

- `PrisonOffenderEventListenerIntTest` — after the event, `GET /incentive-reviews/prisoner/{n}` returns `ENH` on the reinstated booking
- `ManageIncentiveReviewsResourceTest` — same assertion after the repair endpoint
- `PrisonerIncentiveReviewServiceTest` — the selection, and the no-flag fallback

**Verified all three fail against the previous read** (reverted `buildIepSummary` locally, ran them, confirmed 3 failures, restored). `./gradlew build` green.

## Rollout

This supersedes the earlier rollout note. The 20 prisoners already repaired had their flags set correctly, so **once this deploys they will read correctly without being re-run** — the data is right, only the read was wrong. Worth re-running the dry run afterwards to confirm, and A3812EX still needs a real run for the two-booking fix in the first commit.


[IR-1808]: https://dsdmoj.atlassian.net/browse/IR-1808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ